### PR TITLE
KTO-698: Fix valintaperuste valintatapa empty value

### DIFF
--- a/src/main/app/src/utils/__tests__/__snapshots__/getValintaperusteByFormValues.js.snap
+++ b/src/main/app/src/utils/__tests__/__snapshots__/getValintaperusteByFormValues.js.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`getValintaperusteByFormValues returns correct valintaperuste given form values 1`] = `
+exports[`Should convert valintaperuste form with valintatapa 1`] = `
 Object {
   "hakutapaKoodiUri": "tapa_1#1",
   "kielivalinta": Array [
@@ -99,7 +99,61 @@ Object {
   },
   "onkoJulkinen": true,
   "sorakuvausId": "sora_1",
-  "tila": undefined,
+  "tila": "julkaistu",
+  "valintakokeet": Array [
+    Object {
+      "tilaisuudet": Array [
+        Object {
+          "aika": Object {
+            "alkaa": "2019-04-16T08:44",
+            "paattyy": "2019-04-18T08:44",
+          },
+          "lisatietoja": Object {
+            "fi": "fi lisatietoja",
+            "sv": "sv lisatietoja",
+          },
+          "osoite": Object {
+            "osoite": Object {
+              "fi": "fi osoite",
+              "sv": "sv osoite",
+            },
+            "postinumeroKoodiUri": "posti_1#1",
+          },
+        },
+      ],
+      "tyyppiKoodiUri": "tyyppi_1#1",
+    },
+  ],
+}
+`;
+
+exports[`Should convert valintaperuste form without valintatapa 1`] = `
+Object {
+  "hakutapaKoodiUri": "tapa_1#1",
+  "kielivalinta": Array [
+    "fi",
+    "sv",
+  ],
+  "kohdejoukkoKoodiUri": "joukko_1#1",
+  "koulutustyyppi": "tyyppi_1#1",
+  "metadata": Object {
+    "kielitaitovaatimukset": Array [],
+    "kuvaus": Object {
+      "fi": "<h1>Fi kuvaus</h1>",
+      "sv": "<h1>Sv kuvaus</h1>",
+    },
+    "osaamistaustaKoodiUrit": Array [],
+    "tyyppi": "tyyppi_1#1",
+    "valintatavat": Array [],
+  },
+  "muokkaaja": undefined,
+  "nimi": Object {
+    "fi": "Fi nimi",
+    "sv": "Sv nimi",
+  },
+  "onkoJulkinen": true,
+  "sorakuvausId": "sora_1",
+  "tila": "julkaistu",
   "valintakokeet": Array [
     Object {
       "tilaisuudet": Array [

--- a/src/main/app/src/utils/__tests__/getValintaperusteByFormValues.js
+++ b/src/main/app/src/utils/__tests__/getValintaperusteByFormValues.js
@@ -1,7 +1,7 @@
 import parseEditorState from '../draft/parseEditorState';
 import getValintaperusteByFormValues from '../getValintaperusteByFormValues';
 
-test('getValintaperusteByFormValues returns correct valintaperuste given form values', () => {
+test('Should convert valintaperuste form with valintatapa', () => {
   const valintaperuste = getValintaperusteByFormValues({
     perustiedot: {
       tyyppi: 'tyyppi_1#1',
@@ -125,6 +125,91 @@ test('getValintaperusteByFormValues returns correct valintaperuste given form va
         ],
       },
     },
+    tila: 'julkaistu',
+  });
+
+  expect(valintaperuste).toMatchSnapshot();
+});
+
+test('Should convert valintaperuste form without valintatapa', () => {
+  const valintaperuste = getValintaperusteByFormValues({
+    perustiedot: {
+      tyyppi: 'tyyppi_1#1',
+      kieliversiot: ['fi', 'sv'],
+      hakutapa: 'tapa_1#1',
+      kohdejoukko: { value: 'joukko_1#1' },
+    },
+    kuvaus: {
+      nimi: {
+        fi: 'Fi nimi',
+        sv: 'Sv nimi',
+      },
+      kuvaus: {
+        fi: parseEditorState('<h1>Fi kuvaus</h1>'),
+        sv: parseEditorState('<h1>Sv kuvaus</h2>'),
+      },
+    },
+    osaamistausta: [{ value: 'tausta_1#1' }, { value: 'tausta_2#1' }],
+    kielitaitovaatimukset: [
+      {
+        kieli: { value: 'kieli_1#1' },
+        tyyppi: {
+          'tyyppi_1#1': true,
+          'tyyppi_2#1': true,
+          'tyyppi_3#1': false,
+        },
+        kuvaukset: {
+          'tyyppi_1#1': [
+            {
+              kuvaus: { value: 'kuvaus_1#1' },
+              taso: 'erinomainen',
+            },
+          ],
+          'tyyppi_2#1': [
+            {
+              kuvaus: { value: 'kuvaus_2#1' },
+              taso: 'ok',
+            },
+          ],
+        },
+        osoitustavat: ['osoitustapa_1#1', 'osoitustapa_2#1'],
+        muutOsoitustavat: [
+          {
+            kuvaus: {
+              fi: 'Fi kuvaus',
+              sv: 'Sv kuvaus',
+            },
+          },
+        ],
+      },
+    ],
+    valintatavat: [{}],
+    soraKuvaus: {
+      value: 'sora_1',
+    },
+    julkinen: true,
+    valintakoe: {
+      tyypit: [{ value: 'tyyppi_1#1' }],
+      tilaisuudet: {
+        'tyyppi_1#1': [
+          {
+            osoite: { fi: 'fi osoite', sv: 'sv osoite' },
+            postinumero: { value: 'posti_1#1' },
+            postitoimipaikka: {
+              fi: 'fi posititoimipaikka',
+              sv: 'sv posititoimipaikka',
+            },
+            alkaa: '2019-04-16T08:44',
+            paattyy: '2019-04-18T08:44',
+            lisatietoja: {
+              fi: 'fi lisatietoja',
+              sv: 'sv lisatietoja',
+            },
+          },
+        ],
+      },
+    },
+    tila: 'julkaistu',
   });
 
   expect(valintaperuste).toMatchSnapshot();

--- a/src/main/app/src/utils/getValintaperusteByFormValues.js
+++ b/src/main/app/src/utils/getValintaperusteByFormValues.js
@@ -1,25 +1,32 @@
-import { get, isObject, isArray, mapValues, pick } from 'lodash';
+import _ from 'lodash';
 import produce from 'immer';
 import { isNumeric } from './index';
 import serializeEditorState from './draft/serializeEditorState';
 import getValintakoeFieldsData from './getValintakoeFieldsData';
 
+const getArrayValue = (values, key) => {
+  const valueCandidate = _.get(values, key);
+  return _.isEmpty(valueCandidate) || _.isEmpty(_.first(valueCandidate))
+    ? []
+    : valueCandidate;
+};
+
 const serializeTable = ({ table, kielivalinta }) => {
-  if (!get(table, 'rows')) {
+  if (!_.get(table, 'rows')) {
     return { rows: [] };
   }
 
   return produce(table, draft => {
     (draft.rows || []).forEach((row, rowIndex) => {
-      if (isObject(row)) {
+      if (_.isObject(row)) {
         row.index = rowIndex;
 
         (row.columns || []).forEach((column, columnIndex) => {
-          if (isObject(column)) {
+          if (_.isObject(column)) {
             column.index = columnIndex;
 
-            if (isObject(column.text)) {
-              column.text = pick(column.text, kielivalinta);
+            if (_.isObject(column.text)) {
+              column.text = _.pick(column.text, kielivalinta);
             }
           }
         });
@@ -29,7 +36,7 @@ const serializeTable = ({ table, kielivalinta }) => {
 };
 
 const serializeSisalto = ({ sisalto, kielivalinta = [] }) => {
-  if (!isArray(sisalto)) {
+  if (!_.isArray(sisalto)) {
     return [];
   }
 
@@ -37,8 +44,8 @@ const serializeSisalto = ({ sisalto, kielivalinta = [] }) => {
     let serializedData = {};
 
     if (tyyppi === 'teksti') {
-      serializedData = pick(
-        isObject(data) ? mapValues(data, serializeEditorState) : {},
+      serializedData = _.pick(
+        _.isObject(data) ? _.mapValues(data, serializeEditorState) : {},
         kielivalinta,
       );
     }
@@ -57,20 +64,20 @@ const serializeSisalto = ({ sisalto, kielivalinta = [] }) => {
 const getValintaperusteByFormValues = values => {
   const { tila, muokkaaja, perustiedot } = values;
 
-  const hakutapaKoodiUri = get(perustiedot, 'hakutapa');
+  const hakutapaKoodiUri = _.get(perustiedot, 'hakutapa');
 
-  const kielivalinta = get(perustiedot, 'kieliversiot') || [];
+  const kielivalinta = _.get(perustiedot, 'kieliversiot') || [];
 
-  const kohdejoukkoKoodiUri = get(perustiedot, 'kohdejoukko.value') || null;
+  const kohdejoukkoKoodiUri = _.get(perustiedot, 'kohdejoukko.value') || null;
 
-  const nimi = pick(get(values, 'kuvaus.nimi'), kielivalinta);
+  const nimi = _.pick(_.get(values, 'kuvaus.nimi'), kielivalinta);
 
-  const kuvaus = pick(
-    mapValues(get(values, 'kuvaus.kuvaus') || {}, serializeEditorState),
+  const kuvaus = _.pick(
+    _.mapValues(_.get(values, 'kuvaus.kuvaus') || {}, serializeEditorState),
     kielivalinta,
   );
 
-  const valintatavat = (get(values, 'valintatavat') || []).map(
+  const valintatavat = getArrayValue(values, 'valintatavat').map(
     ({
       tapa,
       kuvaus,
@@ -80,12 +87,12 @@ const getValintaperusteByFormValues = values => {
       vahimmaispistemaara,
       sisalto,
     }) => ({
-      kuvaus: pick(kuvaus || {}, kielivalinta),
-      nimi: pick(nimi || {}, kielivalinta),
-      valintatapaKoodiUri: get(tapa, 'value') || null,
+      kuvaus: _.pick(kuvaus || {}, kielivalinta),
+      nimi: _.pick(nimi || {}, kielivalinta),
+      valintatapaKoodiUri: _.get(tapa, 'value') || null,
       sisalto: serializeSisalto({ sisalto, kielivalinta }),
       kaytaMuuntotaulukkoa: false,
-      kynnysehto: pick(kynnysehto || {}, kielivalinta),
+      kynnysehto: _.pick(kynnysehto || {}, kielivalinta),
       enimmaispisteet: isNumeric(enimmaispistemaara)
         ? parseFloat(enimmaispistemaara)
         : null,
@@ -96,13 +103,13 @@ const getValintaperusteByFormValues = values => {
   );
 
   const valintakokeet = getValintakoeFieldsData({
-    valintakoeValues: get(values, 'valintakoe'),
+    valintakoeValues: _.get(values, 'valintakoe'),
     kielivalinta,
   });
 
-  const koulutustyyppi = get(perustiedot, 'tyyppi') || null;
-  const sorakuvausId = get(values, 'soraKuvaus.value') || null;
-  const onkoJulkinen = Boolean(get(values, 'julkinen'));
+  const koulutustyyppi = _.get(perustiedot, 'tyyppi') || null;
+  const sorakuvausId = _.get(values, 'soraKuvaus.value') || null;
+  const onkoJulkinen = Boolean(_.get(values, 'julkinen'));
 
   return {
     tila,


### PR DESCRIPTION
- A dummy 'valintatapa'-object was submitted even when valintatapa field was not visible.
- Improve getValintaPerusteByFormConfig() unit tests
- Import lodash to _ in getValintaperusteByFormValues