### PR TITLE
KTO-426: Fix valintaperuste form validations

### DIFF
--- a/src/main/app/src/components/CreateValintaperustePage/CreateValintaperusteForm.jsx
+++ b/src/main/app/src/components/CreateValintaperustePage/CreateValintaperusteForm.jsx
@@ -8,8 +8,7 @@ import ReduxForm from '../ReduxForm';
 import getFormValuesByValintaperuste from '../../utils/getFormValuesByValintaperuste';
 import getValintaperusteFormConfig from '../../utils/getValintaperusteFormConfig';
 import FormConfigContext from '../FormConfigContext';
-import useFieldValue from "../useFieldValue";
-
+import useFieldValue from '../useFieldValue';
 
 const resolveFn = () => Promise.resolve(null);
 
@@ -20,7 +19,7 @@ const getCopyValues = valintaperusteOid => ({
   },
 });
 
-const getInitialValues = ( valintaperuste, kieliValinnat ) => {
+const getInitialValues = (valintaperuste, kieliValinnat) => {
   return valintaperuste && valintaperuste.oid
     ? {
         ...getCopyValues(valintaperuste.oid),
@@ -30,8 +29,6 @@ const getInitialValues = ( valintaperuste, kieliValinnat ) => {
 };
 
 const ValintaperusteFormWrapper = props => {
-  const { steps } = props;
-
   const koulutustyyppi = useFieldValue('tyyppi');
 
   const config = useMemo(() => getValintaperusteFormConfig(koulutustyyppi), [
@@ -58,7 +55,7 @@ export const CreateValintaperusteForm = ({
     watch: kopioValintaperusteOid,
   });
 
-  kieliValinnat = kieliValinnat == null ? [] : kieliValinnat.split(",");
+  kieliValinnat = kieliValinnat == null ? [] : kieliValinnat.split(',');
 
   const initialValues = useMemo(() => {
     return getInitialValues(valintaperuste, kieliValinnat);

--- a/src/main/app/src/components/EditValintaperustePage/EditValintaperusteForm.jsx
+++ b/src/main/app/src/components/EditValintaperustePage/EditValintaperusteForm.jsx
@@ -7,13 +7,7 @@ import getValintaperusteFormConfig from '../../utils/getValintaperusteFormConfig
 import FormConfigContext from '../FormConfigContext';
 
 const ValintaperusteFormWrapper = props => {
-  const {
-    koulutustyyppi,
-    valintaperuste,
-    steps,
-    canSelectBase,
-    canEditTyyppi
-  } = props;
+  const { koulutustyyppi } = props;
 
   const config = useMemo(() => getValintaperusteFormConfig(koulutustyyppi), [
     koulutustyyppi,
@@ -26,22 +20,24 @@ const ValintaperusteFormWrapper = props => {
   );
 };
 
-const EditValintapersuteetForm = ({ valintaperuste, ...props }) => {
+const EditValintaperusteForm = ({ valintaperuste, ...props }) => {
   const initialValues = useMemo(() => {
     return getFormValuesByValintaperuste(valintaperuste);
   }, [valintaperuste]);
 
   return (
     <ReduxForm form="editValintaperusteForm" initialValues={initialValues}>
-      {() => (<ValintaperusteFormWrapper {...props}
-                                            valintaperuste={valintaperuste}
-                                            steps={false}
-                                            canSelectBase={false}
-                                            canEditTyyppi={false} />
-
+      {() => (
+        <ValintaperusteFormWrapper
+          {...props}
+          valintaperuste={valintaperuste}
+          steps={false}
+          canSelectBase={false}
+          canEditTyyppi={false}
+        />
       )}
     </ReduxForm>
   );
 };
 
-export default EditValintapersuteetForm;
+export default EditValintaperusteForm;

--- a/src/main/app/src/components/ValintaperusteForm/PerustiedotSection.jsx
+++ b/src/main/app/src/components/ValintaperusteForm/PerustiedotSection.jsx
@@ -7,25 +7,25 @@ import KieliversiotFields from '../KieliversiotFields';
 import Divider from '../Divider';
 import { getTestIdProps } from '../../utils';
 
-const PerustiedotSection = ({ canEditTyyppi = true }) => {
+const PerustiedotSection = ({ name, canEditTyyppi = true }) => {
   return (
     <>
       {canEditTyyppi ? (
         <div {...getTestIdProps('tyyppiSection')}>
-          <TyyppiSection name="tyyppi" />
+          <TyyppiSection name={`${name}.tyyppi`} />
           <Divider marginTop={3} marginBottom={3} />
         </div>
       ) : null}
       <div {...getTestIdProps('kieliversiotSection')}>
-        <KieliversiotFields name="kieliversiot" />
+        <KieliversiotFields name={`${name}.kieliversiot`} />
       </div>
       <Divider marginTop={3} marginBottom={3} />
       <div {...getTestIdProps('hakutapaSection')}>
-        <HakutavanRajausSection name="hakutapa" />
+        <HakutavanRajausSection name={`${name}.hakutapa`} />
       </div>
       <Divider marginTop={3} marginBottom={3} />
       <div {...getTestIdProps('kohdejoukkoSection')}>
-        <KohdejoukonRajausSection name="kohdejoukko" />
+        <KohdejoukonRajausSection name={`${name}.kohdejoukko`} />
       </div>
     </>
   );

--- a/src/main/app/src/components/ValintaperusteForm/ValintaperusteForm.jsx
+++ b/src/main/app/src/components/ValintaperusteForm/ValintaperusteForm.jsx
@@ -59,7 +59,7 @@ const ValintaperusteForm = ({
         scrollOnActive={false}
         {...getTestIdProps('perustiedotSection')}
       >
-        <PerustiedotSection canEditTyyppi={canEditTyyppi} />
+        <PerustiedotSection canEditTyyppi={canEditTyyppi} name="perustiedot" />
       </FormCollapse>
 
       {canSelectBase ? (

--- a/src/main/app/src/utils/__tests__/__snapshots__/getFormValuesByValintaperuste.js.snap
+++ b/src/main/app/src/utils/__tests__/__snapshots__/getFormValuesByValintaperuste.js.snap
@@ -2,15 +2,7 @@
 
 exports[`getFormValuesByValintaperuste returns correct form values given valintaperuste 1`] = `
 Object {
-  "hakutapa": "tapa_1#1",
   "julkinen": true,
-  "kieliversiot": Array [
-    "fi",
-    "sv",
-  ],
-  "kohdejoukko": Object {
-    "value": "joukko_1#1",
-  },
   "kuvaus": Object {
     "kuvaus": Object {
       "fi":         "<h1>Fi kuvaus</h1>",
@@ -21,11 +13,21 @@ Object {
       "sv": "Sv nimi",
     },
   },
+  "perustiedot": Object {
+    "hakutapa": "tapa_1#1",
+    "kieliversiot": Array [
+      "fi",
+      "sv",
+    ],
+    "kohdejoukko": Object {
+      "value": "joukko_1#1",
+    },
+    "tyyppi": "tyyppi_1#1",
+  },
   "soraKuvaus": Object {
     "value": "sora_1",
   },
   "tila": "tallennettu",
-  "tyyppi": "tyyppi_1#1",
   "valintakoe": Object {
     "tilaisuudet": Object {
       "tyyppi_1#1": Array [

--- a/src/main/app/src/utils/__tests__/getValintaperusteByFormValues.js
+++ b/src/main/app/src/utils/__tests__/getValintaperusteByFormValues.js
@@ -3,9 +3,12 @@ import getValintaperusteByFormValues from '../getValintaperusteByFormValues';
 
 test('getValintaperusteByFormValues returns correct valintaperuste given form values', () => {
   const valintaperuste = getValintaperusteByFormValues({
-    kieliversiot: ['fi', 'sv'],
-    hakutapa: 'tapa_1#1',
-    kohdejoukko: { value: 'joukko_1#1' },
+    perustiedot: {
+      tyyppi: 'tyyppi_1#1',
+      kieliversiot: ['fi', 'sv'],
+      hakutapa: 'tapa_1#1',
+      kohdejoukko: { value: 'joukko_1#1' },
+    },
     kuvaus: {
       nimi: {
         fi: 'Fi nimi',
@@ -97,7 +100,6 @@ test('getValintaperusteByFormValues returns correct valintaperuste given form va
         ],
       },
     ],
-    tyyppi: 'tyyppi_1#1',
     soraKuvaus: {
       value: 'sora_1',
     },

--- a/src/main/app/src/utils/getFormValuesByValintaperuste.js
+++ b/src/main/app/src/utils/getFormValuesByValintaperuste.js
@@ -1,6 +1,4 @@
-import mapValues from 'lodash/mapValues';
-
-import { isObject, isArray } from './index';
+import { isArray, isObject, mapValues } from 'lodash';
 import parseEditorState from './draft/parseEditorState';
 import getValintakoeFieldsValues from './getValintakoeFieldsValues';
 
@@ -39,9 +37,12 @@ const getFormValuesByValintaperuste = valintaperuste => {
 
   return {
     tila,
-    kieliversiot: kielivalinta,
-    hakutapa: hakutapaKoodiUri,
-    kohdejoukko: kohdejoukkoKoodiUri ? { value: kohdejoukkoKoodiUri } : null,
+    perustiedot: {
+      tyyppi: koulutustyyppi,
+      kieliversiot: kielivalinta,
+      hakutapa: hakutapaKoodiUri,
+      kohdejoukko: kohdejoukkoKoodiUri ? { value: kohdejoukkoKoodiUri } : null,
+    },
     julkinen: onkoJulkinen,
     kuvaus: {
       nimi,
@@ -66,7 +67,6 @@ const getFormValuesByValintaperuste = valintaperuste => {
         sisalto: parseSisalto({ sisalto }),
       }),
     ),
-    tyyppi: koulutustyyppi,
     soraKuvaus: sorakuvausId
       ? {
           value: sorakuvausId,

--- a/src/main/app/src/utils/getValintaperusteByFormValues.js
+++ b/src/main/app/src/utils/getValintaperusteByFormValues.js
@@ -1,9 +1,6 @@
-import get from 'lodash/get';
+import { get, isObject, isArray, mapValues, pick } from 'lodash';
 import produce from 'immer';
-import pick from 'lodash/pick';
-import mapValues from 'lodash/mapValues';
-
-import { isObject, isArray, isNumeric } from './index';
+import { isNumeric } from './index';
 import serializeEditorState from './draft/serializeEditorState';
 import getValintakoeFieldsData from './getValintakoeFieldsData';
 
@@ -58,13 +55,13 @@ const serializeSisalto = ({ sisalto, kielivalinta = [] }) => {
 };
 
 const getValintaperusteByFormValues = values => {
-  const { tila, muokkaaja } = values;
+  const { tila, muokkaaja, perustiedot } = values;
 
-  const hakutapaKoodiUri = get(values, 'hakutapa');
+  const hakutapaKoodiUri = get(perustiedot, 'hakutapa');
 
-  const kielivalinta = get(values, 'kieliversiot') || [];
+  const kielivalinta = get(perustiedot, 'kieliversiot') || [];
 
-  const kohdejoukkoKoodiUri = get(values, 'kohdejoukko.value') || null;
+  const kohdejoukkoKoodiUri = get(perustiedot, 'kohdejoukko.value') || null;
 
   const nimi = pick(get(values, 'kuvaus.nimi'), kielivalinta);
 
@@ -103,7 +100,7 @@ const getValintaperusteByFormValues = values => {
     kielivalinta,
   });
 
-  const koulutustyyppi = get(values, 'tyyppi') || null;
+  const koulutustyyppi = get(perustiedot, 'tyyppi') || null;
   const sorakuvausId = get(values, 'soraKuvaus.value') || null;
   const onkoJulkinen = Boolean(get(values, 'julkinen'));
 

--- a/src/main/app/src/utils/getValintaperusteFormConfig.js
+++ b/src/main/app/src/utils/getValintaperusteFormConfig.js
@@ -1,7 +1,7 @@
-import get from 'lodash/get';
+import { get, reduce } from 'lodash';
 
-import {JULKAISUTILA, KOULUTUSTYYPIT, KOULUTUSTYYPPI} from '../constants';
-import createFormConfigBuilder from "./createFormConfigBuilder";
+import { JULKAISUTILA, KOULUTUSTYYPIT, KOULUTUSTYYPPI } from '../constants';
+import createFormConfigBuilder from './createFormConfigBuilder';
 
 const getKielivalinta = values => get(values, 'kieliversiot') || [];
 
@@ -19,25 +19,51 @@ const koulutustyypitWithValintatapa = [
   KOULUTUSTYYPPI.AMMATILLINEN_ERITYISOPETTAJA_KOULUTUS,
 ];
 
+const validateValintakokeet = (errorBuilder, values) => {
+  const valintakoeTyypit = get(values, 'valintakoe.tyypit');
+  const kieliversiot = getKielivalinta(values);
+
+  return reduce(
+    valintakoeTyypit,
+    (ebAcc, { value: tyyppi }) =>
+      ebAcc
+        .validateArrayMinLength(`valintakoe.tilaisuudet.${tyyppi}`, 1, {
+          isFieldArray: true,
+        })
+        .validateArray(`valintakoe.tilaisuudet.${tyyppi}`, eb =>
+          eb
+            .validateTranslations('osoite', kieliversiot)
+            .validateExistence('postinumero')
+            .validateExistence('alkaa')
+            .validateExistence('paattyy'),
+        ),
+    errorBuilder,
+  );
+};
+
 const config = createFormConfigBuilder()
   .registerField('pohja', 'pohja', KOULUTUSTYYPIT)
-  .registerField('perustiedot', 'koulutustyyppi', KOULUTUSTYYPIT, eb =>
-    eb.validateExistence('koulutustyyppi'),
+  .registerField('perustiedot', 'tyyppi', KOULUTUSTYYPIT, eb =>
+    eb.validateExistence('perustiedot.tyyppi'),
   )
   .registerField('perustiedot', 'kieliversiot', KOULUTUSTYYPIT, eb =>
-    eb.validateArrayMinLength('kieliversiot', 1),
-  ).registerField('perustiedot', 'hakutapa', KOULUTUSTYYPIT,
-    validateIfJulkaistu(eb => eb.validateExistence('hakutapa'))
+    eb.validateArrayMinLength('perustiedot.kieliversiot', 1),
   )
-  .registerField('perustiedot', 'haunkohdejoukko', KOULUTUSTYYPIT,
-    validateIfJulkaistu(eb =>
-      eb.validateExistence('kohdejoukko'),
-    )
+  .registerField(
+    'perustiedot',
+    'hakutapa',
+    KOULUTUSTYYPIT,
+    validateIfJulkaistu(eb => eb.validateExistence('perustiedot.hakutapa')),
   )
+  .registerField('perustiedot', 'haunkohdejoukko', KOULUTUSTYYPIT)
   .registerField('kuvaus', 'nimi', KOULUTUSTYYPIT, (eb, values) =>
     eb.validateTranslations('kuvaus.nimi', getKielivalinta(values)),
-  ).registerField('kuvaus', 'tarkenne', KOULUTUSTYYPIT)
-  .registerField('valintatapa', 'valintatavat', koulutustyypitWithValintatapa,
+  )
+  .registerField('kuvaus', 'tarkenne', KOULUTUSTYYPIT)
+  .registerField(
+    'valintatapa',
+    'valintatavat',
+    koulutustyypitWithValintatapa,
     validateIfJulkaistu((eb, values) =>
       eb
         .validateArrayMinLength('valintatavat', 1, {
@@ -51,10 +77,16 @@ const config = createFormConfigBuilder()
     ),
   )
   .registerField('soraKuvaus', 'soraKuvaus', KOULUTUSTYYPIT)
-  .registerField('julkisuus', 'julkisuus', KOULUTUSTYYPIT
-  ).registerField('julkaisutila', 'julkaisutila', KOULUTUSTYYPIT, eb =>
-    eb.validateExistence('tila')
-  ).registerField('valintakoe', 'valintakoe', KOULUTUSTYYPIT);
+  .registerField('julkisuus', 'julkisuus', KOULUTUSTYYPIT)
+  .registerField('julkaisutila', 'julkaisutila', KOULUTUSTYYPIT, eb =>
+    eb.validateExistence('tila'),
+  )
+  .registerField(
+    'valintakoe',
+    'tyypit',
+    KOULUTUSTYYPIT,
+    validateIfJulkaistu((eb, values) => validateValintakokeet(eb, values)),
+  );
 
 const getValintaperusteFormConfig = koulutustyyppi => {
   return config.getKoulutustyyppiConfig(koulutustyyppi);

--- a/src/main/app/src/utils/validateValintaperusteForm.js
+++ b/src/main/app/src/utils/validateValintaperusteForm.js
@@ -1,8 +1,13 @@
-import getValintaperusteFormConfig from "./getValintaperusteFormConfig";
+import { get } from 'lodash';
+import getValintaperusteFormConfig from './getValintaperusteFormConfig';
 import getErrorBuilderByFormConfig from './getErrorBuilderByFormConfig';
 
 const validateValintaperusteForm = values => {
-  return getErrorBuilderByFormConfig(getValintaperusteFormConfig(), values).getErrors();
+  const koulutustyyppi = get(values, 'perustiedot.tyyppi');
+  return getErrorBuilderByFormConfig(
+    getValintaperusteFormConfig(koulutustyyppi),
+    values,
+  ).getErrors();
 };
 
 export default validateValintaperusteForm;


### PR DESCRIPTION
- Add validation for 'valintakoe' and remove validation for 'haunkohdejoukko'
- Pass koulutustyyppi to getValintaperustoFormConfig()
- Group fields inside perustiedot-section accordingly in form data to detect section errors correctly
- Fix code style in valintaperuste form components
- Fix unit tests for valintaperuste form data conversions