### PR TITLE
KTO-425 valintaperuste käyttämään validaatiota konfiguraatiosta

### DIFF
--- a/src/main/app/src/utils/validateValintaperusteForm.js
+++ b/src/main/app/src/utils/validateValintaperusteForm.js
@@ -1,48 +1,8 @@
-import get from 'lodash/get';
+import getValintaperusteFormConfig from "./getValintaperusteFormConfig";
+import getErrorBuilderByFormConfig from './getErrorBuilderByFormConfig';
 
-import { JULKAISUTILA } from '../constants';
-import createErrorBuilder from './createErrorBuilder';
-
-const getKieliversiot = values => get(values, 'kieliversiot') || [];
-
-const validateEssentials = ({ errorBuilder, values }) => {
-  const kieliversiot = getKieliversiot(values);
-
-  return errorBuilder
-    .validateArrayMinLength('kieliversiot', 1)
-    .validateTranslations('kuvaus.nimi', kieliversiot);
+const validateValintaperusteForm = values => {
+  return getErrorBuilderByFormConfig(getValintaperusteFormConfig(), values).getErrors();
 };
 
-const validateCommon = ({ errorBuilder, values }) => {
-  const kieliversiot = getKieliversiot(values);
-
-  return errorBuilder
-    .validateExistence('hakutapa')
-    .validateExistence('kohdejoukko')
-    .validateArrayMinLength('valintatavat', 1, {
-      isFieldArray: true,
-    })
-    .validateArray('valintatavat', eb => {
-      return eb
-        .validateExistence('tapa')
-        .validateTranslations('nimi', kieliversiot);
-    });
-};
-
-const validate = values => {
-  const { tila } = values;
-
-  let errorBuilder = createErrorBuilder(values);
-
-  errorBuilder = validateEssentials({ errorBuilder, values });
-
-  if (tila === JULKAISUTILA.TALLENNETTU) {
-    return errorBuilder.getErrors();
-  }
-
-  errorBuilder = validateCommon({ errorBuilder, values });
-
-  return errorBuilder.getErrors();
-};
-
-export default validate;
+export default validateValintaperusteForm;


### PR DESCRIPTION
Pois vanhanmallinen validaatio, käyttää nyt https://github.com/Opetushallitus/kouta-ui/blob/master/src/main/app/src/utils/getValintaperusteFormConfig.js 

Huom. manuaalista validaatiota käyttää vielä sorakuvaukset, oppilaitos ja oppilaitoksen osa - nämäkin voisi mahdollisesti siirtää käyttämään registerFieldiä