### PR TITLE
KTO-110 koulutus ja toteutuslomakkeen muutokset

### DIFF
--- a/src/main/app/src/apiUtils/index.js
+++ b/src/main/app/src/apiUtils/index.js
@@ -18,48 +18,60 @@ const getKoodiUriParts = uri => {
   };
 };
 
+const memoizedGetKoulutuksetByKoulutusTyyppi = memoize(
+  async (httpClient, apiUrls, koulutusTyyppi) => {
+    const ids =
+      KOULUTUSTYYPPI_CATEGORY_TO_KOULUTUSTYYPPI_IDS_MAP[koulutusTyyppi];
+
+    if (!ids) {
+      return [];
+    }
+
+    const responses = await Promise.all(
+      ids.map(id =>
+        httpClient.get(apiUrls.url('koodisto-service.sisaltyy-ylakoodit', id)),
+      ),
+    );
+
+    const koulutukset = responses.reduce((acc, response) => {
+      const { data } = response;
+
+      if (!isArray(data)) {
+        return acc;
+      }
+
+      return [
+        ...acc,
+        ...data.map(({ metadata, koodisto, koodiArvo, koodiUri, versio }) => ({
+          metadata,
+          koodisto,
+          koodiArvo,
+          koodiUri,
+          versio,
+        })),
+      ];
+    }, []);
+
+    const latestKoulutukset = toPairs(
+      groupBy(koulutukset, ({ koodiUri }) => koodiUri),
+    ).map(([, versiot]) => maxBy(versiot, ({ versio }) => versio));
+
+    return latestKoulutukset.filter(({ koodiUri }) =>
+      /^koulutus_/.test(koodiUri),
+    );
+  },
+  { promise: true },
+);
+
 export const getKoulutuksetByKoulutusTyyppi = async ({
   httpClient,
   apiUrls,
   koulutusTyyppi,
 }) => {
-  const ids = KOULUTUSTYYPPI_CATEGORY_TO_KOULUTUSTYYPPI_IDS_MAP[koulutusTyyppi];
-
-  if (!ids) {
-    return [];
-  }
-
-  const responses = await Promise.all(
-    ids.map(id =>
-      httpClient.get(apiUrls.url('koodisto-service.sisaltyy-ylakoodit', id)),
-    ),
-  );
-
-  const koulutukset = responses.reduce((acc, response) => {
-    const { data } = response;
-
-    if (!isArray(data)) {
-      return acc;
-    }
-
-    return [
-      ...acc,
-      ...data.map(({ metadata, koodisto, koodiArvo, koodiUri, versio }) => ({
-        metadata,
-        koodisto,
-        koodiArvo,
-        koodiUri,
-        versio,
-      })),
-    ];
-  }, []);
-
-  const latestKoulutukset = toPairs(
-    groupBy(koulutukset, ({ koodiUri }) => koodiUri),
-  ).map(([, versiot]) => maxBy(versiot, ({ versio }) => versio));
-
-  return latestKoulutukset.filter(({ koodiUri }) =>
-    /^koulutus_/.test(koodiUri),
+  return memoizedGetKoulutuksetByKoulutusTyyppi(
+    httpClient,
+    apiUrls,
+    koulutusTyyppi,
   );
 };
 
@@ -165,16 +177,23 @@ export const getKoulutusByKoodi = ({ httpClient, apiUrls, koodiUri }) => {
   return memoizedGetKoulutusByKoodi(httpClient, apiUrls, koodiUri);
 };
 
+const memoizedGetOrganisaatioHierarchyByOid = memoize(
+  async (httpClient, apiUrls, oid) => {
+    const { data } = await httpClient.get(
+      apiUrls.url('organisaatio-service.hierarkia', oid),
+    );
+
+    return get(data, 'organisaatiot') || [];
+  },
+  { promise: true },
+);
+
 export const getOrganisaatioHierarchyByOid = async ({
   oid,
   apiUrls,
   httpClient,
 }) => {
-  const { data } = await httpClient.get(
-    apiUrls.url('organisaatio-service.hierarkia', oid),
-  );
-
-  return get(data, 'organisaatiot') || [];
+  return memoizedGetOrganisaatioHierarchyByOid(httpClient, apiUrls, oid);
 };
 
 const memoizedGetOrganisaatioByOid = memoize(

--- a/src/main/app/src/components/KoulutusForm/KoulutusForm.jsx
+++ b/src/main/app/src/components/KoulutusForm/KoulutusForm.jsx
@@ -15,6 +15,7 @@ import ToteutuksetSection from './ToteutuksetSection';
 import { ModalController } from '../Modal';
 import Button from '../Button';
 import { isFunction } from '../../utils';
+import LisatiedotSection from './LisatiedotSection';
 
 const ActiveLanguages = formValues({
   languages: 'kieliversiot.languages',
@@ -107,12 +108,19 @@ const KoulutusForm = ({
                     </FormCollapse>
 
                     <FormCollapse
+                      header="6 Koulutuksen lisätiedot"
+                      section="lisatiedot"
+                    >
+                      <LisatiedotSection languages={languages} />
+                    </FormCollapse>
+
+                    <FormCollapse
                       header="6 Koulutuksen järjestävä organisaatio"
                       section="organization"
                     >
                       <OrganizationSection organisaatioOid={organisaatioOid} />
                     </FormCollapse>
-                    
+
                     {isFunction(onSaveAndAttachToteutus) ? (
                       <FormCollapse
                         header="7 Koulutukseen liitetyt toteutukset"

--- a/src/main/app/src/components/KoulutusForm/LisatiedotSection.jsx
+++ b/src/main/app/src/components/KoulutusForm/LisatiedotSection.jsx
@@ -1,0 +1,94 @@
+import React from 'react';
+import { Field, formValues } from 'redux-form';
+import mapValues from 'lodash/mapValues';
+
+import Spacing from '../Spacing';
+import Typography from '../Typography';
+import Textarea from '../Textarea';
+import LanguageSelector from '../LanguageSelector';
+import Select from '../Select';
+import { getKoodisto } from '../../apiUtils';
+import {
+  isArray,
+  arrayToTranslationObject,
+  getFirstLanguageValue,
+} from '../../utils';
+import ApiAsync from '../ApiAsync';
+
+const getOsiot = async ({ httpClient, apiUrls }) => {
+  const osiot = await getKoodisto({
+    koodistoUri: 'koulutuksenjarjestamisenlisaosiot',
+    httpClient,
+    apiUrls,
+  });
+
+  return isArray(osiot)
+    ? osiot.map(({ metadata, koodiUri, versio }) => ({
+        koodiUri: `${koodiUri}#${versio}`,
+        nimi: mapValues(arrayToTranslationObject(metadata), ({ nimi }) => nimi),
+      }))
+    : [];
+};
+
+const getOsiotOptions = osiot =>
+  osiot.map(({ nimi, koodiUri }) => ({
+    value: koodiUri,
+    label: getFirstLanguageValue(nimi),
+  }));
+
+const noop = () => {};
+
+const renderSelectField = ({ input, ...props }) => (
+  <Select {...input} onBlur={noop} {...props} />
+);
+
+const renderTextareaField = ({ input, ...props }) => (
+  <Textarea {...input} {...props} />
+);
+
+const OsiotFieldsBase = ({ osiot, language }) => {
+  const osiotArr = osiot || [];
+
+  return osiotArr.map(({ value, label }, index) => (
+    <Spacing marginBottom={index !== osiot.length - 1 ? 2 : 0} key={value}>
+      <Typography variant="h6" marginBottom={1}>
+        {label}
+      </Typography>
+      <Field
+        name={`osioKuvaukset.${value}.${language}`}
+        component={renderTextareaField}
+      />
+    </Spacing>
+  ));
+};
+
+const OsiotFields = formValues({ osiot: 'osiot' })(OsiotFieldsBase);
+
+const LisatiedotSection = ({ languages = [] }) => {
+  return (
+    <LanguageSelector languages={languages} defaultValue="fi">
+      {({ value: activeLanguage }) => (
+        <>
+          <Spacing marginBottom={2}>
+            <Typography variant="h6" marginBottom={1}>
+              Valitse lisättävä osio
+            </Typography>
+            <ApiAsync promiseFn={getOsiot}>
+              {({ data }) => (
+                <Field
+                  name="osiot"
+                  component={renderSelectField}
+                  options={getOsiotOptions(data || [])}
+                  isMulti
+                />
+              )}
+            </ApiAsync>
+          </Spacing>
+          <OsiotFields language={activeLanguage} />
+        </>
+      )}
+    </LanguageSelector>
+  );
+};
+
+export default LisatiedotSection;

--- a/src/main/app/src/components/Select/index.jsx
+++ b/src/main/app/src/components/Select/index.jsx
@@ -8,7 +8,7 @@ import { setLightness } from 'polished';
 import memoize from 'memoizee';
 import get from 'lodash/get';
 
-import { isArray } from '../../utils';
+import { isArray, isObject } from '../../utils';
 
 const getStyles = memoize(theme => ({
   container: provided => ({
@@ -52,9 +52,31 @@ const getDefaultProps = memoize(theme => ({
   theme: getTheme(theme),
 }));
 
+const getOptionLabelByValue = options => {
+  return options.reduce((acc, curr) => {
+    acc[curr.value || '_'] = curr.label;
+
+    return acc;
+  }, {});
+};
+
 const getValue = memoize((value, options) => {
-  if (get(value, 'value') && !get(value, 'label') && isArray(options)) {
-    return options.find(option => get(option, 'value') === value.value) || null;
+  const hasOptions = isArray(options);
+
+  if (isObject(value) && value.value && hasOptions) {
+    return !value.label
+      ? options.find(option => get(option, 'value') === value.value) || null
+      : value;
+  }
+
+  if (isArray(value) && hasOptions) {
+    const labelByValue = getOptionLabelByValue(options);
+
+    return value.map(({ value, label, ...rest }) => ({
+      value,
+      label: label || labelByValue[value] || ' ',
+      ...rest,
+    }));
   }
 
   return value;
@@ -63,7 +85,14 @@ const getValue = memoize((value, options) => {
 const Select = ({ theme, value, options, ...props }) => {
   const resolvedValue = getValue(value, options);
 
-  return <ReactSelect {...getDefaultProps(theme)} value={resolvedValue} options={options} {...props} />;
+  return (
+    <ReactSelect
+      {...getDefaultProps(theme)}
+      value={resolvedValue}
+      options={options}
+      {...props}
+    />
+  );
 };
 
 const CreatableBase = ({ theme, ...props }) => (

--- a/src/main/app/src/components/Spin/Spin.stories.jsx
+++ b/src/main/app/src/components/Spin/Spin.stories.jsx
@@ -1,0 +1,19 @@
+import React from 'react';
+import { storiesOf } from '@storybook/react';
+
+import Spin from './index';
+
+storiesOf('Spin', module)
+  .add('Basic', () => <Spin />)
+  .add('With size', () => (
+    <>
+      <Spin size="small" />
+      <Spin size="medium" />
+      <Spin size="large" />
+    </>
+  ))
+  .add('With center', () => (
+    <>
+      <Spin center />
+    </>
+  ));

--- a/src/main/app/src/components/Spin/index.jsx
+++ b/src/main/app/src/components/Spin/index.jsx
@@ -1,0 +1,60 @@
+import React from 'react';
+import styled, { keyframes, css } from 'styled-components';
+
+const spin = keyframes`
+  0% {
+    transform: rotate(0deg);
+  }
+  100% {
+    transform: rotate(360deg);
+  }
+`;
+
+const baseSize = 35;
+const baseBorderWidth = 4;
+
+const sizeMultipliers = {
+  small: 0.5,
+  medium: 1,
+  large: 1.5,
+};
+
+const CenterContainer = styled.div`
+  display: flex;
+  justify-content: center;
+`;
+
+const SpinCircle = styled.div`
+  width: 35px;
+  height: 35px;
+  border-style: solid;
+  border-color: rgb(0, 0, 0, 0.1);
+  border-right-color: ${({ theme }) => theme.palette.primary.main};
+  border-radius: 50%;
+  animation: ${spin};
+  animation-duration: 0.75s;
+  animation-iteration-count: infinite;
+  animation-timing-function: linear;
+  display: inline-flex;
+  flex-grow: 0;
+
+  ${({ size }) => css`
+    width: ${(sizeMultipliers[size] || 1) * baseSize}px;
+    height: ${(sizeMultipliers[size] || 1) * baseSize}px;
+    border-width: ${(sizeMultipliers[size] || 1) * baseBorderWidth}px;
+  `};
+`;
+
+export const Spin = ({ size = 'medium', center = false, ...props }) => {
+  const spinProps = { size, ...props };
+
+  return center ? (
+    <CenterContainer>
+      <SpinCircle {...spinProps} />
+    </CenterContainer>
+  ) : (
+    <SpinCircle {...spinProps} />
+  );
+};
+
+export default Spin;

--- a/src/main/app/src/components/Spin/index.jsx
+++ b/src/main/app/src/components/Spin/index.jsx
@@ -28,13 +28,13 @@ const SpinCircle = styled.div`
   width: 35px;
   height: 35px;
   border-style: solid;
-  border-color: rgb(0, 0, 0, 0.1);
-  border-right-color: ${({ theme }) => theme.palette.primary.main};
+  border-color: rgba(0, 0, 0, 0.1);
+  border-top-color: ${({ theme }) => theme.palette.primary.main};
   border-radius: 50%;
   animation: ${spin};
-  animation-duration: 0.75s;
+  animation-duration: 1s;
   animation-iteration-count: infinite;
-  animation-timing-function: linear;
+  animation-timing-function: cubic-bezier(0.215, 0.61, 0.355, 1);
   display: inline-flex;
   flex-grow: 0;
 

--- a/src/main/app/src/components/ToteutusForm/AlkamiskausiFields.jsx
+++ b/src/main/app/src/components/ToteutusForm/AlkamiskausiFields.jsx
@@ -1,0 +1,97 @@
+import React from 'react';
+import { Field } from 'redux-form';
+import getYear from 'date-fns/get_year';
+import mapValues from 'lodash/mapValues';
+
+import Typography from '../Typography';
+import Spacing from '../Spacing';
+import Radio, { RadioGroup } from '../Radio';
+import NativeSelect, { Option } from '../NativeSelect';
+import ApiAsync from '../ApiAsync';
+import { getKoodisto } from '../../apiUtils';
+
+import {
+  isArray,
+  getFirstLanguageValue,
+  arrayToTranslationObject,
+} from '../../utils';
+
+const getHakukaudet = async ({ httpClient, apiUrls }) => {
+  const hakukaudet = await getKoodisto({
+    koodistoUri: 'kausi',
+    httpClient,
+    apiUrls,
+  });
+
+  return isArray(hakukaudet)
+    ? hakukaudet.map(({ metadata, koodiUri, versio }) => ({
+        koodiUri: `${koodiUri}#${versio}`,
+        nimi: mapValues(arrayToTranslationObject(metadata), ({ nimi }) => nimi),
+      }))
+    : [];
+};
+
+const renderRadioGroupField = ({ input, options }) => (
+  <RadioGroup {...input}>
+    {options.map(({ value, label }) => (
+      <Radio value={value} key={value}>
+        {label}
+      </Radio>
+    ))}
+  </RadioGroup>
+);
+
+const currentYear = getYear(new Date());
+
+const yearOptions = [...new Array(10)].map((value, index) => ({
+  value: `${currentYear + index}`,
+  label: `${currentYear + index}`,
+}));
+
+const renderYearField = ({ input }) => (
+  <NativeSelect {...input}>
+    <Option value="">Valitse vuosi</Option>
+    {yearOptions.map(({ value, label }) => (
+      <Option value={value} key={value}>
+        {label}
+      </Option>
+    ))}
+  </NativeSelect>
+);
+
+const getHakukausiOptions = hakukaudet =>
+  hakukaudet.map(({ koodiUri, nimi }) => ({
+    value: koodiUri,
+    label: getFirstLanguageValue(nimi),
+  }));
+
+const AlkamiskausiFields = ({ name }) => {
+  return (
+    <ApiAsync promiseFn={getHakukaudet}>
+      {({ data }) => (
+        <>
+          <Spacing marginBottom={2}>
+            <Typography as="div" marginBottom={1}>
+              Kausi
+            </Typography>
+            {isArray(data) ? (
+              <Field
+                name={`${name}.kausi`}
+                component={renderRadioGroupField}
+                options={getHakukausiOptions(data)}
+              />
+            ) : null}
+          </Spacing>
+          <Spacing>
+            <Typography as="div" marginBottom={1}>
+              Vuosi
+            </Typography>
+            <Field name={`${name}.vuosi`} component={renderYearField} />
+          </Spacing>
+        </>
+      )}
+    </ApiAsync>
+  );
+};
+
+export default AlkamiskausiFields;

--- a/src/main/app/src/components/ToteutusForm/JarjestamisTiedotSection.jsx
+++ b/src/main/app/src/components/ToteutusForm/JarjestamisTiedotSection.jsx
@@ -8,21 +8,21 @@ import Typography from '../Typography';
 import Input from '../Input';
 import Textarea from '../Textarea';
 import LanguageSelector from '../LanguageSelector';
-import { isArray } from '../../utils';
-import { TOTEUTUKSEN_OSIOT_OPTIONS } from '../../constants';
-import Select from '../Select';
 import OpetusaikaRadioGroup from './OpetusaikaRadioGroup';
 import OpetuskieliCheckboxGroup from './OpetuskieliCheckboxGroup';
-import OpetustapaRadioGroup from './OpetustapaRadioGroup';
+import OpetustapaCheckboxGroup from './OpetustapaCheckboxGroup';
+import Flex, { FlexItem } from '../Flex';
+import AlkamiskausiFields from './AlkamiskausiFields';
+import OsiotSelect from './OsiotSelect';
 
-const nop = () => {};
+const BorderHeading = styled(Typography).attrs({ variant: 'h6', paddingBottom: 1, marginBottom: 2 })`
+  border-bottom: 1px solid ${({ theme }) => theme.palette.border};
+`;
+
+const noop = () => {};
 
 const renderInputField = ({ input, ...props }) => (
   <Input {...input} {...props} />
-);
-
-const renderSelectField = ({ input, ...props }) => (
-  <Select {...input} onBlur={nop} {...props} />
 );
 
 const renderOpetusaikaField = ({ input }) => (
@@ -34,7 +34,7 @@ const renderOpetuskieliField = ({ input }) => (
 );
 
 const renderOpetustapaField = ({ input }) => (
-  <OpetustapaRadioGroup {...input} />
+  <OpetustapaCheckboxGroup {...input} />
 );
 
 const renderRadioGroupField = ({ input, options }) => (
@@ -51,24 +51,20 @@ const renderTextareaField = ({ input, ...props }) => (
   <Textarea {...input} {...props} />
 );
 
+const renderOsiotField = ({ input }) => (
+  <OsiotSelect {...input} onBlur={noop} />
+);
+
 const maksullisuusOptions = [
   { value: 'ei', label: 'Ei' },
   { value: 'kylla', label: 'Kyllä' },
 ];
 
-const renderOsiot = ({ osiot, language }) => {
-  const osiotArray = isArray(osiot) ? osiot : [];
+const OsiotFieldsBase = ({ osiot, language }) => {
+  const osiotArr = osiot || [];
 
-  const checkedOsiot = TOTEUTUKSEN_OSIOT_OPTIONS.filter(
-    ({ value }) =>
-      !!osiotArray.find(({ value: osioValue }) => osioValue === value),
-  );
-
-  return checkedOsiot.map(({ value, label }, index) => (
-    <Spacing
-      marginBottom={index !== checkedOsiot.length - 1 ? 2 : 0}
-      key={value}
-    >
+  return osiotArr.map(({ value, label }, index) => (
+    <Spacing marginBottom={index !== osiot.length - 1 ? 2 : 0} key={value}>
       <Typography variant="h6" marginBottom={1}>
         {label}
       </Typography>
@@ -80,13 +76,11 @@ const renderOsiot = ({ osiot, language }) => {
   ));
 };
 
+const OsiotFields = formValues({ osiot: 'osiot' })(OsiotFieldsBase);
+
 const MaksullisuusFieldValue = formValues({
   maksullisuus: 'maksullisuus',
 })(({ maksullisuus, children }) => children({ maksullisuus }));
-
-const OsiotFieldValue = formValues({
-  osiot: 'osiot',
-})(({ osiot, children }) => children({ osiot }));
 
 const MaksuWrapper = styled.div`
   max-width: 250px;
@@ -128,73 +122,121 @@ const JarjestamisTiedotSection = ({ languages = [] }) => {
       {({ value: activeLanguage }) => (
         <>
           <Spacing marginBottom={2}>
-            <Typography variant="h6" marginBottom={1}>
+            <BorderHeading>
               Opetuskieli
-            </Typography>
-            <Field
-              name="opetuskieli"
-              component={renderOpetuskieliField}
-            />
+            </BorderHeading>
+            <Flex>
+              <FlexItem grow={0} basis="30%">
+                <Field name="opetuskieli" component={renderOpetuskieliField} />
+              </FlexItem>
+              <FlexItem grow={1} paddingLeft={3}>
+                <Typography marginBottom={1} as="div">
+                  Opetuskielen tarkempi kuvaus
+                </Typography>
+                <Field
+                  name={`opetuskieliKuvaus.${activeLanguage}`}
+                  component={renderTextareaField}
+                />
+              </FlexItem>
+            </Flex>
           </Spacing>
           <Spacing marginBottom={2}>
-            <Typography variant="h6" marginBottom={1}>
+            <BorderHeading>
               Pääasiallinen opetusaika
-            </Typography>
-            <Field
-              name="opetusaika"
-              component={renderOpetusaikaField}
-            />
+            </BorderHeading>
+            <Flex>
+              <FlexItem grow={0} basis="30%">
+                <Field name="opetusaika" component={renderOpetusaikaField} />
+              </FlexItem>
+              <FlexItem grow={1} paddingLeft={3}>
+                <Typography marginBottom={1} as="div">
+                  Opetusajan tarkempi kuvaus
+                </Typography>
+                <Field
+                  name={`opetusaikaKuvaus.${activeLanguage}`}
+                  component={renderTextareaField}
+                />
+              </FlexItem>
+            </Flex>
           </Spacing>
           <Spacing marginBottom={2}>
-            <Typography variant="h6" marginBottom={1}>
+            <BorderHeading>
               Pääasiallinen opetustapa
-            </Typography>
-            <Field
-              name="opetustapa"
-              component={renderOpetustapaField}
-            />
+            </BorderHeading>
+            <Flex>
+              <FlexItem grow={0} basis="30%">
+                <Field name="opetustapa" component={renderOpetustapaField} />
+              </FlexItem>
+              <FlexItem grow={1} paddingLeft={3}>
+                <Typography marginBottom={1} as="div">
+                  Opetustavan tarkempi kuvaus
+                </Typography>
+                <Field
+                  name={`opetustapaKuvaus.${activeLanguage}`}
+                  component={renderTextareaField}
+                />
+              </FlexItem>
+            </Flex>
           </Spacing>
           <Spacing marginBottom={2}>
-            <Typography variant="h6" marginBottom={1}>
+            <BorderHeading>
               Onko opetus maksullista?
-            </Typography>
-            <Field
-              name="maksullisuus"
-              component={renderRadioGroupField}
-              options={maksullisuusOptions}
-            />
-            <MaksullisuusFieldValue>
-              {({ maksullisuus }) =>
-                maksullisuus === 'kylla' ? (
-                  <MaksuContainer language={activeLanguage} />
-                ) : null
-              }
-            </MaksullisuusFieldValue>
+            </BorderHeading>
+            <Flex>
+              <FlexItem grow={0} basis="30%">
+                <Field
+                  name="maksullisuus"
+                  component={renderRadioGroupField}
+                  options={maksullisuusOptions}
+                />
+                <MaksullisuusFieldValue>
+                  {({ maksullisuus }) =>
+                    maksullisuus === 'kylla' ? (
+                      <MaksuContainer language={activeLanguage} />
+                    ) : null
+                  }
+                </MaksullisuusFieldValue>
+              </FlexItem>
+              <FlexItem grow={1} paddingLeft={3}>
+                <Typography marginBottom={1} as="div">
+                  Lisätietoa maksullisuudesta
+                </Typography>
+                <Field
+                  name={`maksullisuusKuvaus.${activeLanguage}`}
+                  component={renderTextareaField}
+                />
+              </FlexItem>
+            </Flex>
           </Spacing>
           <Spacing marginBottom={2}>
-            <Typography variant="h6" marginBottom={1}>
-              Toteutuksen kuvaus
-            </Typography>
-            <Field
-              name={`kuvaus.${activeLanguage}`}
-              component={renderTextareaField}
-              placeholder="Kirjoita kuvaus, miten koulutuksen toteutus järjestetään teidän oppilaitoksessanne"
-            />
+            <BorderHeading>
+              Koulutuksen alkamiskausi
+            </BorderHeading>
+            <Flex>
+              <FlexItem grow={0} basis="30%">
+                <AlkamiskausiFields name="alkamiskausi" />
+              </FlexItem>
+              <FlexItem grow={1} paddingLeft={3}>
+                <Typography marginBottom={1} as="div">
+                  Lisätietoa alkamisajankohdasta
+                </Typography>
+                <Field
+                  name={`alkamiskausiKuvaus.${activeLanguage}`}
+                  component={renderTextareaField}
+                />
+              </FlexItem>
+            </Flex>
           </Spacing>
           <Spacing marginBottom={2}>
-            <Typography variant="h6" marginBottom={1}>
+            <BorderHeading>
               Valitse lisättävä osio
-            </Typography>
+            </BorderHeading>
             <Field
               name="osiot"
-              component={renderSelectField}
-              options={TOTEUTUKSEN_OSIOT_OPTIONS}
-              isMulti
+              component={renderOsiotField}
             />
           </Spacing>
-          <OsiotFieldValue>
-            {({ osiot }) => renderOsiot({ osiot, language: activeLanguage })}
-          </OsiotFieldValue>
+          <OsiotFields language={activeLanguage} />
         </>
       )}
     </LanguageSelector>

--- a/src/main/app/src/components/ToteutusForm/OpetustapaCheckboxGroup.jsx
+++ b/src/main/app/src/components/ToteutusForm/OpetustapaCheckboxGroup.jsx
@@ -2,7 +2,7 @@ import React from 'react';
 
 import { getKoodisto } from '../../apiUtils';
 import ApiAsync from '../ApiAsync';
-import Radio, { RadioGroup } from '../Radio';
+import CheckboxGroup from '../CheckboxGroup';
 import { isArray, getFirstLanguageValue } from '../../utils';
 
 const getOpetustapaKoodisto = async ({ httpClient, apiUrls }) => {
@@ -33,22 +33,16 @@ const getOptions = koodisto => {
   }));
 };
 
-const OpetustapaRadioGroup = props => {
+const OpetustapaCheckboxGroup = props => {
   return (
     <ApiAsync promiseFn={getOpetustapaKoodisto}>
       {({ data }) =>
         data ? (
-          <RadioGroup {...props}>
-            {getOptions(data).map(({ label, value }) => (
-              <Radio key={value} value={value}>
-                {label}
-              </Radio>
-            ))}
-          </RadioGroup>
+          <CheckboxGroup options={getOptions(data || [])} {...props} />
         ) : null
       }
     </ApiAsync>
   );
 };
 
-export default OpetustapaRadioGroup;
+export default OpetustapaCheckboxGroup;

--- a/src/main/app/src/components/ToteutusForm/OsiotSelect.jsx
+++ b/src/main/app/src/components/ToteutusForm/OsiotSelect.jsx
@@ -1,0 +1,48 @@
+import React from 'react';
+import mapValues from 'lodash/mapValues';
+
+import Select from '../Select';
+import { getKoodisto } from '../../apiUtils';
+import {
+  isArray,
+  arrayToTranslationObject,
+  getFirstLanguageValue,
+} from '../../utils';
+import ApiAsync from '../ApiAsync';
+
+const getOsiot = async ({ httpClient, apiUrls }) => {
+  const osiot = await getKoodisto({
+    koodistoUri: 'koulutuksenjarjestamisenlisaosiot',
+    httpClient,
+    apiUrls,
+  });
+
+  return isArray(osiot)
+    ? osiot.map(({ metadata, koodiUri, versio }) => ({
+        koodiUri: `${koodiUri}#${versio}`,
+        nimi: mapValues(arrayToTranslationObject(metadata), ({ nimi }) => nimi),
+      }))
+    : [];
+};
+
+const getOsiotOptions = osiot =>
+  osiot.map(({ nimi, koodiUri }) => ({
+    value: koodiUri,
+    label: getFirstLanguageValue(nimi),
+  }));
+
+const OsiotSelect = props => {
+  return (
+    <ApiAsync promiseFn={getOsiot}>
+      {({ data }) => (
+        <Select
+          options={getOsiotOptions(data || [])}
+          isMulti
+          {...props}
+        />
+      )}
+    </ApiAsync>
+  );
+};
+
+export default OsiotSelect;

--- a/src/main/app/src/state/createKoulutusForm/utils.js
+++ b/src/main/app/src/state/createKoulutusForm/utils.js
@@ -17,7 +17,9 @@ export const getKoulutusByValues = values => {
     tarjoajat,
     koulutusKoodiUri,
     koulutustyyppi,
-    osiot: osiotWithKuvaukset,
+    metadata: {
+      osiot: osiotWithKuvaukset,
+    },
   };
 };
 
@@ -27,8 +29,10 @@ export const getValuesByKoulutus = koulutus => {
     koulutusKoodiUri = '',
     koulutustyyppi = '',
     tarjoajat = [],
-    osiot: osiotArg = [],
+    metadata = {},
   } = koulutus;
+
+  const { osiot: osiotArg = [] } = metadata;
 
   const osiot = osiotArg
     .filter(({ koodiUri }) => !!koodiUri)

--- a/src/main/app/src/state/createKoulutusForm/utils.js
+++ b/src/main/app/src/state/createKoulutusForm/utils.js
@@ -1,4 +1,5 @@
 import get from 'lodash/get';
+import pick from 'lodash/pick';
 
 export const getKoulutusByValues = values => {
   const kielivalinta = get(values, 'kieliversiot.languages') || [];
@@ -8,12 +9,10 @@ export const getKoulutusByValues = values => {
   const osiot = get(values, 'lisatiedot.osiot') || [];
   const osioKuvaukset = get(values, 'lisatiedot.osioKuvaukset') || {};
 
-  const osiotWithKuvaukset = osiot
-    .map(({ value }) => ({
-      otsikkoKoodiUri: value,
-      teksti: osioKuvaukset[value],
-    }))
-    .filter(({ teksti }) => !!teksti);
+  const osiotWithKuvaukset = osiot.map(({ value }) => ({
+    otsikkoKoodiUri: value,
+    teksti: pick(osioKuvaukset[value] || {}, kielivalinta),
+  }));
 
   return {
     kielivalinta,

--- a/src/main/app/src/state/createKoulutusForm/utils.js
+++ b/src/main/app/src/state/createKoulutusForm/utils.js
@@ -9,7 +9,10 @@ export const getKoulutusByValues = values => {
   const osioKuvaukset = get(values, 'lisatiedot.osioKuvaukset') || {};
 
   const osiotWithKuvaukset = osiot
-    .map(({ value }) => ({ koodiUri: value, teksti: osioKuvaukset[value] }))
+    .map(({ value }) => ({
+      otsikkoKoodiUri: value,
+      teksti: osioKuvaukset[value],
+    }))
     .filter(({ teksti }) => !!teksti);
 
   return {
@@ -18,7 +21,7 @@ export const getKoulutusByValues = values => {
     koulutusKoodiUri,
     koulutustyyppi,
     metadata: {
-      osiot: osiotWithKuvaukset,
+      lisatiedot: osiotWithKuvaukset,
     },
   };
 };
@@ -32,15 +35,15 @@ export const getValuesByKoulutus = koulutus => {
     metadata = {},
   } = koulutus;
 
-  const { osiot: osiotArg = [] } = metadata;
+  const { lisatiedot = [] } = metadata;
 
-  const osiot = osiotArg
-    .filter(({ koodiUri }) => !!koodiUri)
-    .map(({ koodiUri }) => ({ value: koodiUri }));
+  const osiot = lisatiedot
+    .filter(({ otsikkoKoodiUri }) => !!otsikkoKoodiUri)
+    .map(({ otsikkoKoodiUri }) => ({ value: otsikkoKoodiUri }));
 
-  const osioKuvaukset = osiotArg.reduce((acc, curr) => {
-    if (curr.koodiUri) {
-      acc[curr.koodiUri] = curr.teksti || {};
+  const osioKuvaukset = lisatiedot.reduce((acc, curr) => {
+    if (curr.otsikkoKoodiUri) {
+      acc[curr.otsikkoKoodiUri] = curr.teksti || {};
     }
 
     return acc;

--- a/src/main/app/src/state/createKoulutusForm/utils.js
+++ b/src/main/app/src/state/createKoulutusForm/utils.js
@@ -5,12 +5,19 @@ export const getKoulutusByValues = values => {
   const tarjoajat = get(values, 'organization.organizations') || null;
   const koulutusKoodiUri = get(values, 'information.koulutus.value') || null;
   const koulutustyyppi = get(values, 'type.type') || null;
+  const osiot = get(values, 'lisatiedot.osiot') || [];
+  const osioKuvaukset = get(values, 'lisatiedot.osioKuvaukset') || {};
+
+  const osiotWithKuvaukset = osiot
+    .map(({ value }) => ({ koodiUri: value, teksti: osioKuvaukset[value] }))
+    .filter(({ teksti }) => !!teksti);
 
   return {
     kielivalinta,
     tarjoajat,
     koulutusKoodiUri,
     koulutustyyppi,
+    osiot: osiotWithKuvaukset,
   };
 };
 
@@ -20,7 +27,20 @@ export const getValuesByKoulutus = koulutus => {
     koulutusKoodiUri = '',
     koulutustyyppi = '',
     tarjoajat = [],
+    osiot: osiotArg = [],
   } = koulutus;
+
+  const osiot = osiotArg
+    .filter(({ koodiUri }) => !!koodiUri)
+    .map(({ koodiUri }) => ({ value: koodiUri }));
+
+  const osioKuvaukset = osiotArg.reduce((acc, curr) => {
+    if (curr.koodiUri) {
+      acc[curr.koodiUri] = curr.teksti || {};
+    }
+
+    return acc;
+  }, {});
 
   return {
     kieliversiot: {
@@ -36,6 +56,10 @@ export const getValuesByKoulutus = koulutus => {
     },
     type: {
       type: koulutustyyppi,
+    },
+    lisatiedot: {
+      osioKuvaukset,
+      osiot,
     },
   };
 };

--- a/src/main/app/src/state/createToteutusForm/utils.js
+++ b/src/main/app/src/state/createToteutusForm/utils.js
@@ -97,13 +97,13 @@ export const getToteutusByValues = values => {
     metadata: {
       opetus: {
         lisatiedot: osiot,
-        opetuskielet,
+        opetuskieliKoodiUrit: opetuskielet,
         kuvaus,
         onkoMaksullinen,
         maksunMaara,
         opetustapaKoodiUrit,
         opetusaikaKoodiUri,
-        opetuskieliKuvaus,
+        opetuskieletKuvaus: opetuskieliKuvaus,
         opetustapaKuvaus,
         opetusaikaKuvaus,
         maksullisuusKuvaus,
@@ -168,15 +168,15 @@ export const getValuesByToteutus = toteutus => {
       opetuskieli: get(opetus, 'opetuskieliKoodiUrit') || [],
       opetusaikaKuvaus: get(opetus, 'opetusaikaKuvaus') || {},
       opetustapaKuvaus: get(opetus, 'opetustapaKuvaus') || {},
-      opetuskieliKuvaus: get(opetus, 'opetuskieliKuvaus') || {},
+      opetuskieliKuvaus: get(opetus, 'opetuskieletKuvaus') || {},
       maksullisuusKuvaus: get(opetus, 'maksullisuusKuvaus') || {},
       osiot,
       osioKuvaukset,
       alkamiskausi: {
         kausi: get(opetus, 'alkamiskausiKoodiUri') || '',
-        vuosi: get(get, 'alkamisvuosi') || '',
+        vuosi: get(opetus, 'alkamisvuosi') || '',
       },
-      alkamiskausiKuvaus: get(opetus, 'alkamiskausiKuvaus') || {},
+      alkamiskausiKuvaus: get(opetus, 'alkamisaikaKuvaus') || {},
     },
     nayttamistiedot: {
       ammattinimikkeet: ammattinimikkeet.reduce((acc, curr) => {

--- a/src/main/app/src/state/createToteutusForm/utils.js
+++ b/src/main/app/src/state/createToteutusForm/utils.js
@@ -34,12 +34,14 @@ export const getToteutusByValues = values => {
   );
   const alkamiskausiKoodiUri =
     get(values, 'jarjestamistiedot.alkamiskausi.kausi') || null;
-  const alkamisvuosi =
-    get(values, 'jarjestamistiedot.alkamiskausi.vuosi') || null;
+
+  const alkamisvuosi = get(values, 'jarjestamistiedot.alkamiskausi.vuosi')
+    ? values.jarjestamistiedot.alkamiskausi.vuosi.toString()
+    : null;
 
   const osiot = (get(values, 'jarjestamistiedot.osiot') || []).map(
-    ({ value, label }) => ({
-      koodiUri: label,
+    ({ value }) => ({
+      otsikkoKoodiUri: value,
       teksti: pick(osioKuvaukset[value] || {}, kielivalinta),
     }),
   );
@@ -94,7 +96,7 @@ export const getToteutusByValues = values => {
     kielivalinta,
     metadata: {
       opetus: {
-        osiot,
+        lisatiedot: osiot,
         opetuskielet,
         kuvaus,
         onkoMaksullinen,
@@ -105,7 +107,7 @@ export const getToteutusByValues = values => {
         opetustapaKuvaus,
         opetusaikaKuvaus,
         maksullisuusKuvaus,
-        alkamiskausiKuvaus,
+        alkamisaikaKuvaus: alkamiskausiKuvaus,
         alkamiskausiKoodiUri,
         alkamisvuosi,
       },
@@ -133,15 +135,15 @@ export const getValuesByToteutus = toteutus => {
     opetus = {},
   } = metadata;
 
-  const { osiot: osiotArg = [] } = opetus;
+  const { lisatiedot = [] } = opetus;
 
-  const osiot = osiotArg
-    .filter(({ koodiUri }) => !!koodiUri)
-    .map(({ koodiUri }) => ({ value: koodiUri }));
+  const osiot = lisatiedot
+    .filter(({ otsikkoKoodiUri }) => !!otsikkoKoodiUri)
+    .map(({ otsikkoKoodiUri }) => ({ value: otsikkoKoodiUri }));
 
-  const osioKuvaukset = osiotArg.reduce((acc, curr) => {
-    if (curr.koodiUri) {
-      acc[curr.koodiUri] = curr.teksti || {};
+  const osioKuvaukset = lisatiedot.reduce((acc, curr) => {
+    if (curr.otsikkoKoodiUri) {
+      acc[curr.otsikkoKoodiUri] = curr.teksti || {};
     }
 
     return acc;

--- a/src/main/app/src/state/createToteutusForm/utils.js
+++ b/src/main/app/src/state/createToteutusForm/utils.js
@@ -6,12 +6,13 @@ import pick from 'lodash/pick';
 export const getToteutusByValues = values => {
   const tarjoajat = get(values, 'jarjestamispaikat.jarjestajat') || [];
   const kielivalinta = get(values, 'kieliversiot.languages') || [];
-  const nimi = get(values, 'nimi.name') || {};
+  const nimi = pick(get(values, 'nimi.name') || {}, kielivalinta);
   const opetuskielet = get(values, 'jarjestamistiedot.opetuskieli') || [];
   const kuvaus = get(values, 'jarjestamistiedot.kuvaus') || {};
   const osioKuvaukset = get(values, 'jarjestamistiedot.osioKuvaukset') || {};
   const opetustapaKoodiUrit = get(values, 'jarjestamistiedot.opetustapa') || [];
   const opetusaikaKoodiUri = get(values, 'jarjestamistiedot.opetusaika');
+
   const opetuskieliKuvaus = pick(
     get(values, 'jarjestamistiedot.opetuskieliKuvaus') || {},
     kielivalinta,
@@ -48,7 +49,11 @@ export const getToteutusByValues = values => {
 
   const onkoMaksullinen =
     get(values, 'jarjestamistiedot.maksullisuus') === 'kylla';
-  const maksunMaara = get(values, 'jarjestamistiedot.maksumaara') || {};
+
+  const maksunMaara = pick(
+    get(values, 'jarjestamistiedot.maksumaara') || {},
+    kielivalinta,
+  );
 
   const osaamisalaLinkit = get(values, 'osaamisalat.osaamisalaLinkit') || {};
   const osaamisalaLinkkiOtsikot =
@@ -63,11 +68,11 @@ export const getToteutusByValues = values => {
   );
 
   const yhteystieto = {
-    nimi: get(values, 'yhteystiedot.name') || {},
-    titteli: get(values, 'yhteystiedot.title') || {},
-    sahkoposti: get(values, 'yhteystiedot.email') || {},
-    puhelinnumero: get(values, 'yhteystiedot.phone') || {},
-    wwwSivu: get(values, 'yhteystiedot.website') || {},
+    nimi: pick(get(values, 'yhteystiedot.name') || {}, kielivalinta),
+    titteli: pick(get(values, 'yhteystiedot.title') || {}, kielivalinta),
+    sahkoposti: pick(get(values, 'yhteystiedot.email') || {}, kielivalinta),
+    puhelinnumero: pick(get(values, 'yhteystiedot.phone') || {}, kielivalinta),
+    wwwSivu: pick(get(values, 'yhteystiedot.website') || {}, kielivalinta),
   };
 
   const ammattinimikkeet = flatMap(


### PR DESCRIPTION
[Linkki testaamiseen](https://virkailija.hahtuvaopintopolku.fi/kouta/organisaatio/1.2.246.562.10.594252633210/koulutus) (hahtuva).

Muutokset käyttöliittymässä:

- Koulutuksen lisätiedot
- Toteutuksen järjestämistiedoissa on nyt kuvaukset ja alkamiskausi

Tarvittavat API-muutokset:

Koulutus:
- `metadata.osiot`: `{ koodiUri: string, teksti: { [string]: string } }`

Opetus:
- `metadata.opetus.osiot`: `{ koodiUri: string, teksti: { [string]: string } }`
- `metadata.opetus.alkamiskausiKuvaus`: `string`
- `metadata.opetus.alkamiskausiKoodiUri`: `string`
- `metadata.opetus.alkamisvuosi`: `number`
- `metadata.opetus.alkamiskausiKuvaus`: `{ [string]: string }`
