### PR TITLE
KTO-99 koulutuslomake korjaukset

### DIFF
--- a/src/main/app/src/apiUtils/index.js
+++ b/src/main/app/src/apiUtils/index.js
@@ -57,7 +57,9 @@ export const getKoulutuksetByKoulutusTyyppi = async ({
     groupBy(koulutukset, ({ koodiUri }) => koodiUri),
   ).map(([, versiot]) => maxBy(versiot, ({ versio }) => versio));
 
-  return latestKoulutukset;
+  return latestKoulutukset.filter(({ koodiUri }) =>
+    /^koulutus_/.test(koodiUri),
+  );
 };
 
 export const getKoulutusByKoodi = async ({

--- a/src/main/app/src/components/KoulutusForm/BaseSelectionSection.jsx
+++ b/src/main/app/src/components/KoulutusForm/BaseSelectionSection.jsx
@@ -4,6 +4,7 @@ import { Field } from 'redux-form';
 import { formValues } from 'redux-form';
 
 import Button from '../Button';
+import Icon from '../Icon';
 
 import {
   UncontrolledDropdown,
@@ -27,18 +28,25 @@ const SelectionContainer = styled.div`
   padding-left: ${({ theme }) => theme.spacing.unit * 3}px;
 `;
 
+const DropdownButton = styled(Button)`
+  display: inline-flex;
+`;
+
 const BaseFieldValue = formValues({
   base: 'base',
 })(({ base, children }) => children({ base }));
 
-const renderBaseDropdownField = ({ input }) => {
+const renderBaseDropdownField = ({ input, onContinue }) => {
   const { onChange } = input;
 
   return (
     <UncontrolledDropdown
       overlay={
         <DropdownMenu>
-          <DropdownMenuItem onClick={() => onChange('new_koulutus')}>
+          <DropdownMenuItem onClick={() => {
+            onChange('new_koulutus');
+            onContinue();
+          }}>
             Luo uusi koulutus
           </DropdownMenuItem>
           <DropdownMenuItem onClick={() => onChange('copy_koulutus')}>
@@ -50,10 +58,11 @@ const renderBaseDropdownField = ({ input }) => {
         </DropdownMenu>
       }
     >
-      {({ ref, onToggle }) => (
-        <Button innerRef={ref} onClick={onToggle} type="button">
-          Valitse pohja
-        </Button>
+      {({ ref, onToggle, visible }) => (
+        <DropdownButton innerRef={ref} onClick={onToggle} type="button">
+          Valitse pohja{' '}
+          <Icon type={visible ? 'arrow_drop_up' : 'arrow_drop_down'} />
+        </DropdownButton>
       )}
     </UncontrolledDropdown>
   );
@@ -69,11 +78,11 @@ const renderEducationSelectionField = ({ options = [], input }) => (
   </Select>
 );
 
-const BaseSelectionSection = props => {
+const BaseSelectionSection = ({ onContinue }) => {
   return (
     <ContentContainer>
       <DropdownContainer>
-        <Field name="base" component={renderBaseDropdownField} />
+        <Field name="base" component={renderBaseDropdownField} onContinue={onContinue} />
       </DropdownContainer>
       <SelectionContainer>
         <BaseFieldValue>

--- a/src/main/app/src/components/KoulutusForm/InformationSection.jsx
+++ b/src/main/app/src/components/KoulutusForm/InformationSection.jsx
@@ -55,8 +55,10 @@ const InfoContent = styled(Content)`
   ${getThemeProp('typography.body')};
 `;
 
+const nop = () => {};
+
 const renderSelectField = ({ input, koulutusTyyppi, ...props }) => (
-  <KoulutusSelect {...input} koulutusTyyppi={koulutusTyyppi} {...props} />
+  <KoulutusSelect {...input} koulutusTyyppi={koulutusTyyppi} {...props} onBlur={nop} />
 );
 
 const ActiveKoulutus = formValues({
@@ -133,7 +135,7 @@ const InformationSection = ({ languages = [], koulutusTyyppi, ...props }) => {
                     <InfoContent>
                       {koulutus ? (
                         <InformationAsync
-                          koodiUri={koulutus}
+                          koodiUri={koulutus.value}
                           language={value}
                         />
                       ) : null}

--- a/src/main/app/src/components/KoulutusForm/KoulutusForm.jsx
+++ b/src/main/app/src/components/KoulutusForm/KoulutusForm.jsx
@@ -1,6 +1,5 @@
 import React from 'react';
-import { FormSection, formValues } from 'redux-form';
-import styled from 'styled-components';
+import { formValues } from 'redux-form';
 
 import TypeSection from './TypeSection';
 import BaseSelectionSection from './BaseSelectionSection';
@@ -8,61 +7,15 @@ import LanguageSection from './LanguageSection';
 import InformationSection from './InformationSection';
 import DescriptionSection from './DescriptionSection';
 import OrganizationSection from './OrganizationSection';
-import Collapse from '../Collapse';
-import Button from '../Button';
-import FormStepper from '../FormStepper';
-import ResetFormSection from '../ResetFormSection';
-import { isObject, isFunction } from '../../utils';
-
-const CollapseFooterContainer = styled.div`
-  display: flex;
-  justify-content: space-between;
-`;
-
-const CollapseWrapper = styled.div`
-  margin-bottom: ${({ theme }) => theme.spacing.unit * 3}px;
-`;
+import { isObject } from '../../utils';
+import FormCollapseGroup from '../FormCollapseGroup';
+import FormCollapse from '../FormCollapse';
 
 const LANGUAGES = [
   { label: 'Suomeksi', value: 'fi' },
   { label: 'Ruotsiksi', value: 'sv' },
   { label: 'Englanniksi', value: 'en' },
 ];
-
-const FormCollapse = ({ onContinue, section, children = null, ...props }) => {
-  return (
-    <CollapseWrapper>
-      <Collapse
-        footer={
-          <CollapseFooterContainer>
-            {section ? (
-              <ResetFormSection name={section}>
-                {({ onReset }) => (
-                  <Button type="button" variant="outlined" onClick={onReset}>
-                    Tyhjennä tiedot
-                  </Button>
-                )}
-              </ResetFormSection>
-            ) : null}
-
-            {isFunction(onContinue) ? (
-              <Button type="button" onClick={onContinue}>
-                Jatka
-              </Button>
-            ) : null}
-          </CollapseFooterContainer>
-        }
-        {...props}
-      >
-        {section ? (
-          <FormSection name={section}>{children}</FormSection>
-        ) : (
-          children
-        )}
-      </Collapse>
-    </CollapseWrapper>
-  );
-};
 
 const ActiveLanguages = formValues({
   language: 'language',
@@ -84,106 +37,63 @@ const ActiveKoulutus = formValues({
   koulutus: 'information.koulutus',
 })(({ koulutus, children }) => children({ koulutus }));
 
-const defaultGetStepCollapseProps = () => ({
-  open: true,
-});
-
-const KoulutusFormBase = ({
-  handleSubmit,
-  getStepCollapseProps = defaultGetStepCollapseProps,
-  organisaatioOid,
-}) => (
+const KoulutusForm = ({ handleSubmit, organisaatioOid, steps = false }) => (
   <form onSubmit={handleSubmit}>
     <ActiveLanguages>
       {({ languages }) => (
-        <>
-          <FormCollapse
-            header="1 Koulutustyyppi"
-            section="type"
-            {...getStepCollapseProps(0)}
-          >
-            <TypeSection />
-          </FormCollapse>
+        <ActiveKoulutus>
+          {({ koulutus }) => (
+            <ActiveKoulutusTyyppi>
+              {({ koulutusTyyppi }) => (
+                <FormCollapseGroup enabled={steps}>
+                  <FormCollapse header="1 Koulutustyyppi" section="type">
+                    <TypeSection />
+                  </FormCollapse>
 
-          <FormCollapse
-            header="2 Pohjan valinta"
-            section="base"
-            {...getStepCollapseProps(1)}
-          >
-            <BaseSelectionSection />
-          </FormCollapse>
+                  <FormCollapse header="2 Pohjan valinta" section="base">
+                    {({ onContinue }) => (
+                      <BaseSelectionSection onContinue={onContinue} />
+                    )}
+                  </FormCollapse>
 
-          <FormCollapse
-            header="3 Kieliversiot"
-            section="language"
-            {...getStepCollapseProps(2)}
-          >
-            <LanguageSection />
-          </FormCollapse>
+                  <FormCollapse header="3 Kieliversiot" section="language">
+                    <LanguageSection />
+                  </FormCollapse>
 
-          <ActiveKoulutusTyyppi>
-            {({ koulutusTyyppi }) => (
-              <FormCollapse
-                header="4 Koulutuksen tiedot"
-                section="information"
-                {...getStepCollapseProps(3)}
-              >
-                <InformationSection
-                  languages={languages}
-                  koulutusTyyppi={koulutusTyyppi}
-                />
-              </FormCollapse>
-            )}
-          </ActiveKoulutusTyyppi>
+                  <FormCollapse
+                    header="4 Koulutuksen tiedot"
+                    section="information"
+                  >
+                    <InformationSection
+                      languages={languages}
+                      koulutusTyyppi={koulutusTyyppi}
+                    />
+                  </FormCollapse>
 
-          <ActiveKoulutus>
-            {({ koulutus }) => (
-              <FormCollapse
-                header="5 Valitun koulutuksen kuvaus"
-                section="description"
-                {...getStepCollapseProps(4)}
-              >
-                <DescriptionSection languages={languages} koodiUri={koulutus} />
-              </FormCollapse>
-            )}
-          </ActiveKoulutus>
+                  <FormCollapse
+                    header="5 Valitun koulutuksen kuvaus"
+                    section="description"
+                  >
+                    <DescriptionSection
+                      languages={languages}
+                      koodiUri={koulutus ? koulutus.value : null}
+                    />
+                  </FormCollapse>
 
-          <FormCollapse
-            header="6 Koulutuksen järjestävä organisaatio"
-            section="organization"
-            {...getStepCollapseProps(5)}
-            onContinue={null}
-          >
-            <OrganizationSection organisaatioOid={organisaatioOid} />
-          </FormCollapse>
-        </>
+                  <FormCollapse
+                    header="6 Koulutuksen järjestävä organisaatio"
+                    section="organization"
+                  >
+                    <OrganizationSection organisaatioOid={organisaatioOid} />
+                  </FormCollapse>
+                </FormCollapseGroup>
+              )}
+            </ActiveKoulutusTyyppi>
+          )}
+        </ActiveKoulutus>
       )}
     </ActiveLanguages>
   </form>
 );
-
-const KoulutusForm = ({ steps = false, ...props }) => {
-  return steps ? (
-    <FormStepper stepCount={6}>
-      {({ activeStep, makeOnGoToStep }) => {
-        const getStepCollapseProps = step => {
-          return {
-            open: activeStep >= step,
-            onContinue: makeOnGoToStep(step + 1),
-          };
-        };
-
-        return (
-          <KoulutusFormBase
-            getStepCollapseProps={getStepCollapseProps}
-            {...props}
-          />
-        );
-      }}
-    </FormStepper>
-  ) : (
-    <KoulutusFormBase {...props} />
-  );
-};
 
 export default KoulutusForm;

--- a/src/main/app/src/components/ToteutusForm/OsaamisalatSection.jsx
+++ b/src/main/app/src/components/ToteutusForm/OsaamisalatSection.jsx
@@ -70,14 +70,20 @@ const makeOnCheckboxChange = ({ value, onChange, optionValue }) => e => {
 
 const getOsaamisalat = async ({ httpClient, apiUrls, koodiUri }) => {
   const koulutus = await getKoulutusByKoodi({ httpClient, apiUrls, koodiUri });
+  const { osaamisalat = [] } = koulutus;
+
+  if (!koulutus.perusteId) {
+    return {
+      koulutus,
+      osaamisalat,
+    };
+  }
 
   const osaamisalakuvaukset = await getOsaamisalakuvauksetByPerusteId({
     httpClient,
     apiUrls,
     perusteId: koulutus.perusteId,
   });
-
-  const { osaamisalat = [] } = koulutus;
 
   const osaamisalatWithDescriptions = osaamisalat.map(osaamisala => ({
     ...osaamisala,

--- a/src/main/app/src/state/createKoulutusForm/actions.js
+++ b/src/main/app/src/state/createKoulutusForm/actions.js
@@ -42,7 +42,7 @@ export const submit = ({ tila = JULKAISUTILA.TALLENNETTU } = {}) => async (
   );
 
   const tarjoajat = get(values, 'organization.organizations') || null;
-  const koulutusKoodiUri = get(values, 'information.koulutus') || null;
+  const koulutusKoodiUri = get(values, 'information.koulutus.value') || null;
   const koulutustyyppi = get(values, 'type.type') || null;
 
   const { nimi = null } = await getKoulutusByKoodi({


### PR DESCRIPTION
- Otettu käyttöön `FormCollapseGroup`, jonka kautta mm. sininen otsikon väri aktiiviselle osiolle
- Koulutuksen valinnassa listataan nyt vain valideja koulutuksia (koodiurit ovat `koulutus_` alkuisia)
- Pohjavalinta dropdownissa on nyt nuoli-ikoni ja "Luo uusi koulutus"-valintaa klikkaamalla siirrytään lomakkeessa eteenpäin