### PR TITLE
KTO-908: Hakukohde - Järjestyspaikan valinta ei periydy Toteutukselta

### DIFF
--- a/src/main/app/.gitignore
+++ b/src/main/app/.gitignore
@@ -24,5 +24,4 @@ yarn-error.log*
 
 cypress/screenshots
 cypress/videos
-cypress/fixtures
 cypress.env.json

--- a/src/main/app/.prettierignore
+++ b/src/main/app/.prettierignore
@@ -1,2 +1,4 @@
 cypress/**/__snapshots__/*
+cypress/fixtures/*
+cypress/mocks/*
 tsconfig.json

--- a/src/main/app/cypress/hakukohdeFormUtils.ts
+++ b/src/main/app/cypress/hakukohdeFormUtils.ts
@@ -49,7 +49,9 @@ export const fillJarjestyspaikkaSection = ({ jatka: jatkaProp = true }) => {
     });
 
     cy.findByText(selectedToimipisteNimi).click();
-    jatkaProp && jatka();
+    if (jatkaProp) {
+      jatka();
+    }
   });
 };
 

--- a/src/main/app/cypress/hakukohdeFormUtils.ts
+++ b/src/main/app/cypress/hakukohdeFormUtils.ts
@@ -6,9 +6,9 @@ import {
   stubOppijanumerorekisteriHenkiloRoute,
   stubKoodiRoute,
   stubCommonRoutes,
+  jatka,
 } from '#/cypress/utils';
 
-import organisaatio from '#/cypress/data/organisaatio';
 import haku from '#/cypress/data/haku';
 import hakukohde from '#/cypress/data/hakukohde';
 import createKoodi from '#/cypress/data/koodi';
@@ -16,17 +16,54 @@ import koulutus from '#/cypress/data/koulutus';
 import toteutus from '#/cypress/data/toteutus';
 import valintaperuste from '#/cypress/data/valintaperuste';
 
+const toimipisteTarjoajat = [
+  '1.2.246.562.10.16538823663',
+  '1.2.246.562.10.2013081415065445951365',
+  '1.2.246.562.10.20485193278',
+  '1.2.246.562.10.20866993056',
+  '1.2.246.562.10.23017513880',
+  '1.2.246.562.10.45854578546',
+  '1.2.246.562.10.55355715099',
+  '1.2.246.562.10.55711304158',
+  '1.2.246.562.10.56139411567',
+  '1.2.246.562.10.60465978314',
+  '1.2.246.562.10.656909794910',
+  '1.2.246.562.10.78321186062',
+  '1.2.246.562.10.879177258610',
+  '1.2.246.562.10.93115250668',
+];
+
+const selectedToimipisteNimi = /stadin ammatti- ja aikuisopisto, myllypuron toimipaikka/i;
+
+const selectedToimipiste = '1.2.246.562.10.45854578546';
+
+export const fillJarjestyspaikkaSection = ({ jatka: jatkaProp = true }) => {
+  cy.findByTestId('jarjestyspaikkaOidSection').within(() => {
+    toimipisteTarjoajat.forEach(oid => {
+      cy.get(`[value="${oid}"]`).should('exist');
+      if (oid === selectedToimipiste) {
+        cy.get(`[value="${oid}"]`).should('not.be.disabled');
+      } else {
+        cy.get(`[value="${oid}"]`).should('be.disabled');
+      }
+    });
+
+    cy.findByText(selectedToimipisteNimi).click();
+    jatkaProp && jatka();
+  });
+};
+
 export const prepareTest = ({
   tyyppi,
   hakuOid,
   hakukohdeOid,
   organisaatioOid,
-  edit,
+  edit = false,
+  tarjoajat,
 }) => {
   const toteutusOid = '2.1.1.1.1.1';
   const koulutusOid = '3.1.1.1.1';
   const valintaperusteId = '649adb37-cd4d-4846-91a9-84b58b90f928';
-  const tarjoajat = ['1.2.3.4.5.6.7', '7.7.7.7.7'];
 
   const testHakukohdeFields = {
     toteutusOid,
@@ -38,16 +75,17 @@ export const prepareTest = ({
 
   cy.server();
 
-  stubHakukohdeFormRoutes({ organisaatioOid, hakuOid, tarjoajat });
+  stubHakukohdeFormRoutes({ organisaatioOid, hakuOid });
 
   cy.route({
     method: 'GET',
     url: `**/toteutus/${toteutusOid}`,
     response: merge(toteutus({ tyyppi }), {
       oid: toteutusOid,
-      organisaatioOid: organisaatioOid,
+      organisaatioOid,
       koulutusOid: koulutusOid,
       tila: 'julkaistu',
+      tarjoajat,
     }),
   });
 
@@ -117,40 +155,8 @@ export const prepareTest = ({
   );
 };
 
-export const stubHakukohdeFormRoutes = ({
-  organisaatioOid,
-  hakuOid,
-  tarjoajat = [],
-}) => {
+export const stubHakukohdeFormRoutes = ({ organisaatioOid, hakuOid }) => {
   stubCommonRoutes();
-
-  cy.route({
-    method: 'GET',
-    url: `**/organisaatio-service/rest/organisaatio/v4/${organisaatioOid}**`,
-    response: merge(organisaatio(), {
-      oid: organisaatioOid,
-    }),
-  });
-
-  tarjoajat.forEach(tarjoajaOid => {
-    cy.route({
-      method: 'GET',
-      url: `**/organisaatio-service/rest/organisaatio/v4/hierarkia/hae?oid=${tarjoajaOid}**`,
-      response: merge(organisaatio(), {
-        oid: tarjoajaOid,
-      }),
-    });
-  });
-
-  cy.route({
-    method: 'POST',
-    url: '**/organisaatio-service/rest/organisaatio/v4/findbyoids',
-    response: [
-      merge(organisaatio(), {
-        oid: organisaatioOid,
-      }),
-    ],
-  });
 
   stubKoodistoRoute({ koodisto: 'pohjakoulutusvaatimustoinenaste' });
   stubKoodistoRoute({ koodisto: 'kausi' });

--- a/src/main/app/cypress/integration/__snapshots__/hakukohde.test.ts.snap
+++ b/src/main/app/cypress/integration/__snapshots__/hakukohde.test.ts.snap
@@ -15,6 +15,7 @@ exports[`createHakukohde > should be able to create ammatillinen hakukohde #0`] 
   "hakulomakeKuvaus": {},
   "hakulomakeLinkki": {},
   "hakulomaketyyppi": "ataru",
+  "jarjestyspaikkaOid": "1.2.246.562.10.45854578546",
   "kaytetaanHaunAikataulua": false,
   "kaytetaanHaunAlkamiskautta": false,
   "kaytetaanHaunHakulomaketta": false,
@@ -57,7 +58,7 @@ exports[`createHakukohde > should be able to create ammatillinen hakukohde #0`] 
   "nimi": {
     "fi": "Hakukohteen nimi"
   },
-  "organisaatioOid": "1.1.1.1.1.1",
+  "organisaatioOid": "1.2.246.562.10.52251087186",
   "pohjakoulutusvaatimusKoodiUrit": [
     "pohjakoulutusvaatimustoinenaste_0#1"
   ],
@@ -128,6 +129,7 @@ exports[`createHakukohde > should be able to create korkeakoulu hakukohde #0`] =
   "hakulomakeKuvaus": {},
   "hakulomakeLinkki": {},
   "hakulomaketyyppi": "ataru",
+  "jarjestyspaikkaOid": "1.2.246.562.10.45854578546",
   "kaytetaanHaunAikataulua": false,
   "kaytetaanHaunAlkamiskautta": false,
   "kaytetaanHaunHakulomaketta": false,
@@ -170,7 +172,7 @@ exports[`createHakukohde > should be able to create korkeakoulu hakukohde #0`] =
   "nimi": {
     "fi": "Hakukohteen nimi"
   },
-  "organisaatioOid": "1.1.1.1.1.1",
+  "organisaatioOid": "1.2.246.562.10.52251087186",
   "pohjakoulutusvaatimusKoodiUrit": [
     "pohjakoulutusvaatimustoinenaste_0#1"
   ],
@@ -242,6 +244,7 @@ exports[`editHakukohde > should be able to edit hakukohde #0`] =
   "hakulomakeKuvaus": {},
   "hakulomakeLinkki": {},
   "hakulomaketyyppi": "ataru",
+  "jarjestyspaikkaOid": "1.2.246.562.10.45854578546",
   "kaytetaanHaunAikataulua": false,
   "kaytetaanHaunAlkamiskautta": false,
   "kaytetaanHaunHakulomaketta": false,
@@ -287,7 +290,7 @@ exports[`editHakukohde > should be able to edit hakukohde #0`] =
     "fi": "Hakukohteen nimi"
   },
   "oid": "6.1.1.1.1.1",
-  "organisaatioOid": "1.1.1.1.1.1",
+  "organisaatioOid": "1.2.246.562.10.52251087186",
   "pohjakoulutusvaatimusKoodiUrit": [
     "pohjakoulutusvaatimustoinenaste_0#1"
   ],

--- a/src/main/app/cypress/integration/hakukohdeForm/createHakukohdeForm.ts
+++ b/src/main/app/cypress/integration/hakukohdeForm/createHakukohdeForm.ts
@@ -1,3 +1,4 @@
+import autoRecord from 'cypress-autorecord';
 import {
   getRadio,
   selectOption,
@@ -14,7 +15,10 @@ import {
   tallenna,
 } from '#/cypress/utils';
 
-import { prepareTest } from '#/cypress/hakukohdeFormUtils';
+import {
+  fillJarjestyspaikkaSection,
+  prepareTest,
+} from '#/cypress/hakukohdeFormUtils';
 
 const lisaa = () => {
   getByTestId('lisaaButton').click({ force: true });
@@ -152,16 +156,24 @@ const fillLiitteetSection = () => {
   });
 };
 
-export const createHakukohdeForm = () => {
-  const organisaatioOid = '1.1.1.1.1.1';
+export const createHakukohdeForm = function () {
+  const organisaatioOid = '1.2.246.562.10.52251087186'; // Stadin ammatti- ja aikuisopisto
   const hakuOid = '4.1.1.1.1.1';
   const hakukohdeOid = '1.2.3.4.5.6';
-  it('should be able to create ammatillinen hakukohde', () => {
+
+  const tarjoajat = [
+    '1.2.246.562.10.45854578546', // Stadin ammatti- ja aikuisopisto, Myllypuron toimipaikka
+  ];
+
+  autoRecord();
+
+  it('should be able to create ammatillinen hakukohde', function () {
     prepareTest({
       tyyppi: 'amm',
       hakuOid,
       hakukohdeOid,
       organisaatioOid,
+      tarjoajat,
     });
 
     fillKieliversiotSection({ jatka: true });
@@ -171,6 +183,9 @@ export const createHakukohdeForm = () => {
     fillValintaperusteenKuvausSection();
     fillValintakokeetSection();
     fillLiitteetSection();
+    fillJarjestyspaikkaSection({
+      jatka: true,
+    });
     fillTilaSection();
     tallenna();
 
@@ -190,6 +205,7 @@ export const createHakukohdeForm = () => {
       hakuOid,
       hakukohdeOid,
       organisaatioOid,
+      tarjoajat,
     });
 
     fillKieliversiotSection({ jatka: true });
@@ -199,6 +215,7 @@ export const createHakukohdeForm = () => {
     fillValintaperusteenKuvausSection();
     fillValintakokeetSection();
     fillLiitteetSection();
+    fillJarjestyspaikkaSection({ jatka: true });
     fillTilaSection();
 
     tallenna();

--- a/src/main/app/cypress/integration/hakukohdeForm/editHakukohde.ts
+++ b/src/main/app/cypress/integration/hakukohdeForm/editHakukohde.ts
@@ -1,10 +1,15 @@
-import { prepareTest } from '#/cypress/hakukohdeFormUtils';
+import autoRecord from 'cypress-autorecord';
+import {
+  prepareTest,
+  fillJarjestyspaikkaSection,
+} from '#/cypress/hakukohdeFormUtils';
 import { fillKieliversiotSection, tallenna } from '#/cypress/utils';
 
 export const editHakukohdeForm = () => {
-  const organisaatioOid = '1.1.1.1.1.1';
+  const organisaatioOid = '1.2.246.562.10.52251087186';
   const hakuOid = '4.1.1.1.1.1';
   const hakukohdeOid = '6.1.1.1.1.1';
+  autoRecord();
 
   it('should be able to edit hakukohde', () => {
     prepareTest({
@@ -13,9 +18,13 @@ export const editHakukohdeForm = () => {
       hakukohdeOid,
       organisaatioOid,
       edit: true,
+      tarjoajat: ['1.2.246.562.10.45854578546'],
     });
 
     fillKieliversiotSection();
+    fillJarjestyspaikkaSection({
+      jatka: false,
+    });
     tallenna();
 
     cy.wait('@updateHakukohdeRequest').then(({ request }) => {

--- a/src/main/app/cypress/mocks/hakukohde.test.json
+++ b/src/main/app/cypress/mocks/hakukohde.test.json
@@ -1,0 +1,7377 @@
+{
+  "should be able to create ammatillinen hakukohde": {
+    "timestamp": 1603350484306,
+    "routes": [
+      {
+        "url": "https://localhost:3000/kouta-backend/auth/session",
+        "method": "GET",
+        "status": 200,
+        "headers": {},
+        "body": null,
+        "response": {}
+      },
+      {
+        "url": "https://localhost:3000/kouta-backend/auth/session",
+        "method": "GET",
+        "status": 200,
+        "headers": {},
+        "body": null,
+        "response": {}
+      },
+      {
+        "url": "https://localhost:3000/kayttooikeus-service/cas/me",
+        "method": "GET",
+        "status": 200,
+        "headers": {},
+        "body": null,
+        "response": {
+          "uid": "johndoe",
+          "oid": "1.2.246.562.24.62301161440",
+          "firstName": "John",
+          "lastName": "Doe",
+          "lang": "fi",
+          "roles": "[\"APP_KOUTA\",\"APP_KOUTA_OPHPAAKAYTTAJA\",\"APP_KOUTA_OPHPAAKAYTTAJA_1.2.246.562.10.00000000001\"]"
+        }
+      },
+      {
+        "url": "https://localhost:3000/kouta-backend/toteutus/2.1.1.1.1.1",
+        "method": "GET",
+        "status": 200,
+        "headers": {},
+        "body": null,
+        "response": {
+          "oid": "2.1.1.1.1.1",
+          "koulutusOid": "3.1.1.1.1",
+          "tila": "julkaistu",
+          "tarjoajat": [
+            "1.2.3.4.5.6",
+            "9.8.7.6.5.4"
+          ],
+          "nimi": {
+            "fi": "Koulutuskeskus Salpaus, jatkuva haku, eläintenhoitaja"
+          },
+          "metadata": {
+            "kuvaus": {},
+            "opetus": {
+              "koulutuksenAlkamispaivamaara": "2019-08-23T00:00",
+              "koulutuksenPaattymispaivamaara": "2019-08-26T00:00",
+              "opetuskieliKoodiUrit": [
+                "oppilaitoksenopetuskieli_1#1"
+              ],
+              "opetuskieletKuvaus": {
+                "fi": "Opetuskieli kuvaus"
+              },
+              "suunniteltuKestoKuvaus": {
+                "fi": "Fi suunniteltuKestoKuvaus",
+                "sv": "Sv suunniteltuKestoKuvaus"
+              },
+              "suunniteltuKestoVuodet": 2,
+              "suunniteltuKestoKuukaudet": 6,
+              "opetusaikaKoodiUrit": [
+                "opetusaikakk_1#1"
+              ],
+              "opetusaikaKuvaus": {
+                "fi": "Opetusaika kuvaus"
+              },
+              "opetustapaKoodiUrit": [
+                "opetuspaikkakk_1#1"
+              ],
+              "opetustapaKuvaus": {
+                "fi": "Opetustapa kuvaus"
+              },
+              "onkoMaksullinen": true,
+              "maksullisuusKuvaus": {
+                "fi": "Maksullisuus kuvaus"
+              },
+              "maksunMaara": 20,
+              "alkamiskausiKoodiUri": "kausi_1#1",
+              "alkamisvuosi": "2024",
+              "alkamisaikaKuvaus": {
+                "fi": "Alkamisaika kuvaus"
+              },
+              "onkoStipendia": true,
+              "stipendinMaara": 90,
+              "stipendinKuvaus": {
+                "fi": "Stipendin kuvaus"
+              },
+              "lisatiedot": [
+                {
+                  "otsikkoKoodiUri": "koulutuksenlisatiedot_0#1",
+                  "teksti": {
+                    "fi": "koulutuksenlisatiedot_0 kuvaus"
+                  }
+                }
+              ]
+            },
+            "asiasanat": [
+              {
+                "kieli": "fi",
+                "arvo": "koira"
+              },
+              {
+                "kieli": "fi",
+                "arvo": "eläintenhoito"
+              }
+            ],
+            "ammattinimikkeet": [
+              {
+                "kieli": "fi",
+                "arvo": "eläintenhoitaja"
+              }
+            ],
+            "yhteyshenkilot": [
+              {
+                "nimi": {
+                  "fi": "Fi nimi",
+                  "sv": "Sv nimi"
+                },
+                "puhelinnumero": {
+                  "fi": "Fi puhelinnumero",
+                  "sv": "Sv puhelinnumero"
+                },
+                "sahkoposti": {
+                  "fi": "Fi sähköposti",
+                  "sv": "Sv sähköposti"
+                },
+                "titteli": {
+                  "fi": "Fi titteli",
+                  "sv": "Sv titteli"
+                },
+                "wwwSivu": {
+                  "fi": "Fi verkkosivu",
+                  "sv": "Sv verkkosivu"
+                }
+              }
+            ],
+            "tyyppi": "amm",
+            "osaamisalat": [
+              {
+                "koodiUri": "osaamisala_0",
+                "linkki": {
+                  "fi": "https://www.salpaus.fi/koulutusesittely/elaintenhoitaja/"
+                },
+                "otsikko": {
+                  "fi": "Otsikko"
+                }
+              }
+            ]
+          },
+          "muokkaaja": "1.2.246.562.24.62301161440",
+          "organisaatioOid": "1.2.246.562.10.52251087186",
+          "kielivalinta": [
+            "fi",
+            "sv"
+          ],
+          "modified": "2019-03-26T10:19"
+        }
+      },
+      {
+        "url": "https://localhost:3000/kouta-backend/haku/4.1.1.1.1.1",
+        "method": "GET",
+        "status": 200,
+        "headers": {},
+        "body": null,
+        "response": {
+          "oid": "4.1.1.1.1.1",
+          "tila": "julkaistu",
+          "nimi": {
+            "fi": "Haku"
+          },
+          "hakutapaKoodiUri": "hakutapa_0#1",
+          "hakukohteenLiittamisenTakaraja": "2019-02-08T07:05",
+          "hakukohteenMuokkaamisenTakaraja": "2019-02-08T07:05",
+          "alkamiskausiKoodiUri": "kausi_0#1",
+          "alkamisvuosi": "2024",
+          "kohdejoukkoKoodiUri": "haunkohdejoukko_0#1",
+          "kohdejoukonTarkenneKoodiUri": "haunkohdejoukontarkenne_0#1",
+          "hakulomaketyyppi": "muu",
+          "hakulomakeAtaruId": "12345",
+          "hakulomakeKuvaus": {},
+          "hakulomakeLinkki": {},
+          "metadata": {
+            "tulevaisuudenAikataulu": [
+              {
+                "alkaa": "2019-10-11T09:05",
+                "paattyy": "2019-12-25T20:30"
+              }
+            ],
+            "yhteyshenkilot": [
+              {
+                "nimi": {
+                  "fi": "nimi"
+                },
+                "titteli": {
+                  "fi": "titteli"
+                },
+                "puhelinnumero": {
+                  "fi": "puhelin"
+                },
+                "wwwSivu": {
+                  "fi": "verkkosivu"
+                },
+                "sahkoposti": {
+                  "fi": "sähkoposti"
+                }
+              }
+            ]
+          },
+          "organisaatioOid": "1.2.246.562.10.52251087186",
+          "hakuajat": [
+            {
+              "alkaa": "2019-02-08T07:05",
+              "paattyy": "2020-02-08T07:05"
+            }
+          ],
+          "ajastettuJulkaisu": "2019-12-05T06:45",
+          "muokkaaja": "1.2.246.562.24.62301161440",
+          "kielivalinta": [
+            "fi",
+            "sv"
+          ],
+          "modified": "2019-03-29T12:48"
+        }
+      },
+      {
+        "url": "https://localhost:3000/organisaatio-service/rest/organisaatio/v4/1.2.246.562.10.52251087186?includeImage=false",
+        "method": "GET",
+        "status": 200,
+        "headers": {},
+        "body": null,
+        "response": {
+          "metadata": {
+            "nimi": {},
+            "hakutoimistoEctsNimi": {},
+            "hakutoimistoEctsEmail": {},
+            "hakutoimistoEctsPuhelin": {},
+            "hakutoimistoEctsTehtavanimike": {},
+            "yhteystiedot": [
+              {
+                "kieli": "kieli_fi#1",
+                "www": "http://www.stadinammattiopisto.fi",
+                "yhteystietoOid": "14812023190550.9836378324069386",
+                "id": "3861227"
+              },
+              {
+                "kieli": "kieli_fi#1",
+                "numero": "09 310 89318",
+                "tyyppi": "puhelin",
+                "yhteystietoOid": "1.2.246.562.5.62477770688",
+                "id": "3861228"
+              },
+              {
+                "kieli": "kieli_fi#1",
+                "yhteystietoOid": "14303205263410.7259206293670477",
+                "id": "3861229",
+                "email": "hakutoimisto@edu.hel.fi"
+              },
+              {
+                "osoiteTyyppi": "posti",
+                "kieli": "kieli_fi#1",
+                "postinumeroUri": "posti_00099",
+                "yhteystietoOid": "1.2.246.562.5.20277448420",
+                "id": "3861230",
+                "postitoimipaikka": "HELSINGIN KAUPUNKI",
+                "osoite": "PL 55306"
+              },
+              {
+                "osoiteTyyppi": "kaynti",
+                "kieli": "kieli_fi#1",
+                "postinumeroUri": "posti_00550",
+                "yhteystietoOid": "1.2.246.562.5.26047810076",
+                "id": "3861231",
+                "postitoimipaikka": "HELSINKI",
+                "osoite": "Hattulantie 2, 1. krs"
+              }
+            ],
+            "hakutoimistonNimi": {
+              "kieli_fi#1": "Stadin ammatti- ja aikuisopiston hakutoimisto"
+            },
+            "luontiPvm": 1376895579333,
+            "muokkausPvm": 1376859600000,
+            "data": {
+              "KANSAINVALISET_KOULUTUSOHJELMAT": {},
+              "YLEISKUVAUS": {
+                "kieli_fi#1": "<p>Stadin ammatti- ja aikuisopisto järjestää ammatillista peruskoulutusta, ammatillista täydennyskoulutusta, oppisopimuskoulutusta ja nivelvaiheen koulutusta Helsingin kaupungin alueella 15 eri toimipaikassa. Meillä Suomen suurimmassa ammattiopistossa opiskelee noin 17 000 nuorta ja aikuista yli 50 eri ammattiin.</p> <p>Kun suoritat ammatillisen koulutuksen, saat laaja-alaiset valmiudet toimia oman alasi erilaisissa ja vaihtelevissa työtehtävissä sekä kehittää ammattitaitoasi läpi elämän. Lisäksi ammatillinen perustutkinto antaa sinulle yleisen jatko-opintokelpoisuuden ammattikorkeakouluihin ja yliopistoihin.</p> <p>Stadin ammatti- ja aikuisopistossa voit opiskella joustavasti eri oppimisratkaisuin. Opintojen suunnittelussa huomioidaan aina opiskelijan aiempi osaaminen esimerkiksi yhdistämällä oppilaitosmuotoista opiskelua ja oppisopimuskoulutusta. Lisäksi ammatilliseen perustutkintoon johtavassa koulutuksessa on mahdollista suorittaa lukio-opintoja sekä hakea ohjattuun urheiluvalmennukseen.</p> <p>Stadin ammatti- ja aikuisopiston Brygga tarjoaa nivelvaiheen koulutusta ja palveluja. Siihen kuuluvat ammatilliseen koulutukseen valmentava koulutus (VALMA), osa kaupungin perusopetuksen lisäopetuksesta (kymppiluokat), avoimet opinnot ja nuorten työpajatoiminta. Stadin osaamiskeskus puolestaan yhdistää kuntoutuksen, koulutuksen ja työllistymisen palvelut helsinkiläisille aikuisille maahanmuuttajille.</p> <p>Lisätietoa Stadin ammatti- ja aikuisopiston koulutustarjonnasta löytyy nettisivuiltamme www.stadinammattiopisto.fi</p> <p> </p>"
+              },
+              "KIELIOPINNOT": {
+                "kieli_fi#1": "<p>Kaikkiin perustutkintoihin kuuluu vähintään 2 osaamispistettä englantia (A-kieli) ja 1 osaamispistettä ruotsia. Lisäksi joissain toimipaikoissa voit valinnaisissa opinnoissa opiskella ylimääräisiä kieliä.</p>"
+              },
+              "TERVEYDENHUOLTOPALVELUT": {
+                "kieli_fi#1": "<p>Stadin ammatti- ja aikuisopistossa on sekä terveydenhoitajia että lääkäreitä opiskelijoita varten. Ensimmäisenä opiskeluvuonna terveydenhoitaja kutsuu sinut terveystarkastukseen, jossa selvitetään opiskelun tai ammatissa toimimisen kannalta tärkeät seikat. Lääkärin vastaanotolle haetaan terveydenhoitajan kautta.</p> <p>Oppilaitoksessa ei ole hammashoitolaa. Opiskelijat käyttävät oman asuinalueensa terveysaseman palveluita.</p>"
+              },
+              "TEHTAVANIMIKE": {},
+              "SAHKOPOSTIOSOITE": {},
+              "RAHOITUS": {},
+              "AIEMMIN_HANKITTU_OSAAMINEN": {
+                "kieli_fi#1": "<p>Osaamisen tunnistaminen ja tunnustaminen</p> <p>Ennalta hankittu osaaminen, kuten aiemmin suoritetut opinnot tai työkokemus, voidaan sisällyttää osaksi ammatillista tutkintoasi, mikäli osaamisesi on opetussuunnitelman mukaista. Tällöin opiskeluaikasi mahdollisesti lyhenee ja valmistut aikaisemmin.</p> <p>Osaamisen tunnistamista ja tunnustamista haetaan lomakkeella, jonka saat opettajaltasi tai opinto-ohjaajaltasi. He myös ohjaavat sen täyttämisessä.</p> <p>Opinnoista vapauttaminen</p> <p>Ruotsin kielestä voit anoa vapautusta, jos et ole opiskellut ruotsia aiemmin. Vapautusta haetaan lomakkeella, jonka saat opettajaltasi tai opinto-ohjaajaltasi. Ruotsin sijasta opiskelet jonkin muun sovitun opinnon.</p>"
+              },
+              "sosiaalinenmedia_7#1": {},
+              "sosiaalinenmedia_5#1": {
+                "kieli_fi#1": "http://www.pinterest.com/StadinAO"
+              },
+              "sosiaalinenmedia_6#1": {
+                "kieli_fi#1": "http://www.instagram.com/stadinao"
+              },
+              "OPISKELIJALIIKKUVUUS": {
+                "kieli_fi#1": "<p>Kansainvälisyys on osa Stadin ammatti- ja aikuisopiston arkea. Tarjoamme opiskelijalle mahdollisuuden lisätä kansainvälisyysosaamista opintojen aikana.  Kotikansainvälistymistä edistetään tarjoamalla kieliin ja kulttuuriin liittyviä oppimistilanteita, virtuaaliliikkuvuutta ja taitaja-toimintaa.</p> <p>Stadin ammatti- ja aikuisopistosta voi lähteä työssäoppimisjaksolle ulkomaille. Kansainväliset vaihdot täydentävät opiskelijoiden työelämävalmiuksia ammatillisen osaamisen, kielitaidon ja kulttuurien tuntemisen kautta sekä tukevat opiskelijan itsenäisyyttä, avoimuutta ja rohkeutta.</p> <p>Ulkomaanjaksoja voi suorittaa mm. Pohjoismaissa, Iso-Britanniassa, Hollannissa, Saksassa, Ranskassa, Espanjassa, Irlannissa, Virossa, Sloveniassa, Itävallassa, Venäjällä ja Kiinassa. Ulkomaanjaksolle lähdetään toisena tai kolmantena opintovuotena.</p>"
+              },
+              "VAKUUTUKSET": {
+                "kieli_fi#1": "<p>Kaikki opiskelijat on vakuutettu opiskelun aikana sattuneiden tapaturmien varalta. Tapaturma korvataan, jos se on sattunut oppitunnilla, työssäoppimisen aikana, opintokäynneillä tai koulumatkalla. Koulumatkalla vakuutus on voimassa vain, mikäli matka on tapahtunut viivytyksettä ja suorinta, tavanomaista tietä.</p> <p>Vakuutus on voimassa myös ulkomaille suuntautuvien opintomatkojen ja työssäoppimisjaksojen aikana. Oppilaitoksen vakuutukset eivät kuitenkaan ole voimassa, jos olet sairauslomalla. Pidempien sairauslomien ajaksi opinnot yleensä keskeytetään väliaikaisesti.</p>"
+              },
+              "OPISKELIJA_JARJESTOT": {
+                "kieli_fi#1": "<p>Opiskelijakuntatoiminta ja opiskelijayhdistys STAO ry</p> <p>Jokainen opiskelija kuuluu oman toimipaikkansa opiskelijakuntaan. Kustakin toimipaikasta valitaan lukuvuoden alussa opiskelijakunnan hallitus, jonka tehtävänä on tuoda opiskelijoiden ääni kuuluviin omassa toimipaikassa.</p> <p>STAO ry (Stadin ammattiin opiskelevat) on Stadin ammattiopiston opiskelijayhdistys, johon jokainen opiskelija voi liittyä. Yhdistys edistää opiskelijoiden toimintaa, osallistumista ja hyvinvointia koko oppilaitoksessa.</p>"
+              },
+              "VALINTAMENETTELY": {
+                "kieli_fi#1": "<p>Kevään yhteishaussa hakevat peruskoulunsa päättävät, ylioppilaat ja muut ilman toisen asteen ammatillista tutkintoa olevat (valintamenettelyssä noudatetaan Oph:n antamia ohjeita). Kaikki muut hakevat jatkuvassa haussa (oppilaitoksen oma valintamenettely, hakija saa valintapäätöksen kolmen viikon kuluessa hakemisesta).</p>"
+              },
+              "sosiaalinenmedia_3#1": {},
+              "sosiaalinenmedia_4#1": {
+                "kieli_fi#1": "http://www.twitter.com/stadinao"
+              },
+              "sosiaalinenmedia_1#1": {
+                "kieli_fi#1": "http://www.facebook.com/stadinammattiopisto"
+              },
+              "VASTUUHENKILOT": {},
+              "KUSTANNUKSET": {
+                "kieli_fi#1": "<p>Opintojensa aikana opiskelijat hankkivat itse esimerkiksi oppikirjoja, kansioita, muistiinpanovälineitä sekä henkilökohtaisia työvälineitä. Osassa tutkinnoista työvaatteet ja -kengät saa oppilaitoksen puolesta.</p>"
+              },
+              "OPPIMISYMPARISTO": {
+                "kieli_fi#1": "<p>Stadin ammatti- ja aikuisopiston kaikki toimipaikat sijaitsevat Helsingin kaupungin alueella. Toimipaikkojen oppimisympäristöjä uudistetaan monimuotoisiksi ja viihtyisiksi, jolloin ne tukevat opiskelijakeskeistä ja työelämälähtöistä pedagogiikkaa. Opiskelijoiden ja opettajien käytettävissä on mm. kattava, digitaalisuuden hyödyntämistä tukeva wifi.</p>"
+              },
+              "sosiaalinenmedia_2#1": {},
+              "PUHELINNUMERO": {},
+              "NIMI": {},
+              "OPISKELIJALIIKUNTA": {},
+              "VUOSIKELLO": {},
+              "OPISKELIJARUOKAILU": {
+                "kieli_fi#1": "<p>Stadin ammatti- ja aikuisopistossa on kaikissa toimipaikoissa opiskelijaravintola ja kahvila. Opiskelijoille on koulupäivinä tarjolla yksi maksuton lounasateria. Tarjolla on joka päivä myös kasvislounasvaihtoehto.</p>"
+              },
+              "VAPAA_AIKA": {},
+              "ESTEETOMYYS": {
+                "kieli_fi#1": "<p>Stadin ammatti- ja aikuisopisto on kaikille yhteinen oppilaitos, jossa jokainen pystyy ominaisuuksistaan riippumatta toimimaan yhdenvertaisesti muiden kanssa, jolloin opiskeluympäristössä ei pitäisi olla liikkumiseen, ryhmään kuulumiseen tai oppimiseen liittyviä esteitä.</p> <p><em> </em></p> <p><em>Opiskeluhuolto</em></p> <p>Opiskeluhuollon tavoitteena on edistää oppimistasi, terveyttäsi ja hyvinvointiasi opiskelun aikana. Opiskelijahuolto huolehtii myös oppilaitosyhteisön hyvinvoinnista sekä opiskeluympäristön terveellisyydestä ja turvallisuudesta. Opiskeluhuoltoa toteutetaan sekä yhteisöllisenä että yksilökohtaisena opiskeluhuoltona.</p> <p><em> </em></p> <p><em>Yhteisöllinen opiskeluhuolto</em></p> <p>Yhteisöllinen opiskeluhuolto edistää opiskelijoiden osallisuutta, oppimista, hyvinvointia ja terveyttä. Lisäksi se seuraa ja kehittää opiskeluyhteisön hyvinvointia sekä opiskeluympäristön terveellisyyttä, turvallisuutta ja esteettömyyttä. Toimipaikan hyvinvointiryhmä vastaa opiskeluhuollon suunnittelusta, kehittämisestä ja arvioinnista yhteisöllisen opiskeluhuollon osa-alueet huomioon ottaen. Ryhmää johtaa apulaisrehtori tai koulutuspäällikkö. Opetushenkilöstön lisäksi ryhmään kuuluu erityisopettaja, opinto-ohjaaja, kuraattori, psykologi, terveydenhoitaja ja opiskelijajäseniä. Ryhmään voi kuulua myös huoltajien edustaja.</p> <p><em> </em></p> <p><em>Yksilökohtainen opiskelijahuolto</em></p> <p>Yksilökohtaisella opiskelijahuollolla tarkoitetaan opiskelijan käytössä olevia palveluja, joita ovat • opiskeluterveydenhuolto • opiskeluhuollon psykologi- ja kuraattoripalvelut • yksittäistä opiskelijaa koskeva monialainen opiskeluhuolto, jota toteutetaan tapauskohtaisesti koottavassa monialaisessa asiantuntijaryhmässä. Yksilökohtaista opiskeluhuoltoa tehdään yhteistyössä opiskelijan kanssa ja hänen suostumuksellaan.</p> <p><em> </em></p> <p><em>Kun tarvitset tukea opinnoissasi</em></p> <p>Opintojesi alussa kanssasi tehdään henkilökohtainen osaamisen kehittämisen suunnitelma (HOKS). Suunnitelmaan kirjataan aiemmin hankittu ja osoitettu osaaminen, tarvittava ammattitaidon ja osaamisen hankkiminen, osaamisen osoittaminen sekä ohjaus- ja tukitoimet. Jos tarvitset erityistä tukea, suunnitelmassa sovitaan sinulle tarjottavan erityisen tuen sisällöstä ja erityisen tuen tarpeen mukaisista toimenpiteistä osaamisen hankkimisen aikana. Erityistä tukea voi saada kaikissa ammatilliseen perustutkintoon johtavissa koulutuksissa.</p>"
+              },
+              "TIETOA_ASUMISESTA": {
+                "kieli_fi#1": "<p>Stadin ammatti- ja aikuisopistolla ei ole asuntolaa. Tutkintoon johtavassa koulutuksessa oleva opiskelija voi hakea opiskelija-asuntoa esim. HOAS:lta.</p>"
+              },
+              "TYOHARJOITTELU": {
+                "kieli_fi#1": "<p>Kaikkiin perustutkintoihin kuuluu vähintään 30 osaamispistettä, n. kuusi kuukautta, työssäoppimista. Työssäoppiminen suoritetaan pääasiassa työpaikoilla ja työelämälähtöisissä oppimisympäristöissä.</p>"
+              }
+            }
+          },
+          "oid": "1.2.246.562.10.52251087186",
+          "nimi": {
+            "fi": "Stadin ammatti- ja aikuisopisto",
+            "sv": "Stadin ammatti- ja aikuisopisto",
+            "en": "Stadin ammatti- ja aikuisopisto"
+          },
+          "alkuPvm": "2013-01-01",
+          "oppilaitosKoodi": "10105",
+          "ryhmatyypit": [],
+          "kayttoryhmat": [],
+          "piilotettu": false,
+          "parentOid": "1.2.246.562.10.346830761110",
+          "postiosoite": {
+            "postinumeroUri": "posti_00099",
+            "osoiteTyyppi": "posti",
+            "yhteystietoOid": "1.2.246.562.5.69596457015",
+            "postitoimipaikka": "HELSINGIN KAUPUNKI",
+            "osoite": "PL 55308"
+          },
+          "kuvaus2": {},
+          "tyypit": [
+            "organisaatiotyyppi_02"
+          ],
+          "yhteystietoArvos": [
+            {
+              "YhteystietoArvo.arvoText": "stadiprimus@edu.hel.fi",
+              "YhteystietojenTyyppi.nimi.fi": "KOSKI-palvelun omien tietojen virheilmoituksen sähköpostiosoite",
+              "YhteystietojenTyyppi.nimi.sv": "E-postadress för felanmälan i egna uppgifter i KOSKI-tjänsten",
+              "YhteystietoElementti.tyyppi": "Email",
+              "YhteystietojenTyyppi.oid": "1.2.246.562.5.79385887983",
+              "YhteystietoElementti.oid": "1.2.246.562.5.57850489428",
+              "YhteystietoElementti.nimi": "Sähköpostiosoite",
+              "YhteystietoElementti.nimiSv": "Epostadress",
+              "YhteystietoElementti.pakollinen": "false",
+              "YhteystietojenTyyppi.nimi.en": "KOSKI-palvelun omien tietojen virheilmoituksen sähköpostiosoite",
+              "YhteystietoElementti.kaytossa": "true",
+              "YhteystietoArvo.kieli": "kieli_fi#1"
+            }
+          ],
+          "yhteystiedot": [
+            {
+              "osoiteTyyppi": "posti",
+              "kieli": "kieli_fi#1",
+              "postinumeroUri": "posti_00099",
+              "yhteystietoOid": "1.2.246.562.5.69596457015",
+              "id": "3861240",
+              "postitoimipaikka": "HELSINGIN KAUPUNKI",
+              "osoite": "PL 55308"
+            },
+            {
+              "kieli": "kieli_fi#1",
+              "yhteystietoOid": "14931031965550.42925150233306597",
+              "id": "3861238",
+              "email": "hakutoimisto@edu.hel.fi"
+            },
+            {
+              "osoiteTyyppi": "kaynti",
+              "kieli": "kieli_fi#1",
+              "postinumeroUri": "posti_00550",
+              "yhteystietoOid": "1.2.246.562.5.32847643825",
+              "id": "3861237",
+              "postitoimipaikka": "HELSINKI",
+              "osoite": "Hattulantie 2"
+            },
+            {
+              "kieli": "kieli_fi#1",
+              "numero": "09 310 8415",
+              "tyyppi": "puhelin",
+              "yhteystietoOid": "1.2.246.562.5.90059839549",
+              "id": "3861236"
+            },
+            {
+              "kieli": "kieli_fi#1",
+              "www": "http://www.stadinammattiopisto.fi",
+              "yhteystietoOid": "1.2.246.562.5.38465214716",
+              "id": "3861239"
+            }
+          ],
+          "nimet": [
+            {
+              "nimi": {
+                "fi": "Stadin ammattiopisto"
+              },
+              "alkuPvm": "2013-01-01",
+              "version": 1
+            },
+            {
+              "nimi": {
+                "fi": "Stadin ammatti- ja aikuisopisto",
+                "sv": "Stadin ammatti- ja aikuisopisto",
+                "en": "Stadin ammatti- ja aikuisopisto"
+              },
+              "alkuPvm": "2018-12-31",
+              "version": 0
+            }
+          ],
+          "vuosiluokat": [],
+          "parentOidPath": "|1.2.246.562.10.00000000001|1.2.246.562.10.346830761110|",
+          "toimipistekoodi": "10105",
+          "kotipaikkaUri": "kunta_091",
+          "kieletUris": [
+            "oppilaitoksenopetuskieli_1#1"
+          ],
+          "maaUri": "maatjavaltiot1_fin",
+          "oppilaitosTyyppiUri": "oppilaitostyyppi_21#1",
+          "muutKotipaikatUris": [],
+          "kayntiosoite": {
+            "postinumeroUri": "posti_00550",
+            "osoiteTyyppi": "kaynti",
+            "yhteystietoOid": "1.2.246.562.5.32847643825",
+            "postitoimipaikka": "HELSINKI",
+            "osoite": "Hattulantie 2"
+          },
+          "lisatiedot": [],
+          "muutOppilaitosTyyppiUris": [],
+          "version": 89,
+          "status": "AKTIIVINEN"
+        }
+      },
+      {
+        "url": "https://localhost:3000/kouta-backend/koulutus/3.1.1.1.1",
+        "method": "GET",
+        "status": 200,
+        "headers": {},
+        "body": null,
+        "response": {
+          "oid": "3.1.1.1.1",
+          "koulutustyyppi": "amm",
+          "koulutusKoodiUri": "koulutus_351107#12",
+          "tila": "julkaistu",
+          "tarjoajat": [
+            "1.2.3.4.5.6.7",
+            "7.7.7.7.7"
+          ],
+          "nimi": {
+            "en": "Vocational qualification in Mining",
+            "fi": "Kaivosalan perustutkinto",
+            "sv": "Grundexamen inom gruvbranschen"
+          },
+          "metadata": {
+            "tyyppi": "amm",
+            "kuvaus": {},
+            "lisatiedot": [
+              {
+                "otsikkoKoodiUri": "koulutuksenlisatiedot_0#1",
+                "teksti": {
+                  "fi": "koulutuksenlisatiedot_0 kuvaus"
+                }
+              }
+            ]
+          },
+          "julkinen": true,
+          "muokkaaja": "1.2.246.562.24.26603962037",
+          "organisaatioOid": "1.2.246.562.10.52251087186",
+          "kielivalinta": [
+            "fi",
+            "sv"
+          ],
+          "modified": "2020-09-21T16:27",
+          "johtaaTutkintoon": false,
+          "esikatselu": true,
+          "ePerusteId": 6777660
+        }
+      },
+      {
+        "url": "https://localhost:3000/kouta-backend/valintaperuste/list?organisaatioOid=1.2.246.562.10.52251087186&hakuOid=4.1.1.1.1.1",
+        "method": "GET",
+        "status": 200,
+        "headers": {},
+        "body": null,
+        "response": [
+          {
+            "koulutustyyppi": "amm",
+            "id": "649adb37-cd4d-4846-91a9-84b58b90f928",
+            "tila": "julkaistu",
+            "hakutapaKoodiUri": "hakutapa_0#1",
+            "kohdejoukkoKoodiUri": "haunkohdejoukko_0#1",
+            "nimi": {
+              "fi": "Valintaperusteen nimi"
+            },
+            "julkinen": false,
+            "sorakuvausId": "1",
+            "metadata": {
+              "koulutustyyppi": "amm",
+              "valintatavat": [
+                {
+                  "valintatapaKoodiUri": "valintatapajono_0#1",
+                  "kuvaus": {},
+                  "nimi": {
+                    "fi": "Valintatavan nimi"
+                  },
+                  "sisalto": [
+                    {
+                      "tyyppi": "teksti",
+                      "data": {
+                        "fi": "<p>Tekstia</p>"
+                      }
+                    },
+                    {
+                      "tyyppi": "taulukko",
+                      "data": {
+                        "nimi": {},
+                        "rows": [
+                          {
+                            "index": 0,
+                            "isHeader": false,
+                            "columns": [
+                              {
+                                "index": 0,
+                                "text": {
+                                  "fi": "Solu"
+                                }
+                              }
+                            ]
+                          }
+                        ]
+                      }
+                    }
+                  ],
+                  "kaytaMuuntotaulukkoa": false,
+                  "kynnysehto": {
+                    "fi": "Kynnysehto"
+                  },
+                  "enimmaispisteet": 100,
+                  "vahimmaispisteet": 10
+                }
+              ],
+              "kielitaitovaatimukset": [],
+              "kuvaus": {
+                "fi": "<p>Loppukuvaus</p>"
+              },
+              "valintakokeidenYleiskuvaus": {
+                "fi": "<p>Valintakokeiden kuvaus - fi</p>"
+              }
+            },
+            "organisaatioOid": "1.2.246.562.10.594252633210",
+            "muokkaaja": "1.2.246.562.24.62301161440",
+            "kielivalinta": [
+              "fi",
+              "sv"
+            ],
+            "modified": "2019-04-03T13:56",
+            "valintakokeet": [
+              {
+                "nimi": {
+                  "fi": "Kokeen nimi - fi"
+                },
+                "metadata": {
+                  "tietoja": {
+                    "fi": "<p>Tietoa kokeesta - fi</p>"
+                  },
+                  "liittyyEnnakkovalmistautumista": true,
+                  "ohjeetEnnakkovalmistautumiseen": {
+                    "fi": "<p>Ohjeet ennakkovalmistautumiseen - fi</p>"
+                  },
+                  "erityisjarjestelytMahdollisia": true,
+                  "ohjeetErityisjarjestelyihin": {
+                    "fi": "<p>Ohjeet erityisjärjestelyihin - fi</p>"
+                  }
+                },
+                "tyyppiKoodiUri": "tyyppi_1#1",
+                "tilaisuudet": [
+                  {
+                    "osoite": {
+                      "osoite": {
+                        "fi": "fi osoite"
+                      },
+                      "postinumeroKoodiUri": "posti_00350#1"
+                    },
+                    "aika": {
+                      "alkaa": "2019-04-16T08:44",
+                      "paattyy": "2019-04-18T08:44"
+                    },
+                    "lisatietoja": {
+                      "fi": "fi lisatietoja"
+                    },
+                    "jarjestamispaikka": {
+                      "fi": "Jarjestamispaikka - fi"
+                    }
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "url": "https://localhost:3000/koodisto-service/rest/json/pohjakoulutusvaatimustoinenaste/koodi?onlyValidKoodis=true&koodistoVersio=",
+        "method": "GET",
+        "status": 200,
+        "headers": {},
+        "body": null,
+        "response": [
+          {
+            "koodiUri": "pohjakoulutusvaatimustoinenaste_0",
+            "resourceUri": "https://virkailija.hahtuvaopintopolku.fi/koodisto-service/rest/codeelement/pohjakoulutusvaatimustoinenaste_11",
+            "version": 1,
+            "versio": 1,
+            "koodisto": {
+              "koodistoUri": "pohjakoulutusvaatimustoinenaste",
+              "organisaatioOid": "1.2.246.562.10.00000000001",
+              "koodistoVersios": [
+                1
+              ]
+            },
+            "koodiArvo": "0",
+            "paivitysPvm": 1427461978048,
+            "voimassaAlkuPvm": "2000-01-01",
+            "voimassaLoppuPvm": null,
+            "tila": "LUONNOS",
+            "metadata": [
+              {
+                "nimi": "pohjakoulutusvaatimustoinenaste_0",
+                "kuvaus": "pohjakoulutusvaatimustoinenaste_0",
+                "lyhytNimi": "pohjakoulutusvaatimustoinenaste_0",
+                "kieli": "fi"
+              },
+              {
+                "nimi": "pohjakoulutusvaatimustoinenaste_0",
+                "kuvaus": "pohjakoulutusvaatimustoinenaste_0",
+                "lyhytNimi": "pohjakoulutusvaatimustoinenaste_0",
+                "kieli": "sv"
+              },
+              {
+                "nimi": "pohjakoulutusvaatimustoinenaste_0",
+                "kuvaus": "pohjakoulutusvaatimustoinenaste_0",
+                "lyhytNimi": "pohjakoulutusvaatimustoinenaste_0",
+                "kieli": "en"
+              }
+            ]
+          },
+          {
+            "koodiUri": "pohjakoulutusvaatimustoinenaste_1",
+            "resourceUri": "https://virkailija.hahtuvaopintopolku.fi/koodisto-service/rest/codeelement/pohjakoulutusvaatimustoinenaste_11",
+            "version": 1,
+            "versio": 1,
+            "koodisto": {
+              "koodistoUri": "pohjakoulutusvaatimustoinenaste",
+              "organisaatioOid": "1.2.246.562.10.00000000001",
+              "koodistoVersios": [
+                1
+              ]
+            },
+            "koodiArvo": "1",
+            "paivitysPvm": 1427461978048,
+            "voimassaAlkuPvm": "2000-01-01",
+            "voimassaLoppuPvm": null,
+            "tila": "LUONNOS",
+            "metadata": [
+              {
+                "nimi": "pohjakoulutusvaatimustoinenaste_1",
+                "kuvaus": "pohjakoulutusvaatimustoinenaste_1",
+                "lyhytNimi": "pohjakoulutusvaatimustoinenaste_1",
+                "kieli": "fi"
+              },
+              {
+                "nimi": "pohjakoulutusvaatimustoinenaste_1",
+                "kuvaus": "pohjakoulutusvaatimustoinenaste_1",
+                "lyhytNimi": "pohjakoulutusvaatimustoinenaste_1",
+                "kieli": "sv"
+              },
+              {
+                "nimi": "pohjakoulutusvaatimustoinenaste_1",
+                "kuvaus": "pohjakoulutusvaatimustoinenaste_1",
+                "lyhytNimi": "pohjakoulutusvaatimustoinenaste_1",
+                "kieli": "en"
+              }
+            ]
+          },
+          {
+            "koodiUri": "pohjakoulutusvaatimustoinenaste_2",
+            "resourceUri": "https://virkailija.hahtuvaopintopolku.fi/koodisto-service/rest/codeelement/pohjakoulutusvaatimustoinenaste_11",
+            "version": 1,
+            "versio": 1,
+            "koodisto": {
+              "koodistoUri": "pohjakoulutusvaatimustoinenaste",
+              "organisaatioOid": "1.2.246.562.10.00000000001",
+              "koodistoVersios": [
+                1
+              ]
+            },
+            "koodiArvo": "2",
+            "paivitysPvm": 1427461978048,
+            "voimassaAlkuPvm": "2000-01-01",
+            "voimassaLoppuPvm": null,
+            "tila": "LUONNOS",
+            "metadata": [
+              {
+                "nimi": "pohjakoulutusvaatimustoinenaste_2",
+                "kuvaus": "pohjakoulutusvaatimustoinenaste_2",
+                "lyhytNimi": "pohjakoulutusvaatimustoinenaste_2",
+                "kieli": "fi"
+              },
+              {
+                "nimi": "pohjakoulutusvaatimustoinenaste_2",
+                "kuvaus": "pohjakoulutusvaatimustoinenaste_2",
+                "lyhytNimi": "pohjakoulutusvaatimustoinenaste_2",
+                "kieli": "sv"
+              },
+              {
+                "nimi": "pohjakoulutusvaatimustoinenaste_2",
+                "kuvaus": "pohjakoulutusvaatimustoinenaste_2",
+                "lyhytNimi": "pohjakoulutusvaatimustoinenaste_2",
+                "kieli": "en"
+              }
+            ]
+          },
+          {
+            "koodiUri": "pohjakoulutusvaatimustoinenaste_3",
+            "resourceUri": "https://virkailija.hahtuvaopintopolku.fi/koodisto-service/rest/codeelement/pohjakoulutusvaatimustoinenaste_11",
+            "version": 1,
+            "versio": 1,
+            "koodisto": {
+              "koodistoUri": "pohjakoulutusvaatimustoinenaste",
+              "organisaatioOid": "1.2.246.562.10.00000000001",
+              "koodistoVersios": [
+                1
+              ]
+            },
+            "koodiArvo": "3",
+            "paivitysPvm": 1427461978048,
+            "voimassaAlkuPvm": "2000-01-01",
+            "voimassaLoppuPvm": null,
+            "tila": "LUONNOS",
+            "metadata": [
+              {
+                "nimi": "pohjakoulutusvaatimustoinenaste_3",
+                "kuvaus": "pohjakoulutusvaatimustoinenaste_3",
+                "lyhytNimi": "pohjakoulutusvaatimustoinenaste_3",
+                "kieli": "fi"
+              },
+              {
+                "nimi": "pohjakoulutusvaatimustoinenaste_3",
+                "kuvaus": "pohjakoulutusvaatimustoinenaste_3",
+                "lyhytNimi": "pohjakoulutusvaatimustoinenaste_3",
+                "kieli": "sv"
+              },
+              {
+                "nimi": "pohjakoulutusvaatimustoinenaste_3",
+                "kuvaus": "pohjakoulutusvaatimustoinenaste_3",
+                "lyhytNimi": "pohjakoulutusvaatimustoinenaste_3",
+                "kieli": "en"
+              }
+            ]
+          },
+          {
+            "koodiUri": "pohjakoulutusvaatimustoinenaste_4",
+            "resourceUri": "https://virkailija.hahtuvaopintopolku.fi/koodisto-service/rest/codeelement/pohjakoulutusvaatimustoinenaste_11",
+            "version": 1,
+            "versio": 1,
+            "koodisto": {
+              "koodistoUri": "pohjakoulutusvaatimustoinenaste",
+              "organisaatioOid": "1.2.246.562.10.00000000001",
+              "koodistoVersios": [
+                1
+              ]
+            },
+            "koodiArvo": "4",
+            "paivitysPvm": 1427461978048,
+            "voimassaAlkuPvm": "2000-01-01",
+            "voimassaLoppuPvm": null,
+            "tila": "LUONNOS",
+            "metadata": [
+              {
+                "nimi": "pohjakoulutusvaatimustoinenaste_4",
+                "kuvaus": "pohjakoulutusvaatimustoinenaste_4",
+                "lyhytNimi": "pohjakoulutusvaatimustoinenaste_4",
+                "kieli": "fi"
+              },
+              {
+                "nimi": "pohjakoulutusvaatimustoinenaste_4",
+                "kuvaus": "pohjakoulutusvaatimustoinenaste_4",
+                "lyhytNimi": "pohjakoulutusvaatimustoinenaste_4",
+                "kieli": "sv"
+              },
+              {
+                "nimi": "pohjakoulutusvaatimustoinenaste_4",
+                "kuvaus": "pohjakoulutusvaatimustoinenaste_4",
+                "lyhytNimi": "pohjakoulutusvaatimustoinenaste_4",
+                "kieli": "en"
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "url": "https://localhost:3000/organisaatio-service/rest/organisaatio/v4/hierarkia/hae?oid=1.2.246.562.10.52251087186&aktiiviset=true&suunnitellut=true&lakkautetut=false",
+        "method": "GET",
+        "status": 200,
+        "headers": {},
+        "body": null,
+        "response": {
+          "numHits": 16,
+          "organisaatiot": [
+            {
+              "oid": "1.2.246.562.10.346830761110",
+              "alkuPvm": 268005600000,
+              "parentOid": "1.2.246.562.10.00000000001",
+              "parentOidPath": "1.2.246.562.10.346830761110/1.2.246.562.10.00000000001",
+              "ytunnus": "0201256-6",
+              "toimipistekoodi": "",
+              "match": false,
+              "nimi": {
+                "fi": "Helsingin kaupunki",
+                "sv": "Helsingfors stad"
+              },
+              "kieletUris": [
+                "oppilaitoksenopetuskieli_1#1",
+                "oppilaitoksenopetuskieli_2#1",
+                "oppilaitoksenopetuskieli_3#1"
+              ],
+              "kotipaikkaUri": "kunta_091",
+              "children": [
+                {
+                  "oid": "1.2.246.562.10.52251087186",
+                  "alkuPvm": 1356991200000,
+                  "parentOid": "1.2.246.562.10.346830761110",
+                  "parentOidPath": "1.2.246.562.10.52251087186/1.2.246.562.10.346830761110/1.2.246.562.10.00000000001",
+                  "oppilaitosKoodi": "10105",
+                  "oppilaitostyyppi": "oppilaitostyyppi_21#1",
+                  "toimipistekoodi": "10105",
+                  "match": true,
+                  "nimi": {
+                    "fi": "Stadin ammatti- ja aikuisopisto",
+                    "sv": "Stadin ammatti- ja aikuisopisto",
+                    "en": "Stadin ammatti- ja aikuisopisto"
+                  },
+                  "kieletUris": [
+                    "oppilaitoksenopetuskieli_1#1"
+                  ],
+                  "kotipaikkaUri": "kunta_091",
+                  "children": [
+                    {
+                      "oid": "1.2.246.562.10.45854578546",
+                      "alkuPvm": 1413234000000,
+                      "parentOid": "1.2.246.562.10.52251087186",
+                      "parentOidPath": "1.2.246.562.10.45854578546/1.2.246.562.10.52251087186/1.2.246.562.10.346830761110/1.2.246.562.10.00000000001",
+                      "toimipistekoodi": "1010516",
+                      "match": false,
+                      "nimi": {
+                        "fi": "Stadin ammatti- ja aikuisopisto, Myllypuron toimipaikka"
+                      },
+                      "kieletUris": [
+                        "oppilaitoksenopetuskieli_1#1"
+                      ],
+                      "kotipaikkaUri": "kunta_091",
+                      "children": [],
+                      "aliOrganisaatioMaara": 0,
+                      "organisaatiotyypit": [
+                        "organisaatiotyyppi_03"
+                      ],
+                      "status": "AKTIIVINEN"
+                    },
+                    {
+                      "oid": "1.2.246.562.10.656909794910",
+                      "alkuPvm": 1356991200000,
+                      "parentOid": "1.2.246.562.10.52251087186",
+                      "parentOidPath": "1.2.246.562.10.656909794910/1.2.246.562.10.52251087186/1.2.246.562.10.346830761110/1.2.246.562.10.00000000001",
+                      "toimipistekoodi": "1010508",
+                      "match": false,
+                      "nimi": {
+                        "fi": "Stadin ammatti- ja aikuisopisto, Prinsessantien toimipaikka"
+                      },
+                      "kieletUris": [
+                        "oppilaitoksenopetuskieli_1#1"
+                      ],
+                      "kotipaikkaUri": "kunta_091",
+                      "children": [],
+                      "aliOrganisaatioMaara": 0,
+                      "organisaatiotyypit": [
+                        "organisaatiotyyppi_03"
+                      ],
+                      "status": "AKTIIVINEN"
+                    },
+                    {
+                      "oid": "1.2.246.562.10.56139411567",
+                      "alkuPvm": 1356991200000,
+                      "parentOid": "1.2.246.562.10.52251087186",
+                      "parentOidPath": "1.2.246.562.10.56139411567/1.2.246.562.10.52251087186/1.2.246.562.10.346830761110/1.2.246.562.10.00000000001",
+                      "toimipistekoodi": "1010501",
+                      "match": false,
+                      "nimi": {
+                        "fi": "Stadin ammatti- ja aikuisopisto, Abraham Wetterin tien toimipaikka"
+                      },
+                      "kieletUris": [
+                        "oppilaitoksenopetuskieli_1#1"
+                      ],
+                      "kotipaikkaUri": "kunta_091",
+                      "children": [],
+                      "aliOrganisaatioMaara": 0,
+                      "organisaatiotyypit": [
+                        "organisaatiotyyppi_03"
+                      ],
+                      "status": "AKTIIVINEN"
+                    },
+                    {
+                      "oid": "1.2.246.562.10.20485193278",
+                      "alkuPvm": 1356991200000,
+                      "parentOid": "1.2.246.562.10.52251087186",
+                      "parentOidPath": "1.2.246.562.10.20485193278/1.2.246.562.10.52251087186/1.2.246.562.10.346830761110/1.2.246.562.10.00000000001",
+                      "toimipistekoodi": "1010502",
+                      "match": false,
+                      "nimi": {
+                        "fi": "Stadin ammatti- ja aikuisopisto, Vilppulantien toimipaikka"
+                      },
+                      "kieletUris": [
+                        "oppilaitoksenopetuskieli_1#1"
+                      ],
+                      "kotipaikkaUri": "kunta_091",
+                      "children": [],
+                      "aliOrganisaatioMaara": 0,
+                      "organisaatiotyypit": [
+                        "organisaatiotyyppi_03"
+                      ],
+                      "status": "AKTIIVINEN"
+                    },
+                    {
+                      "oid": "1.2.246.562.10.93115250668",
+                      "alkuPvm": 1413234000000,
+                      "parentOid": "1.2.246.562.10.52251087186",
+                      "parentOidPath": "1.2.246.562.10.93115250668/1.2.246.562.10.52251087186/1.2.246.562.10.346830761110/1.2.246.562.10.00000000001",
+                      "toimipistekoodi": "1010515",
+                      "match": false,
+                      "nimi": {
+                        "fi": "Stadin ammatti- ja aikuisopisto, Meritalon toimipaikka"
+                      },
+                      "kieletUris": [
+                        "oppilaitoksenopetuskieli_1#1"
+                      ],
+                      "kotipaikkaUri": "kunta_091",
+                      "children": [],
+                      "aliOrganisaatioMaara": 0,
+                      "organisaatiotyypit": [
+                        "organisaatiotyyppi_03"
+                      ],
+                      "status": "AKTIIVINEN"
+                    },
+                    {
+                      "oid": "1.2.246.562.10.78321186062",
+                      "alkuPvm": 1356991200000,
+                      "parentOid": "1.2.246.562.10.52251087186",
+                      "parentOidPath": "1.2.246.562.10.78321186062/1.2.246.562.10.52251087186/1.2.246.562.10.346830761110/1.2.246.562.10.00000000001",
+                      "toimipistekoodi": "1010509",
+                      "match": false,
+                      "nimi": {
+                        "fi": "Stadin ammatti- ja aikuisopisto, Savonkadun toimipaikka"
+                      },
+                      "kieletUris": [
+                        "oppilaitoksenopetuskieli_1#1"
+                      ],
+                      "kotipaikkaUri": "kunta_091",
+                      "children": [],
+                      "aliOrganisaatioMaara": 0,
+                      "organisaatiotyypit": [
+                        "organisaatiotyyppi_03"
+                      ],
+                      "status": "AKTIIVINEN"
+                    },
+                    {
+                      "oid": "1.2.246.562.10.55711304158",
+                      "alkuPvm": 1356991200000,
+                      "parentOid": "1.2.246.562.10.52251087186",
+                      "parentOidPath": "1.2.246.562.10.55711304158/1.2.246.562.10.52251087186/1.2.246.562.10.346830761110/1.2.246.562.10.00000000001",
+                      "toimipistekoodi": "1010519",
+                      "match": false,
+                      "nimi": {
+                        "fi": "Stadin ammatti- ja aikuisopisto, Teollisuuskadun toimipaikka"
+                      },
+                      "kieletUris": [
+                        "oppilaitoksenopetuskieli_1#1"
+                      ],
+                      "kotipaikkaUri": "kunta_091",
+                      "children": [],
+                      "aliOrganisaatioMaara": 0,
+                      "organisaatiotyypit": [
+                        "organisaatiotyyppi_03"
+                      ],
+                      "status": "AKTIIVINEN"
+                    },
+                    {
+                      "oid": "1.2.246.562.10.879177258610",
+                      "alkuPvm": 1356991200000,
+                      "parentOid": "1.2.246.562.10.52251087186",
+                      "parentOidPath": "1.2.246.562.10.879177258610/1.2.246.562.10.52251087186/1.2.246.562.10.346830761110/1.2.246.562.10.00000000001",
+                      "toimipistekoodi": "1010507",
+                      "match": false,
+                      "nimi": {
+                        "fi": "Stadin ammatti- ja aikuisopisto, Muotoilijankadun toimipaikka",
+                        "en": "Helsinki City College, Muotoilijankatu"
+                      },
+                      "kieletUris": [
+                        "oppilaitoksenopetuskieli_1#1"
+                      ],
+                      "kotipaikkaUri": "kunta_091",
+                      "children": [],
+                      "aliOrganisaatioMaara": 0,
+                      "organisaatiotyypit": [
+                        "organisaatiotyyppi_03"
+                      ],
+                      "status": "AKTIIVINEN"
+                    },
+                    {
+                      "oid": "1.2.246.562.10.55355715099",
+                      "alkuPvm": 1356991200000,
+                      "parentOid": "1.2.246.562.10.52251087186",
+                      "parentOidPath": "1.2.246.562.10.55355715099/1.2.246.562.10.52251087186/1.2.246.562.10.346830761110/1.2.246.562.10.00000000001",
+                      "toimipistekoodi": "1010504",
+                      "match": false,
+                      "nimi": {
+                        "fi": "Stadin ammatti- ja aikuisopisto, Ilkantien toimipaikka"
+                      },
+                      "kieletUris": [
+                        "oppilaitoksenopetuskieli_1#1"
+                      ],
+                      "kotipaikkaUri": "kunta_091",
+                      "children": [],
+                      "aliOrganisaatioMaara": 0,
+                      "organisaatiotyypit": [
+                        "organisaatiotyyppi_03"
+                      ],
+                      "status": "AKTIIVINEN"
+                    },
+                    {
+                      "oid": "1.2.246.562.10.2013081415065445951365",
+                      "alkuPvm": 1375304400000,
+                      "parentOid": "1.2.246.562.10.52251087186",
+                      "parentOidPath": "1.2.246.562.10.2013081415065445951365/1.2.246.562.10.52251087186/1.2.246.562.10.346830761110/1.2.246.562.10.00000000001",
+                      "toimipistekoodi": "1010514",
+                      "match": false,
+                      "nimi": {
+                        "fi": "Stadin ammatti- ja aikuisopisto, Pälkäneentien toimipaikka"
+                      },
+                      "kieletUris": [
+                        "oppilaitoksenopetuskieli_1#1"
+                      ],
+                      "kotipaikkaUri": "kunta_091",
+                      "children": [],
+                      "aliOrganisaatioMaara": 0,
+                      "organisaatiotyypit": [
+                        "organisaatiotyyppi_03"
+                      ],
+                      "status": "AKTIIVINEN"
+                    },
+                    {
+                      "oid": "1.2.246.562.10.20866993056",
+                      "alkuPvm": 1356991200000,
+                      "parentOid": "1.2.246.562.10.52251087186",
+                      "parentOidPath": "1.2.246.562.10.20866993056/1.2.246.562.10.52251087186/1.2.246.562.10.346830761110/1.2.246.562.10.00000000001",
+                      "toimipistekoodi": "1010505",
+                      "match": false,
+                      "nimi": {
+                        "fi": "Stadin ammatti- ja aikuisopisto, Kullervonkadun toimipaikka"
+                      },
+                      "kieletUris": [
+                        "oppilaitoksenopetuskieli_1#1"
+                      ],
+                      "kotipaikkaUri": "kunta_091",
+                      "children": [],
+                      "aliOrganisaatioMaara": 0,
+                      "organisaatiotyypit": [
+                        "organisaatiotyyppi_03"
+                      ],
+                      "status": "AKTIIVINEN"
+                    },
+                    {
+                      "oid": "1.2.246.562.10.16538823663",
+                      "alkuPvm": 1356991200000,
+                      "parentOid": "1.2.246.562.10.52251087186",
+                      "parentOidPath": "1.2.246.562.10.16538823663/1.2.246.562.10.52251087186/1.2.246.562.10.346830761110/1.2.246.562.10.00000000001",
+                      "toimipistekoodi": "1010510",
+                      "match": false,
+                      "nimi": {
+                        "fi": "Stadin ammatti- ja aikuisopisto, Sturenkadun toimipaikka"
+                      },
+                      "kieletUris": [
+                        "oppilaitoksenopetuskieli_1#1"
+                      ],
+                      "kotipaikkaUri": "kunta_091",
+                      "children": [],
+                      "aliOrganisaatioMaara": 0,
+                      "organisaatiotyypit": [
+                        "organisaatiotyyppi_03"
+                      ],
+                      "status": "AKTIIVINEN"
+                    },
+                    {
+                      "oid": "1.2.246.562.10.23017513880",
+                      "alkuPvm": 1470603600000,
+                      "parentOid": "1.2.246.562.10.52251087186",
+                      "parentOidPath": "1.2.246.562.10.23017513880/1.2.246.562.10.52251087186/1.2.246.562.10.346830761110/1.2.246.562.10.00000000001",
+                      "toimipistekoodi": "1010517",
+                      "match": false,
+                      "nimi": {
+                        "fi": "Stadin ammatti- ja aikuisopisto, Hattulantien toimipaikka"
+                      },
+                      "kieletUris": [
+                        "oppilaitoksenopetuskieli_1#1"
+                      ],
+                      "kotipaikkaUri": "kunta_091",
+                      "children": [],
+                      "aliOrganisaatioMaara": 0,
+                      "organisaatiotyypit": [
+                        "organisaatiotyyppi_03"
+                      ],
+                      "status": "AKTIIVINEN"
+                    },
+                    {
+                      "oid": "1.2.246.562.10.60465978314",
+                      "alkuPvm": 1356991200000,
+                      "parentOid": "1.2.246.562.10.52251087186",
+                      "parentOidPath": "1.2.246.562.10.60465978314/1.2.246.562.10.52251087186/1.2.246.562.10.346830761110/1.2.246.562.10.00000000001",
+                      "toimipistekoodi": "1010503",
+                      "match": false,
+                      "nimi": {
+                        "fi": "Stadin ammatti- ja aikuisopisto, Holkkitien toimipaikka"
+                      },
+                      "kieletUris": [
+                        "oppilaitoksenopetuskieli_1#1"
+                      ],
+                      "kotipaikkaUri": "kunta_091",
+                      "children": [],
+                      "aliOrganisaatioMaara": 0,
+                      "organisaatiotyypit": [
+                        "organisaatiotyyppi_03"
+                      ],
+                      "status": "AKTIIVINEN"
+                    }
+                  ],
+                  "aliOrganisaatioMaara": 14,
+                  "organisaatiotyypit": [
+                    "organisaatiotyyppi_02"
+                  ],
+                  "status": "AKTIIVINEN"
+                }
+              ],
+              "aliOrganisaatioMaara": 621,
+              "organisaatiotyypit": [
+                "organisaatiotyyppi_01",
+                "organisaatiotyyppi_07"
+              ],
+              "status": "AKTIIVINEN"
+            }
+          ]
+        }
+      },
+      {
+        "url": "https://localhost:3000/koodisto-service/rest/json/kausi/koodi?onlyValidKoodis=true&koodistoVersio=",
+        "method": "GET",
+        "status": 200,
+        "headers": {},
+        "body": null,
+        "response": [
+          {
+            "koodiUri": "kausi_0",
+            "resourceUri": "https://virkailija.hahtuvaopintopolku.fi/koodisto-service/rest/codeelement/kausi_11",
+            "version": 1,
+            "versio": 1,
+            "koodisto": {
+              "koodistoUri": "kausi",
+              "organisaatioOid": "1.2.246.562.10.00000000001",
+              "koodistoVersios": [
+                1
+              ]
+            },
+            "koodiArvo": "0",
+            "paivitysPvm": 1427461978048,
+            "voimassaAlkuPvm": "2000-01-01",
+            "voimassaLoppuPvm": null,
+            "tila": "LUONNOS",
+            "metadata": [
+              {
+                "nimi": "kausi_0",
+                "kuvaus": "kausi_0",
+                "lyhytNimi": "kausi_0",
+                "kieli": "fi"
+              },
+              {
+                "nimi": "kausi_0",
+                "kuvaus": "kausi_0",
+                "lyhytNimi": "kausi_0",
+                "kieli": "sv"
+              },
+              {
+                "nimi": "kausi_0",
+                "kuvaus": "kausi_0",
+                "lyhytNimi": "kausi_0",
+                "kieli": "en"
+              }
+            ]
+          },
+          {
+            "koodiUri": "kausi_1",
+            "resourceUri": "https://virkailija.hahtuvaopintopolku.fi/koodisto-service/rest/codeelement/kausi_11",
+            "version": 1,
+            "versio": 1,
+            "koodisto": {
+              "koodistoUri": "kausi",
+              "organisaatioOid": "1.2.246.562.10.00000000001",
+              "koodistoVersios": [
+                1
+              ]
+            },
+            "koodiArvo": "1",
+            "paivitysPvm": 1427461978048,
+            "voimassaAlkuPvm": "2000-01-01",
+            "voimassaLoppuPvm": null,
+            "tila": "LUONNOS",
+            "metadata": [
+              {
+                "nimi": "kausi_1",
+                "kuvaus": "kausi_1",
+                "lyhytNimi": "kausi_1",
+                "kieli": "fi"
+              },
+              {
+                "nimi": "kausi_1",
+                "kuvaus": "kausi_1",
+                "lyhytNimi": "kausi_1",
+                "kieli": "sv"
+              },
+              {
+                "nimi": "kausi_1",
+                "kuvaus": "kausi_1",
+                "lyhytNimi": "kausi_1",
+                "kieli": "en"
+              }
+            ]
+          },
+          {
+            "koodiUri": "kausi_2",
+            "resourceUri": "https://virkailija.hahtuvaopintopolku.fi/koodisto-service/rest/codeelement/kausi_11",
+            "version": 1,
+            "versio": 1,
+            "koodisto": {
+              "koodistoUri": "kausi",
+              "organisaatioOid": "1.2.246.562.10.00000000001",
+              "koodistoVersios": [
+                1
+              ]
+            },
+            "koodiArvo": "2",
+            "paivitysPvm": 1427461978048,
+            "voimassaAlkuPvm": "2000-01-01",
+            "voimassaLoppuPvm": null,
+            "tila": "LUONNOS",
+            "metadata": [
+              {
+                "nimi": "kausi_2",
+                "kuvaus": "kausi_2",
+                "lyhytNimi": "kausi_2",
+                "kieli": "fi"
+              },
+              {
+                "nimi": "kausi_2",
+                "kuvaus": "kausi_2",
+                "lyhytNimi": "kausi_2",
+                "kieli": "sv"
+              },
+              {
+                "nimi": "kausi_2",
+                "kuvaus": "kausi_2",
+                "lyhytNimi": "kausi_2",
+                "kieli": "en"
+              }
+            ]
+          },
+          {
+            "koodiUri": "kausi_3",
+            "resourceUri": "https://virkailija.hahtuvaopintopolku.fi/koodisto-service/rest/codeelement/kausi_11",
+            "version": 1,
+            "versio": 1,
+            "koodisto": {
+              "koodistoUri": "kausi",
+              "organisaatioOid": "1.2.246.562.10.00000000001",
+              "koodistoVersios": [
+                1
+              ]
+            },
+            "koodiArvo": "3",
+            "paivitysPvm": 1427461978048,
+            "voimassaAlkuPvm": "2000-01-01",
+            "voimassaLoppuPvm": null,
+            "tila": "LUONNOS",
+            "metadata": [
+              {
+                "nimi": "kausi_3",
+                "kuvaus": "kausi_3",
+                "lyhytNimi": "kausi_3",
+                "kieli": "fi"
+              },
+              {
+                "nimi": "kausi_3",
+                "kuvaus": "kausi_3",
+                "lyhytNimi": "kausi_3",
+                "kieli": "sv"
+              },
+              {
+                "nimi": "kausi_3",
+                "kuvaus": "kausi_3",
+                "lyhytNimi": "kausi_3",
+                "kieli": "en"
+              }
+            ]
+          },
+          {
+            "koodiUri": "kausi_4",
+            "resourceUri": "https://virkailija.hahtuvaopintopolku.fi/koodisto-service/rest/codeelement/kausi_11",
+            "version": 1,
+            "versio": 1,
+            "koodisto": {
+              "koodistoUri": "kausi",
+              "organisaatioOid": "1.2.246.562.10.00000000001",
+              "koodistoVersios": [
+                1
+              ]
+            },
+            "koodiArvo": "4",
+            "paivitysPvm": 1427461978048,
+            "voimassaAlkuPvm": "2000-01-01",
+            "voimassaLoppuPvm": null,
+            "tila": "LUONNOS",
+            "metadata": [
+              {
+                "nimi": "kausi_4",
+                "kuvaus": "kausi_4",
+                "lyhytNimi": "kausi_4",
+                "kieli": "fi"
+              },
+              {
+                "nimi": "kausi_4",
+                "kuvaus": "kausi_4",
+                "lyhytNimi": "kausi_4",
+                "kieli": "sv"
+              },
+              {
+                "nimi": "kausi_4",
+                "kuvaus": "kausi_4",
+                "lyhytNimi": "kausi_4",
+                "kieli": "en"
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "url": "https://localhost:3000/koodisto-service/rest/json/liitetyypitamm/koodi?onlyValidKoodis=true&koodistoVersio=",
+        "method": "GET",
+        "status": 200,
+        "headers": {},
+        "body": null,
+        "response": [
+          {
+            "koodiUri": "liitetyypitamm_0",
+            "resourceUri": "https://virkailija.hahtuvaopintopolku.fi/koodisto-service/rest/codeelement/liitetyypitamm_11",
+            "version": 1,
+            "versio": 1,
+            "koodisto": {
+              "koodistoUri": "liitetyypitamm",
+              "organisaatioOid": "1.2.246.562.10.00000000001",
+              "koodistoVersios": [
+                1
+              ]
+            },
+            "koodiArvo": "0",
+            "paivitysPvm": 1427461978048,
+            "voimassaAlkuPvm": "2000-01-01",
+            "voimassaLoppuPvm": null,
+            "tila": "LUONNOS",
+            "metadata": [
+              {
+                "nimi": "liitetyypitamm_0",
+                "kuvaus": "liitetyypitamm_0",
+                "lyhytNimi": "liitetyypitamm_0",
+                "kieli": "fi"
+              },
+              {
+                "nimi": "liitetyypitamm_0",
+                "kuvaus": "liitetyypitamm_0",
+                "lyhytNimi": "liitetyypitamm_0",
+                "kieli": "sv"
+              },
+              {
+                "nimi": "liitetyypitamm_0",
+                "kuvaus": "liitetyypitamm_0",
+                "lyhytNimi": "liitetyypitamm_0",
+                "kieli": "en"
+              }
+            ]
+          },
+          {
+            "koodiUri": "liitetyypitamm_1",
+            "resourceUri": "https://virkailija.hahtuvaopintopolku.fi/koodisto-service/rest/codeelement/liitetyypitamm_11",
+            "version": 1,
+            "versio": 1,
+            "koodisto": {
+              "koodistoUri": "liitetyypitamm",
+              "organisaatioOid": "1.2.246.562.10.00000000001",
+              "koodistoVersios": [
+                1
+              ]
+            },
+            "koodiArvo": "1",
+            "paivitysPvm": 1427461978048,
+            "voimassaAlkuPvm": "2000-01-01",
+            "voimassaLoppuPvm": null,
+            "tila": "LUONNOS",
+            "metadata": [
+              {
+                "nimi": "liitetyypitamm_1",
+                "kuvaus": "liitetyypitamm_1",
+                "lyhytNimi": "liitetyypitamm_1",
+                "kieli": "fi"
+              },
+              {
+                "nimi": "liitetyypitamm_1",
+                "kuvaus": "liitetyypitamm_1",
+                "lyhytNimi": "liitetyypitamm_1",
+                "kieli": "sv"
+              },
+              {
+                "nimi": "liitetyypitamm_1",
+                "kuvaus": "liitetyypitamm_1",
+                "lyhytNimi": "liitetyypitamm_1",
+                "kieli": "en"
+              }
+            ]
+          },
+          {
+            "koodiUri": "liitetyypitamm_2",
+            "resourceUri": "https://virkailija.hahtuvaopintopolku.fi/koodisto-service/rest/codeelement/liitetyypitamm_11",
+            "version": 1,
+            "versio": 1,
+            "koodisto": {
+              "koodistoUri": "liitetyypitamm",
+              "organisaatioOid": "1.2.246.562.10.00000000001",
+              "koodistoVersios": [
+                1
+              ]
+            },
+            "koodiArvo": "2",
+            "paivitysPvm": 1427461978048,
+            "voimassaAlkuPvm": "2000-01-01",
+            "voimassaLoppuPvm": null,
+            "tila": "LUONNOS",
+            "metadata": [
+              {
+                "nimi": "liitetyypitamm_2",
+                "kuvaus": "liitetyypitamm_2",
+                "lyhytNimi": "liitetyypitamm_2",
+                "kieli": "fi"
+              },
+              {
+                "nimi": "liitetyypitamm_2",
+                "kuvaus": "liitetyypitamm_2",
+                "lyhytNimi": "liitetyypitamm_2",
+                "kieli": "sv"
+              },
+              {
+                "nimi": "liitetyypitamm_2",
+                "kuvaus": "liitetyypitamm_2",
+                "lyhytNimi": "liitetyypitamm_2",
+                "kieli": "en"
+              }
+            ]
+          },
+          {
+            "koodiUri": "liitetyypitamm_3",
+            "resourceUri": "https://virkailija.hahtuvaopintopolku.fi/koodisto-service/rest/codeelement/liitetyypitamm_11",
+            "version": 1,
+            "versio": 1,
+            "koodisto": {
+              "koodistoUri": "liitetyypitamm",
+              "organisaatioOid": "1.2.246.562.10.00000000001",
+              "koodistoVersios": [
+                1
+              ]
+            },
+            "koodiArvo": "3",
+            "paivitysPvm": 1427461978048,
+            "voimassaAlkuPvm": "2000-01-01",
+            "voimassaLoppuPvm": null,
+            "tila": "LUONNOS",
+            "metadata": [
+              {
+                "nimi": "liitetyypitamm_3",
+                "kuvaus": "liitetyypitamm_3",
+                "lyhytNimi": "liitetyypitamm_3",
+                "kieli": "fi"
+              },
+              {
+                "nimi": "liitetyypitamm_3",
+                "kuvaus": "liitetyypitamm_3",
+                "lyhytNimi": "liitetyypitamm_3",
+                "kieli": "sv"
+              },
+              {
+                "nimi": "liitetyypitamm_3",
+                "kuvaus": "liitetyypitamm_3",
+                "lyhytNimi": "liitetyypitamm_3",
+                "kieli": "en"
+              }
+            ]
+          },
+          {
+            "koodiUri": "liitetyypitamm_4",
+            "resourceUri": "https://virkailija.hahtuvaopintopolku.fi/koodisto-service/rest/codeelement/liitetyypitamm_11",
+            "version": 1,
+            "versio": 1,
+            "koodisto": {
+              "koodistoUri": "liitetyypitamm",
+              "organisaatioOid": "1.2.246.562.10.00000000001",
+              "koodistoVersios": [
+                1
+              ]
+            },
+            "koodiArvo": "4",
+            "paivitysPvm": 1427461978048,
+            "voimassaAlkuPvm": "2000-01-01",
+            "voimassaLoppuPvm": null,
+            "tila": "LUONNOS",
+            "metadata": [
+              {
+                "nimi": "liitetyypitamm_4",
+                "kuvaus": "liitetyypitamm_4",
+                "lyhytNimi": "liitetyypitamm_4",
+                "kieli": "fi"
+              },
+              {
+                "nimi": "liitetyypitamm_4",
+                "kuvaus": "liitetyypitamm_4",
+                "lyhytNimi": "liitetyypitamm_4",
+                "kieli": "sv"
+              },
+              {
+                "nimi": "liitetyypitamm_4",
+                "kuvaus": "liitetyypitamm_4",
+                "lyhytNimi": "liitetyypitamm_4",
+                "kieli": "en"
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "url": "https://localhost:3000/organisaatio-service/rest/organisaatio/v4/findbyoids",
+        "method": "POST",
+        "status": 200,
+        "headers": {},
+        "body": [
+          "1.2.246.562.10.52251087186"
+        ],
+        "response": [
+          {
+            "metadata": {
+              "nimi": {},
+              "hakutoimistoEctsNimi": {},
+              "hakutoimistoEctsEmail": {},
+              "hakutoimistoEctsPuhelin": {},
+              "hakutoimistoEctsTehtavanimike": {},
+              "yhteystiedot": [
+                {
+                  "kieli": "kieli_fi#1",
+                  "www": "http://www.stadinammattiopisto.fi",
+                  "yhteystietoOid": "14812023190550.9836378324069386",
+                  "id": "3861227"
+                },
+                {
+                  "kieli": "kieli_fi#1",
+                  "numero": "09 310 89318",
+                  "tyyppi": "puhelin",
+                  "yhteystietoOid": "1.2.246.562.5.62477770688",
+                  "id": "3861228"
+                },
+                {
+                  "kieli": "kieli_fi#1",
+                  "yhteystietoOid": "14303205263410.7259206293670477",
+                  "id": "3861229",
+                  "email": "hakutoimisto@edu.hel.fi"
+                },
+                {
+                  "osoiteTyyppi": "posti",
+                  "kieli": "kieli_fi#1",
+                  "postinumeroUri": "posti_00099",
+                  "yhteystietoOid": "1.2.246.562.5.20277448420",
+                  "id": "3861230",
+                  "postitoimipaikka": "HELSINGIN KAUPUNKI",
+                  "osoite": "PL 55306"
+                },
+                {
+                  "osoiteTyyppi": "kaynti",
+                  "kieli": "kieli_fi#1",
+                  "postinumeroUri": "posti_00550",
+                  "yhteystietoOid": "1.2.246.562.5.26047810076",
+                  "id": "3861231",
+                  "postitoimipaikka": "HELSINKI",
+                  "osoite": "Hattulantie 2, 1. krs"
+                }
+              ],
+              "hakutoimistonNimi": {
+                "kieli_fi#1": "Stadin ammatti- ja aikuisopiston hakutoimisto"
+              },
+              "luontiPvm": 1376895579333,
+              "muokkausPvm": 1376859600000,
+              "data": {
+                "KANSAINVALISET_KOULUTUSOHJELMAT": {},
+                "YLEISKUVAUS": {
+                  "kieli_fi#1": "<p>Stadin ammatti- ja aikuisopisto järjestää ammatillista peruskoulutusta, ammatillista täydennyskoulutusta, oppisopimuskoulutusta ja nivelvaiheen koulutusta Helsingin kaupungin alueella 15 eri toimipaikassa. Meillä Suomen suurimmassa ammattiopistossa opiskelee noin 17 000 nuorta ja aikuista yli 50 eri ammattiin.</p> <p>Kun suoritat ammatillisen koulutuksen, saat laaja-alaiset valmiudet toimia oman alasi erilaisissa ja vaihtelevissa työtehtävissä sekä kehittää ammattitaitoasi läpi elämän. Lisäksi ammatillinen perustutkinto antaa sinulle yleisen jatko-opintokelpoisuuden ammattikorkeakouluihin ja yliopistoihin.</p> <p>Stadin ammatti- ja aikuisopistossa voit opiskella joustavasti eri oppimisratkaisuin. Opintojen suunnittelussa huomioidaan aina opiskelijan aiempi osaaminen esimerkiksi yhdistämällä oppilaitosmuotoista opiskelua ja oppisopimuskoulutusta. Lisäksi ammatilliseen perustutkintoon johtavassa koulutuksessa on mahdollista suorittaa lukio-opintoja sekä hakea ohjattuun urheiluvalmennukseen.</p> <p>Stadin ammatti- ja aikuisopiston Brygga tarjoaa nivelvaiheen koulutusta ja palveluja. Siihen kuuluvat ammatilliseen koulutukseen valmentava koulutus (VALMA), osa kaupungin perusopetuksen lisäopetuksesta (kymppiluokat), avoimet opinnot ja nuorten työpajatoiminta. Stadin osaamiskeskus puolestaan yhdistää kuntoutuksen, koulutuksen ja työllistymisen palvelut helsinkiläisille aikuisille maahanmuuttajille.</p> <p>Lisätietoa Stadin ammatti- ja aikuisopiston koulutustarjonnasta löytyy nettisivuiltamme www.stadinammattiopisto.fi</p> <p> </p>"
+                },
+                "KIELIOPINNOT": {
+                  "kieli_fi#1": "<p>Kaikkiin perustutkintoihin kuuluu vähintään 2 osaamispistettä englantia (A-kieli) ja 1 osaamispistettä ruotsia. Lisäksi joissain toimipaikoissa voit valinnaisissa opinnoissa opiskella ylimääräisiä kieliä.</p>"
+                },
+                "TERVEYDENHUOLTOPALVELUT": {
+                  "kieli_fi#1": "<p>Stadin ammatti- ja aikuisopistossa on sekä terveydenhoitajia että lääkäreitä opiskelijoita varten. Ensimmäisenä opiskeluvuonna terveydenhoitaja kutsuu sinut terveystarkastukseen, jossa selvitetään opiskelun tai ammatissa toimimisen kannalta tärkeät seikat. Lääkärin vastaanotolle haetaan terveydenhoitajan kautta.</p> <p>Oppilaitoksessa ei ole hammashoitolaa. Opiskelijat käyttävät oman asuinalueensa terveysaseman palveluita.</p>"
+                },
+                "TEHTAVANIMIKE": {},
+                "SAHKOPOSTIOSOITE": {},
+                "RAHOITUS": {},
+                "AIEMMIN_HANKITTU_OSAAMINEN": {
+                  "kieli_fi#1": "<p>Osaamisen tunnistaminen ja tunnustaminen</p> <p>Ennalta hankittu osaaminen, kuten aiemmin suoritetut opinnot tai työkokemus, voidaan sisällyttää osaksi ammatillista tutkintoasi, mikäli osaamisesi on opetussuunnitelman mukaista. Tällöin opiskeluaikasi mahdollisesti lyhenee ja valmistut aikaisemmin.</p> <p>Osaamisen tunnistamista ja tunnustamista haetaan lomakkeella, jonka saat opettajaltasi tai opinto-ohjaajaltasi. He myös ohjaavat sen täyttämisessä.</p> <p>Opinnoista vapauttaminen</p> <p>Ruotsin kielestä voit anoa vapautusta, jos et ole opiskellut ruotsia aiemmin. Vapautusta haetaan lomakkeella, jonka saat opettajaltasi tai opinto-ohjaajaltasi. Ruotsin sijasta opiskelet jonkin muun sovitun opinnon.</p>"
+                },
+                "sosiaalinenmedia_7#1": {},
+                "sosiaalinenmedia_5#1": {
+                  "kieli_fi#1": "http://www.pinterest.com/StadinAO"
+                },
+                "sosiaalinenmedia_6#1": {
+                  "kieli_fi#1": "http://www.instagram.com/stadinao"
+                },
+                "OPISKELIJALIIKKUVUUS": {
+                  "kieli_fi#1": "<p>Kansainvälisyys on osa Stadin ammatti- ja aikuisopiston arkea. Tarjoamme opiskelijalle mahdollisuuden lisätä kansainvälisyysosaamista opintojen aikana.  Kotikansainvälistymistä edistetään tarjoamalla kieliin ja kulttuuriin liittyviä oppimistilanteita, virtuaaliliikkuvuutta ja taitaja-toimintaa.</p> <p>Stadin ammatti- ja aikuisopistosta voi lähteä työssäoppimisjaksolle ulkomaille. Kansainväliset vaihdot täydentävät opiskelijoiden työelämävalmiuksia ammatillisen osaamisen, kielitaidon ja kulttuurien tuntemisen kautta sekä tukevat opiskelijan itsenäisyyttä, avoimuutta ja rohkeutta.</p> <p>Ulkomaanjaksoja voi suorittaa mm. Pohjoismaissa, Iso-Britanniassa, Hollannissa, Saksassa, Ranskassa, Espanjassa, Irlannissa, Virossa, Sloveniassa, Itävallassa, Venäjällä ja Kiinassa. Ulkomaanjaksolle lähdetään toisena tai kolmantena opintovuotena.</p>"
+                },
+                "VAKUUTUKSET": {
+                  "kieli_fi#1": "<p>Kaikki opiskelijat on vakuutettu opiskelun aikana sattuneiden tapaturmien varalta. Tapaturma korvataan, jos se on sattunut oppitunnilla, työssäoppimisen aikana, opintokäynneillä tai koulumatkalla. Koulumatkalla vakuutus on voimassa vain, mikäli matka on tapahtunut viivytyksettä ja suorinta, tavanomaista tietä.</p> <p>Vakuutus on voimassa myös ulkomaille suuntautuvien opintomatkojen ja työssäoppimisjaksojen aikana. Oppilaitoksen vakuutukset eivät kuitenkaan ole voimassa, jos olet sairauslomalla. Pidempien sairauslomien ajaksi opinnot yleensä keskeytetään väliaikaisesti.</p>"
+                },
+                "OPISKELIJA_JARJESTOT": {
+                  "kieli_fi#1": "<p>Opiskelijakuntatoiminta ja opiskelijayhdistys STAO ry</p> <p>Jokainen opiskelija kuuluu oman toimipaikkansa opiskelijakuntaan. Kustakin toimipaikasta valitaan lukuvuoden alussa opiskelijakunnan hallitus, jonka tehtävänä on tuoda opiskelijoiden ääni kuuluviin omassa toimipaikassa.</p> <p>STAO ry (Stadin ammattiin opiskelevat) on Stadin ammattiopiston opiskelijayhdistys, johon jokainen opiskelija voi liittyä. Yhdistys edistää opiskelijoiden toimintaa, osallistumista ja hyvinvointia koko oppilaitoksessa.</p>"
+                },
+                "VALINTAMENETTELY": {
+                  "kieli_fi#1": "<p>Kevään yhteishaussa hakevat peruskoulunsa päättävät, ylioppilaat ja muut ilman toisen asteen ammatillista tutkintoa olevat (valintamenettelyssä noudatetaan Oph:n antamia ohjeita). Kaikki muut hakevat jatkuvassa haussa (oppilaitoksen oma valintamenettely, hakija saa valintapäätöksen kolmen viikon kuluessa hakemisesta).</p>"
+                },
+                "sosiaalinenmedia_3#1": {},
+                "sosiaalinenmedia_4#1": {
+                  "kieli_fi#1": "http://www.twitter.com/stadinao"
+                },
+                "sosiaalinenmedia_1#1": {
+                  "kieli_fi#1": "http://www.facebook.com/stadinammattiopisto"
+                },
+                "VASTUUHENKILOT": {},
+                "KUSTANNUKSET": {
+                  "kieli_fi#1": "<p>Opintojensa aikana opiskelijat hankkivat itse esimerkiksi oppikirjoja, kansioita, muistiinpanovälineitä sekä henkilökohtaisia työvälineitä. Osassa tutkinnoista työvaatteet ja -kengät saa oppilaitoksen puolesta.</p>"
+                },
+                "OPPIMISYMPARISTO": {
+                  "kieli_fi#1": "<p>Stadin ammatti- ja aikuisopiston kaikki toimipaikat sijaitsevat Helsingin kaupungin alueella. Toimipaikkojen oppimisympäristöjä uudistetaan monimuotoisiksi ja viihtyisiksi, jolloin ne tukevat opiskelijakeskeistä ja työelämälähtöistä pedagogiikkaa. Opiskelijoiden ja opettajien käytettävissä on mm. kattava, digitaalisuuden hyödyntämistä tukeva wifi.</p>"
+                },
+                "sosiaalinenmedia_2#1": {},
+                "PUHELINNUMERO": {},
+                "NIMI": {},
+                "OPISKELIJALIIKUNTA": {},
+                "VUOSIKELLO": {},
+                "OPISKELIJARUOKAILU": {
+                  "kieli_fi#1": "<p>Stadin ammatti- ja aikuisopistossa on kaikissa toimipaikoissa opiskelijaravintola ja kahvila. Opiskelijoille on koulupäivinä tarjolla yksi maksuton lounasateria. Tarjolla on joka päivä myös kasvislounasvaihtoehto.</p>"
+                },
+                "VAPAA_AIKA": {},
+                "ESTEETOMYYS": {
+                  "kieli_fi#1": "<p>Stadin ammatti- ja aikuisopisto on kaikille yhteinen oppilaitos, jossa jokainen pystyy ominaisuuksistaan riippumatta toimimaan yhdenvertaisesti muiden kanssa, jolloin opiskeluympäristössä ei pitäisi olla liikkumiseen, ryhmään kuulumiseen tai oppimiseen liittyviä esteitä.</p> <p><em> </em></p> <p><em>Opiskeluhuolto</em></p> <p>Opiskeluhuollon tavoitteena on edistää oppimistasi, terveyttäsi ja hyvinvointiasi opiskelun aikana. Opiskelijahuolto huolehtii myös oppilaitosyhteisön hyvinvoinnista sekä opiskeluympäristön terveellisyydestä ja turvallisuudesta. Opiskeluhuoltoa toteutetaan sekä yhteisöllisenä että yksilökohtaisena opiskeluhuoltona.</p> <p><em> </em></p> <p><em>Yhteisöllinen opiskeluhuolto</em></p> <p>Yhteisöllinen opiskeluhuolto edistää opiskelijoiden osallisuutta, oppimista, hyvinvointia ja terveyttä. Lisäksi se seuraa ja kehittää opiskeluyhteisön hyvinvointia sekä opiskeluympäristön terveellisyyttä, turvallisuutta ja esteettömyyttä. Toimipaikan hyvinvointiryhmä vastaa opiskeluhuollon suunnittelusta, kehittämisestä ja arvioinnista yhteisöllisen opiskeluhuollon osa-alueet huomioon ottaen. Ryhmää johtaa apulaisrehtori tai koulutuspäällikkö. Opetushenkilöstön lisäksi ryhmään kuuluu erityisopettaja, opinto-ohjaaja, kuraattori, psykologi, terveydenhoitaja ja opiskelijajäseniä. Ryhmään voi kuulua myös huoltajien edustaja.</p> <p><em> </em></p> <p><em>Yksilökohtainen opiskelijahuolto</em></p> <p>Yksilökohtaisella opiskelijahuollolla tarkoitetaan opiskelijan käytössä olevia palveluja, joita ovat • opiskeluterveydenhuolto • opiskeluhuollon psykologi- ja kuraattoripalvelut • yksittäistä opiskelijaa koskeva monialainen opiskeluhuolto, jota toteutetaan tapauskohtaisesti koottavassa monialaisessa asiantuntijaryhmässä. Yksilökohtaista opiskeluhuoltoa tehdään yhteistyössä opiskelijan kanssa ja hänen suostumuksellaan.</p> <p><em> </em></p> <p><em>Kun tarvitset tukea opinnoissasi</em></p> <p>Opintojesi alussa kanssasi tehdään henkilökohtainen osaamisen kehittämisen suunnitelma (HOKS). Suunnitelmaan kirjataan aiemmin hankittu ja osoitettu osaaminen, tarvittava ammattitaidon ja osaamisen hankkiminen, osaamisen osoittaminen sekä ohjaus- ja tukitoimet. Jos tarvitset erityistä tukea, suunnitelmassa sovitaan sinulle tarjottavan erityisen tuen sisällöstä ja erityisen tuen tarpeen mukaisista toimenpiteistä osaamisen hankkimisen aikana. Erityistä tukea voi saada kaikissa ammatilliseen perustutkintoon johtavissa koulutuksissa.</p>"
+                },
+                "TIETOA_ASUMISESTA": {
+                  "kieli_fi#1": "<p>Stadin ammatti- ja aikuisopistolla ei ole asuntolaa. Tutkintoon johtavassa koulutuksessa oleva opiskelija voi hakea opiskelija-asuntoa esim. HOAS:lta.</p>"
+                },
+                "TYOHARJOITTELU": {
+                  "kieli_fi#1": "<p>Kaikkiin perustutkintoihin kuuluu vähintään 30 osaamispistettä, n. kuusi kuukautta, työssäoppimista. Työssäoppiminen suoritetaan pääasiassa työpaikoilla ja työelämälähtöisissä oppimisympäristöissä.</p>"
+                }
+              }
+            },
+            "oid": "1.2.246.562.10.52251087186",
+            "nimi": {
+              "fi": "Stadin ammatti- ja aikuisopisto",
+              "sv": "Stadin ammatti- ja aikuisopisto",
+              "en": "Stadin ammatti- ja aikuisopisto"
+            },
+            "alkuPvm": "2013-01-01",
+            "oppilaitosKoodi": "10105",
+            "ryhmatyypit": [],
+            "kayttoryhmat": [],
+            "piilotettu": false,
+            "parentOid": "1.2.246.562.10.346830761110",
+            "postiosoite": {
+              "postinumeroUri": "posti_00099",
+              "osoiteTyyppi": "posti",
+              "yhteystietoOid": "1.2.246.562.5.69596457015",
+              "postitoimipaikka": "HELSINGIN KAUPUNKI",
+              "osoite": "PL 55308"
+            },
+            "kuvaus2": {},
+            "tyypit": [
+              "organisaatiotyyppi_02"
+            ],
+            "yhteystietoArvos": [
+              {
+                "YhteystietoArvo.arvoText": "stadiprimus@edu.hel.fi",
+                "YhteystietojenTyyppi.nimi.fi": "KOSKI-palvelun omien tietojen virheilmoituksen sähköpostiosoite",
+                "YhteystietojenTyyppi.nimi.sv": "E-postadress för felanmälan i egna uppgifter i KOSKI-tjänsten",
+                "YhteystietoElementti.tyyppi": "Email",
+                "YhteystietojenTyyppi.oid": "1.2.246.562.5.79385887983",
+                "YhteystietoElementti.oid": "1.2.246.562.5.57850489428",
+                "YhteystietoElementti.nimi": "Sähköpostiosoite",
+                "YhteystietoElementti.nimiSv": "Epostadress",
+                "YhteystietoElementti.pakollinen": "false",
+                "YhteystietojenTyyppi.nimi.en": "KOSKI-palvelun omien tietojen virheilmoituksen sähköpostiosoite",
+                "YhteystietoElementti.kaytossa": "true",
+                "YhteystietoArvo.kieli": "kieli_fi#1"
+              }
+            ],
+            "yhteystiedot": [
+              {
+                "osoiteTyyppi": "posti",
+                "kieli": "kieli_fi#1",
+                "postinumeroUri": "posti_00099",
+                "yhteystietoOid": "1.2.246.562.5.69596457015",
+                "id": "3861240",
+                "postitoimipaikka": "HELSINGIN KAUPUNKI",
+                "osoite": "PL 55308"
+              },
+              {
+                "kieli": "kieli_fi#1",
+                "yhteystietoOid": "14931031965550.42925150233306597",
+                "id": "3861238",
+                "email": "hakutoimisto@edu.hel.fi"
+              },
+              {
+                "osoiteTyyppi": "kaynti",
+                "kieli": "kieli_fi#1",
+                "postinumeroUri": "posti_00550",
+                "yhteystietoOid": "1.2.246.562.5.32847643825",
+                "id": "3861237",
+                "postitoimipaikka": "HELSINKI",
+                "osoite": "Hattulantie 2"
+              },
+              {
+                "kieli": "kieli_fi#1",
+                "numero": "09 310 8415",
+                "tyyppi": "puhelin",
+                "yhteystietoOid": "1.2.246.562.5.90059839549",
+                "id": "3861236"
+              },
+              {
+                "kieli": "kieli_fi#1",
+                "www": "http://www.stadinammattiopisto.fi",
+                "yhteystietoOid": "1.2.246.562.5.38465214716",
+                "id": "3861239"
+              }
+            ],
+            "nimet": [
+              {
+                "nimi": {
+                  "fi": "Stadin ammattiopisto"
+                },
+                "alkuPvm": "2013-01-01",
+                "version": 1
+              },
+              {
+                "nimi": {
+                  "fi": "Stadin ammatti- ja aikuisopisto",
+                  "sv": "Stadin ammatti- ja aikuisopisto",
+                  "en": "Stadin ammatti- ja aikuisopisto"
+                },
+                "alkuPvm": "2018-12-31",
+                "version": 0
+              }
+            ],
+            "vuosiluokat": [],
+            "parentOidPath": "|1.2.246.562.10.00000000001|1.2.246.562.10.346830761110|",
+            "toimipistekoodi": "10105",
+            "kotipaikkaUri": "kunta_091",
+            "kieletUris": [
+              "oppilaitoksenopetuskieli_1#1"
+            ],
+            "maaUri": "maatjavaltiot1_fin",
+            "oppilaitosTyyppiUri": "oppilaitostyyppi_21#1",
+            "muutKotipaikatUris": [],
+            "kayntiosoite": {
+              "postinumeroUri": "posti_00550",
+              "osoiteTyyppi": "kaynti",
+              "yhteystietoOid": "1.2.246.562.5.32847643825",
+              "postitoimipaikka": "HELSINKI",
+              "osoite": "Hattulantie 2"
+            },
+            "lisatiedot": [],
+            "muutOppilaitosTyyppiUris": [],
+            "version": 89,
+            "status": "AKTIIVINEN"
+          }
+        ]
+      },
+      {
+        "url": "https://localhost:3000/lomake-editori/api/forms",
+        "method": "GET",
+        "status": 200,
+        "headers": {},
+        "body": null,
+        "response": {
+          "forms": [
+            {
+              "name": {
+                "fi": "Lomake 1"
+              },
+              "key": "lomake_1"
+            }
+          ]
+        }
+      },
+      {
+        "url": "https://localhost:3000/kouta-backend/valintaperuste/list?organisaatioOid=1.2.246.562.10.52251087186&hakuOid=4.1.1.1.1.1",
+        "method": "GET",
+        "status": 200,
+        "headers": {},
+        "body": null,
+        "response": [
+          {
+            "koulutustyyppi": "amm",
+            "id": "649adb37-cd4d-4846-91a9-84b58b90f928",
+            "tila": "julkaistu",
+            "hakutapaKoodiUri": "hakutapa_0#1",
+            "kohdejoukkoKoodiUri": "haunkohdejoukko_0#1",
+            "nimi": {
+              "fi": "Valintaperusteen nimi"
+            },
+            "julkinen": false,
+            "sorakuvausId": "1",
+            "metadata": {
+              "koulutustyyppi": "amm",
+              "valintatavat": [
+                {
+                  "valintatapaKoodiUri": "valintatapajono_0#1",
+                  "kuvaus": {},
+                  "nimi": {
+                    "fi": "Valintatavan nimi"
+                  },
+                  "sisalto": [
+                    {
+                      "tyyppi": "teksti",
+                      "data": {
+                        "fi": "<p>Tekstia</p>"
+                      }
+                    },
+                    {
+                      "tyyppi": "taulukko",
+                      "data": {
+                        "nimi": {},
+                        "rows": [
+                          {
+                            "index": 0,
+                            "isHeader": false,
+                            "columns": [
+                              {
+                                "index": 0,
+                                "text": {
+                                  "fi": "Solu"
+                                }
+                              }
+                            ]
+                          }
+                        ]
+                      }
+                    }
+                  ],
+                  "kaytaMuuntotaulukkoa": false,
+                  "kynnysehto": {
+                    "fi": "Kynnysehto"
+                  },
+                  "enimmaispisteet": 100,
+                  "vahimmaispisteet": 10
+                }
+              ],
+              "kielitaitovaatimukset": [],
+              "kuvaus": {
+                "fi": "<p>Loppukuvaus</p>"
+              },
+              "valintakokeidenYleiskuvaus": {
+                "fi": "<p>Valintakokeiden kuvaus - fi</p>"
+              }
+            },
+            "organisaatioOid": "1.2.246.562.10.594252633210",
+            "muokkaaja": "1.2.246.562.24.62301161440",
+            "kielivalinta": [
+              "fi",
+              "sv"
+            ],
+            "modified": "2019-04-03T13:56",
+            "valintakokeet": [
+              {
+                "nimi": {
+                  "fi": "Kokeen nimi - fi"
+                },
+                "metadata": {
+                  "tietoja": {
+                    "fi": "<p>Tietoa kokeesta - fi</p>"
+                  },
+                  "liittyyEnnakkovalmistautumista": true,
+                  "ohjeetEnnakkovalmistautumiseen": {
+                    "fi": "<p>Ohjeet ennakkovalmistautumiseen - fi</p>"
+                  },
+                  "erityisjarjestelytMahdollisia": true,
+                  "ohjeetErityisjarjestelyihin": {
+                    "fi": "<p>Ohjeet erityisjärjestelyihin - fi</p>"
+                  }
+                },
+                "tyyppiKoodiUri": "tyyppi_1#1",
+                "tilaisuudet": [
+                  {
+                    "osoite": {
+                      "osoite": {
+                        "fi": "fi osoite"
+                      },
+                      "postinumeroKoodiUri": "posti_00350#1"
+                    },
+                    "aika": {
+                      "alkaa": "2019-04-16T08:44",
+                      "paattyy": "2019-04-18T08:44"
+                    },
+                    "lisatietoja": {
+                      "fi": "fi lisatietoja"
+                    },
+                    "jarjestamispaikka": {
+                      "fi": "Jarjestamispaikka - fi"
+                    }
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "url": "https://localhost:3000/koodisto-service/rest/json/valintakokeentyyppi/koodi?onlyValidKoodis=true&koodistoVersio=",
+        "method": "GET",
+        "status": 200,
+        "headers": {},
+        "body": null,
+        "response": [
+          {
+            "koodiUri": "valintakokeentyyppi_0",
+            "resourceUri": "https://virkailija.hahtuvaopintopolku.fi/koodisto-service/rest/codeelement/valintakokeentyyppi_11",
+            "version": 1,
+            "versio": 1,
+            "koodisto": {
+              "koodistoUri": "valintakokeentyyppi",
+              "organisaatioOid": "1.2.246.562.10.00000000001",
+              "koodistoVersios": [
+                1
+              ]
+            },
+            "koodiArvo": "0",
+            "paivitysPvm": 1427461978048,
+            "voimassaAlkuPvm": "2000-01-01",
+            "voimassaLoppuPvm": null,
+            "tila": "LUONNOS",
+            "metadata": [
+              {
+                "nimi": "valintakokeentyyppi_0",
+                "kuvaus": "valintakokeentyyppi_0",
+                "lyhytNimi": "valintakokeentyyppi_0",
+                "kieli": "fi"
+              },
+              {
+                "nimi": "valintakokeentyyppi_0",
+                "kuvaus": "valintakokeentyyppi_0",
+                "lyhytNimi": "valintakokeentyyppi_0",
+                "kieli": "sv"
+              },
+              {
+                "nimi": "valintakokeentyyppi_0",
+                "kuvaus": "valintakokeentyyppi_0",
+                "lyhytNimi": "valintakokeentyyppi_0",
+                "kieli": "en"
+              }
+            ]
+          },
+          {
+            "koodiUri": "valintakokeentyyppi_1",
+            "resourceUri": "https://virkailija.hahtuvaopintopolku.fi/koodisto-service/rest/codeelement/valintakokeentyyppi_11",
+            "version": 1,
+            "versio": 1,
+            "koodisto": {
+              "koodistoUri": "valintakokeentyyppi",
+              "organisaatioOid": "1.2.246.562.10.00000000001",
+              "koodistoVersios": [
+                1
+              ]
+            },
+            "koodiArvo": "1",
+            "paivitysPvm": 1427461978048,
+            "voimassaAlkuPvm": "2000-01-01",
+            "voimassaLoppuPvm": null,
+            "tila": "LUONNOS",
+            "metadata": [
+              {
+                "nimi": "valintakokeentyyppi_1",
+                "kuvaus": "valintakokeentyyppi_1",
+                "lyhytNimi": "valintakokeentyyppi_1",
+                "kieli": "fi"
+              },
+              {
+                "nimi": "valintakokeentyyppi_1",
+                "kuvaus": "valintakokeentyyppi_1",
+                "lyhytNimi": "valintakokeentyyppi_1",
+                "kieli": "sv"
+              },
+              {
+                "nimi": "valintakokeentyyppi_1",
+                "kuvaus": "valintakokeentyyppi_1",
+                "lyhytNimi": "valintakokeentyyppi_1",
+                "kieli": "en"
+              }
+            ]
+          },
+          {
+            "koodiUri": "valintakokeentyyppi_2",
+            "resourceUri": "https://virkailija.hahtuvaopintopolku.fi/koodisto-service/rest/codeelement/valintakokeentyyppi_11",
+            "version": 1,
+            "versio": 1,
+            "koodisto": {
+              "koodistoUri": "valintakokeentyyppi",
+              "organisaatioOid": "1.2.246.562.10.00000000001",
+              "koodistoVersios": [
+                1
+              ]
+            },
+            "koodiArvo": "2",
+            "paivitysPvm": 1427461978048,
+            "voimassaAlkuPvm": "2000-01-01",
+            "voimassaLoppuPvm": null,
+            "tila": "LUONNOS",
+            "metadata": [
+              {
+                "nimi": "valintakokeentyyppi_2",
+                "kuvaus": "valintakokeentyyppi_2",
+                "lyhytNimi": "valintakokeentyyppi_2",
+                "kieli": "fi"
+              },
+              {
+                "nimi": "valintakokeentyyppi_2",
+                "kuvaus": "valintakokeentyyppi_2",
+                "lyhytNimi": "valintakokeentyyppi_2",
+                "kieli": "sv"
+              },
+              {
+                "nimi": "valintakokeentyyppi_2",
+                "kuvaus": "valintakokeentyyppi_2",
+                "lyhytNimi": "valintakokeentyyppi_2",
+                "kieli": "en"
+              }
+            ]
+          },
+          {
+            "koodiUri": "valintakokeentyyppi_3",
+            "resourceUri": "https://virkailija.hahtuvaopintopolku.fi/koodisto-service/rest/codeelement/valintakokeentyyppi_11",
+            "version": 1,
+            "versio": 1,
+            "koodisto": {
+              "koodistoUri": "valintakokeentyyppi",
+              "organisaatioOid": "1.2.246.562.10.00000000001",
+              "koodistoVersios": [
+                1
+              ]
+            },
+            "koodiArvo": "3",
+            "paivitysPvm": 1427461978048,
+            "voimassaAlkuPvm": "2000-01-01",
+            "voimassaLoppuPvm": null,
+            "tila": "LUONNOS",
+            "metadata": [
+              {
+                "nimi": "valintakokeentyyppi_3",
+                "kuvaus": "valintakokeentyyppi_3",
+                "lyhytNimi": "valintakokeentyyppi_3",
+                "kieli": "fi"
+              },
+              {
+                "nimi": "valintakokeentyyppi_3",
+                "kuvaus": "valintakokeentyyppi_3",
+                "lyhytNimi": "valintakokeentyyppi_3",
+                "kieli": "sv"
+              },
+              {
+                "nimi": "valintakokeentyyppi_3",
+                "kuvaus": "valintakokeentyyppi_3",
+                "lyhytNimi": "valintakokeentyyppi_3",
+                "kieli": "en"
+              }
+            ]
+          },
+          {
+            "koodiUri": "valintakokeentyyppi_4",
+            "resourceUri": "https://virkailija.hahtuvaopintopolku.fi/koodisto-service/rest/codeelement/valintakokeentyyppi_11",
+            "version": 1,
+            "versio": 1,
+            "koodisto": {
+              "koodistoUri": "valintakokeentyyppi",
+              "organisaatioOid": "1.2.246.562.10.00000000001",
+              "koodistoVersios": [
+                1
+              ]
+            },
+            "koodiArvo": "4",
+            "paivitysPvm": 1427461978048,
+            "voimassaAlkuPvm": "2000-01-01",
+            "voimassaLoppuPvm": null,
+            "tila": "LUONNOS",
+            "metadata": [
+              {
+                "nimi": "valintakokeentyyppi_4",
+                "kuvaus": "valintakokeentyyppi_4",
+                "lyhytNimi": "valintakokeentyyppi_4",
+                "kieli": "fi"
+              },
+              {
+                "nimi": "valintakokeentyyppi_4",
+                "kuvaus": "valintakokeentyyppi_4",
+                "lyhytNimi": "valintakokeentyyppi_4",
+                "kieli": "sv"
+              },
+              {
+                "nimi": "valintakokeentyyppi_4",
+                "kuvaus": "valintakokeentyyppi_4",
+                "lyhytNimi": "valintakokeentyyppi_4",
+                "kieli": "en"
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "url": "https://localhost:3000/koodisto-service/rest/codeelement/posti_0/2",
+        "method": "GET",
+        "status": 200,
+        "headers": {},
+        "body": null,
+        "response": {
+          "koodiUri": "posti_0",
+          "resourceUri": "https://virkailija.hahtuvaopintopolku.fi/koodisto-service/rest/codeelement/posti_0/2",
+          "version": 2,
+          "versio": 2,
+          "koodisto": {
+            "koodistoUri": "posti",
+            "organisaatioOid": "1.2.246.562.10.00000000001",
+            "koodistoVersios": [
+              2
+            ]
+          },
+          "koodiArvo": "0",
+          "paivitysPvm": 1427461978048,
+          "voimassaAlkuPvm": "2000-01-01",
+          "voimassaLoppuPvm": null,
+          "tila": "LUONNOS",
+          "metadata": [
+            {
+              "nimi": "posti_0",
+              "kuvaus": "posti_0",
+              "lyhytNimi": "posti_0",
+              "kieli": "fi"
+            },
+            {
+              "nimi": "posti_0",
+              "kuvaus": "posti_0",
+              "lyhytNimi": "posti_0",
+              "kieli": "sv"
+            },
+            {
+              "nimi": "posti_0",
+              "kuvaus": "posti_0",
+              "lyhytNimi": "posti_0",
+              "kieli": "en"
+            }
+          ]
+        }
+      },
+      {
+        "url": "https://localhost:3000/kouta-backend/toteutus/2.1.1.1.1.1",
+        "method": "GET",
+        "status": 200,
+        "headers": {},
+        "body": null,
+        "response": {
+          "oid": "2.1.1.1.1.1",
+          "koulutusOid": "3.1.1.1.1",
+          "tila": "julkaistu",
+          "tarjoajat": [
+            "1.2.3.4.5.6",
+            "9.8.7.6.5.4"
+          ],
+          "nimi": {
+            "fi": "Koulutuskeskus Salpaus, jatkuva haku, eläintenhoitaja"
+          },
+          "metadata": {
+            "kuvaus": {},
+            "opetus": {
+              "koulutuksenAlkamispaivamaara": "2019-08-23T00:00",
+              "koulutuksenPaattymispaivamaara": "2019-08-26T00:00",
+              "opetuskieliKoodiUrit": [
+                "oppilaitoksenopetuskieli_1#1"
+              ],
+              "opetuskieletKuvaus": {
+                "fi": "Opetuskieli kuvaus"
+              },
+              "suunniteltuKestoKuvaus": {
+                "fi": "Fi suunniteltuKestoKuvaus",
+                "sv": "Sv suunniteltuKestoKuvaus"
+              },
+              "suunniteltuKestoVuodet": 2,
+              "suunniteltuKestoKuukaudet": 6,
+              "opetusaikaKoodiUrit": [
+                "opetusaikakk_1#1"
+              ],
+              "opetusaikaKuvaus": {
+                "fi": "Opetusaika kuvaus"
+              },
+              "opetustapaKoodiUrit": [
+                "opetuspaikkakk_1#1"
+              ],
+              "opetustapaKuvaus": {
+                "fi": "Opetustapa kuvaus"
+              },
+              "onkoMaksullinen": true,
+              "maksullisuusKuvaus": {
+                "fi": "Maksullisuus kuvaus"
+              },
+              "maksunMaara": 20,
+              "alkamiskausiKoodiUri": "kausi_1#1",
+              "alkamisvuosi": "2024",
+              "alkamisaikaKuvaus": {
+                "fi": "Alkamisaika kuvaus"
+              },
+              "onkoStipendia": true,
+              "stipendinMaara": 90,
+              "stipendinKuvaus": {
+                "fi": "Stipendin kuvaus"
+              },
+              "lisatiedot": [
+                {
+                  "otsikkoKoodiUri": "koulutuksenlisatiedot_0#1",
+                  "teksti": {
+                    "fi": "koulutuksenlisatiedot_0 kuvaus"
+                  }
+                }
+              ]
+            },
+            "asiasanat": [
+              {
+                "kieli": "fi",
+                "arvo": "koira"
+              },
+              {
+                "kieli": "fi",
+                "arvo": "eläintenhoito"
+              }
+            ],
+            "ammattinimikkeet": [
+              {
+                "kieli": "fi",
+                "arvo": "eläintenhoitaja"
+              }
+            ],
+            "yhteyshenkilot": [
+              {
+                "nimi": {
+                  "fi": "Fi nimi",
+                  "sv": "Sv nimi"
+                },
+                "puhelinnumero": {
+                  "fi": "Fi puhelinnumero",
+                  "sv": "Sv puhelinnumero"
+                },
+                "sahkoposti": {
+                  "fi": "Fi sähköposti",
+                  "sv": "Sv sähköposti"
+                },
+                "titteli": {
+                  "fi": "Fi titteli",
+                  "sv": "Sv titteli"
+                },
+                "wwwSivu": {
+                  "fi": "Fi verkkosivu",
+                  "sv": "Sv verkkosivu"
+                }
+              }
+            ],
+            "tyyppi": "amm",
+            "osaamisalat": [
+              {
+                "koodiUri": "osaamisala_0",
+                "linkki": {
+                  "fi": "https://www.salpaus.fi/koulutusesittely/elaintenhoitaja/"
+                },
+                "otsikko": {
+                  "fi": "Otsikko"
+                }
+              }
+            ]
+          },
+          "muokkaaja": "1.2.246.562.24.62301161440",
+          "organisaatioOid": "1.2.246.562.10.52251087186",
+          "kielivalinta": [
+            "fi",
+            "sv"
+          ],
+          "modified": "2019-03-26T10:19"
+        }
+      },
+      {
+        "url": "https://localhost:3000/kouta-backend/haku/4.1.1.1.1.1",
+        "method": "GET",
+        "status": 200,
+        "headers": {},
+        "body": null,
+        "response": {
+          "oid": "4.1.1.1.1.1",
+          "tila": "julkaistu",
+          "nimi": {
+            "fi": "Haku"
+          },
+          "hakutapaKoodiUri": "hakutapa_0#1",
+          "hakukohteenLiittamisenTakaraja": "2019-02-08T07:05",
+          "hakukohteenMuokkaamisenTakaraja": "2019-02-08T07:05",
+          "alkamiskausiKoodiUri": "kausi_0#1",
+          "alkamisvuosi": "2024",
+          "kohdejoukkoKoodiUri": "haunkohdejoukko_0#1",
+          "kohdejoukonTarkenneKoodiUri": "haunkohdejoukontarkenne_0#1",
+          "hakulomaketyyppi": "muu",
+          "hakulomakeAtaruId": "12345",
+          "hakulomakeKuvaus": {},
+          "hakulomakeLinkki": {},
+          "metadata": {
+            "tulevaisuudenAikataulu": [
+              {
+                "alkaa": "2019-10-11T09:05",
+                "paattyy": "2019-12-25T20:30"
+              }
+            ],
+            "yhteyshenkilot": [
+              {
+                "nimi": {
+                  "fi": "nimi"
+                },
+                "titteli": {
+                  "fi": "titteli"
+                },
+                "puhelinnumero": {
+                  "fi": "puhelin"
+                },
+                "wwwSivu": {
+                  "fi": "verkkosivu"
+                },
+                "sahkoposti": {
+                  "fi": "sähkoposti"
+                }
+              }
+            ]
+          },
+          "organisaatioOid": "1.2.246.562.10.52251087186",
+          "hakuajat": [
+            {
+              "alkaa": "2019-02-08T07:05",
+              "paattyy": "2020-02-08T07:05"
+            }
+          ],
+          "ajastettuJulkaisu": "2019-12-05T06:45",
+          "muokkaaja": "1.2.246.562.24.62301161440",
+          "kielivalinta": [
+            "fi",
+            "sv"
+          ],
+          "modified": "2019-03-29T12:48"
+        }
+      },
+      {
+        "url": "https://localhost:3000/kouta-backend/valintaperuste/649adb37-cd4d-4846-91a9-84b58b90f928",
+        "method": "GET",
+        "status": 200,
+        "headers": {},
+        "body": null,
+        "response": {
+          "koulutustyyppi": "amm",
+          "id": "649adb37-cd4d-4846-91a9-84b58b90f928",
+          "tila": "julkaistu",
+          "hakutapaKoodiUri": "hakutapa_0#1",
+          "kohdejoukkoKoodiUri": "haunkohdejoukko_0#1",
+          "nimi": {
+            "fi": "Valintaperusteen nimi"
+          },
+          "julkinen": false,
+          "sorakuvausId": "1",
+          "metadata": {
+            "koulutustyyppi": "amm",
+            "valintatavat": [
+              {
+                "valintatapaKoodiUri": "valintatapajono_0#1",
+                "kuvaus": {},
+                "nimi": {
+                  "fi": "Valintatavan nimi"
+                },
+                "sisalto": [
+                  {
+                    "tyyppi": "teksti",
+                    "data": {
+                      "fi": "<p>Tekstia</p>"
+                    }
+                  },
+                  {
+                    "tyyppi": "taulukko",
+                    "data": {
+                      "nimi": {},
+                      "rows": [
+                        {
+                          "index": 0,
+                          "isHeader": false,
+                          "columns": [
+                            {
+                              "index": 0,
+                              "text": {
+                                "fi": "Solu"
+                              }
+                            }
+                          ]
+                        }
+                      ]
+                    }
+                  }
+                ],
+                "kaytaMuuntotaulukkoa": false,
+                "kynnysehto": {
+                  "fi": "Kynnysehto"
+                },
+                "enimmaispisteet": 100,
+                "vahimmaispisteet": 10
+              }
+            ],
+            "kielitaitovaatimukset": [],
+            "kuvaus": {
+              "fi": "<p>Loppukuvaus</p>"
+            },
+            "valintakokeidenYleiskuvaus": {
+              "fi": "<p>Valintakokeiden kuvaus - fi</p>"
+            }
+          },
+          "organisaatioOid": "1.2.246.562.10.594252633210",
+          "muokkaaja": "1.2.246.562.24.62301161440",
+          "kielivalinta": [
+            "fi",
+            "sv"
+          ],
+          "modified": "2019-04-03T13:56",
+          "valintakokeet": [
+            {
+              "nimi": {
+                "fi": "Kokeen nimi - fi"
+              },
+              "metadata": {
+                "tietoja": {
+                  "fi": "<p>Tietoa kokeesta - fi</p>"
+                },
+                "liittyyEnnakkovalmistautumista": true,
+                "ohjeetEnnakkovalmistautumiseen": {
+                  "fi": "<p>Ohjeet ennakkovalmistautumiseen - fi</p>"
+                },
+                "erityisjarjestelytMahdollisia": true,
+                "ohjeetErityisjarjestelyihin": {
+                  "fi": "<p>Ohjeet erityisjärjestelyihin - fi</p>"
+                }
+              },
+              "tyyppiKoodiUri": "tyyppi_1#1",
+              "tilaisuudet": [
+                {
+                  "osoite": {
+                    "osoite": {
+                      "fi": "fi osoite"
+                    },
+                    "postinumeroKoodiUri": "posti_00350#1"
+                  },
+                  "aika": {
+                    "alkaa": "2019-04-16T08:44",
+                    "paattyy": "2019-04-18T08:44"
+                  },
+                  "lisatietoja": {
+                    "fi": "fi lisatietoja"
+                  },
+                  "jarjestamispaikka": {
+                    "fi": "Jarjestamispaikka - fi"
+                  }
+                }
+              ]
+            }
+          ]
+        }
+      },
+      {
+        "url": "https://localhost:3000/kouta-backend/hakukohde",
+        "method": "PUT",
+        "status": 200,
+        "headers": {},
+        "body": {
+          "muokkaaja": "1.2.246.562.24.62301161440",
+          "tila": "julkaistu",
+          "alkamiskausiKoodiUri": "kausi_0#1",
+          "kaytetaanHaunAikataulua": false,
+          "kielivalinta": [
+            "fi"
+          ],
+          "aloituspaikat": 10,
+          "hakuajat": [
+            {
+              "alkaa": "2019-04-02T10:45",
+              "paattyy": "2019-11-25T23:59"
+            }
+          ],
+          "liitteetOnkoSamaToimitusaika": false,
+          "liitteetOnkoSamaToimitusosoite": false,
+          "liitteidenToimitustapa": null,
+          "liitteet": [
+            {
+              "toimitustapa": "osoite",
+              "tyyppiKoodiUri": "liitetyypitamm_0#1",
+              "nimi": {
+                "fi": "Nimi"
+              },
+              "toimitusaika": "2019-11-25T23:59",
+              "toimitusosoite": {
+                "osoite": {
+                  "osoite": {
+                    "fi": "Osoite"
+                  },
+                  "postinumeroKoodiUri": "posti_0#2"
+                },
+                "sahkoposti": "sahkoposti@email.com"
+              },
+              "kuvaus": {
+                "fi": "Kuvaus"
+              }
+            }
+          ],
+          "alkamisvuosi": 2020,
+          "liitteidenToimitusosoite": null,
+          "liitteidenToimitusaika": null,
+          "nimi": {
+            "fi": "Hakukohteen nimi"
+          },
+          "toinenAsteOnkoKaksoistutkinto": true,
+          "valintakokeet": [
+            {
+              "tyyppiKoodiUri": "valintakokeentyyppi_1#1",
+              "nimi": {
+                "fi": "nimi"
+              },
+              "metadata": {
+                "tietoja": {
+                  "fi": "<p>Tietoa hakijalle</p>"
+                },
+                "liittyyEnnakkovalmistautumista": true,
+                "ohjeetEnnakkovalmistautumiseen": {
+                  "fi": "<p>ohjeet ennakkovalmistautumiseen</p>"
+                },
+                "erityisjarjestelytMahdollisia": true,
+                "ohjeetErityisjarjestelyihin": {
+                  "fi": "<p>ohjeet erityisjärjestelyihin</p>"
+                }
+              },
+              "tilaisuudet": [
+                {
+                  "osoite": {
+                    "osoite": {
+                      "fi": "osoite"
+                    },
+                    "postinumeroKoodiUri": "posti_0#2"
+                  },
+                  "aika": {
+                    "alkaa": "2019-04-02T10:45",
+                    "paattyy": "2019-04-02T19:00"
+                  },
+                  "lisatietoja": {
+                    "fi": "lisatietoja"
+                  },
+                  "jarjestamispaikka": {
+                    "fi": "paikka"
+                  }
+                }
+              ]
+            }
+          ],
+          "pohjakoulutusvaatimusKoodiUrit": [
+            "pohjakoulutusvaatimustoinenaste_0#1"
+          ],
+          "pohjakoulutusvaatimusTarkenne": {
+            "fi": "<p>Tarkenne</p>"
+          },
+          "valintaperusteId": "649adb37-cd4d-4846-91a9-84b58b90f928",
+          "ensikertalaisenAloituspaikat": null,
+          "kaytetaanHaunHakulomaketta": false,
+          "hakulomaketyyppi": "ataru",
+          "hakulomakeAtaruId": "lomake_1",
+          "hakulomakeLinkki": {},
+          "hakulomakeKuvaus": {},
+          "kaytetaanHaunAlkamiskautta": false,
+          "metadata": {
+            "valintakokeidenYleiskuvaus": {
+              "fi": "<p>Valintakokeiden kuvaus</p>"
+            }
+          },
+          "organisaatioOid": "1.2.246.562.10.52251087186",
+          "hakuOid": "4.1.1.1.1.1",
+          "toteutusOid": "2.1.1.1.1.1"
+        },
+        "response": {
+          "oid": "1.2.3.4.5.6"
+        }
+      }
+    ]
+  },
+  "should be able to create korkeakoulu hakukohde": {
+    "timestamp": 1603365080041,
+    "routes": [
+      {
+        "url": "https://localhost:3000/kouta-backend/auth/session",
+        "method": "GET",
+        "status": 200,
+        "headers": {},
+        "body": null,
+        "response": {}
+      },
+      {
+        "url": "https://localhost:3000/kayttooikeus-service/cas/me",
+        "method": "GET",
+        "status": 200,
+        "headers": {},
+        "body": null,
+        "response": {
+          "uid": "johndoe",
+          "oid": "1.2.246.562.24.62301161440",
+          "firstName": "John",
+          "lastName": "Doe",
+          "lang": "fi",
+          "roles": "[\"APP_KOUTA\",\"APP_KOUTA_OPHPAAKAYTTAJA\",\"APP_KOUTA_OPHPAAKAYTTAJA_1.2.246.562.10.00000000001\"]"
+        }
+      },
+      {
+        "url": "https://localhost:3000/kouta-backend/auth/session",
+        "method": "GET",
+        "status": 200,
+        "headers": {},
+        "body": null,
+        "response": {}
+      },
+      {
+        "url": "https://localhost:3000/kouta-backend/toteutus/2.1.1.1.1.1",
+        "method": "GET",
+        "status": 200,
+        "headers": {},
+        "body": null,
+        "response": {
+          "oid": "2.1.1.1.1.1",
+          "koulutusOid": "3.1.1.1.1",
+          "tila": "julkaistu",
+          "tarjoajat": [
+            "1.2.246.562.10.45854578546"
+          ],
+          "nimi": {
+            "fi": "Koulutuskeskus Salpaus, jatkuva haku, eläintenhoitaja"
+          },
+          "metadata": {
+            "kuvaus": {},
+            "opetus": {
+              "koulutuksenAlkamispaivamaara": "2019-08-23T00:00",
+              "koulutuksenPaattymispaivamaara": "2019-08-26T00:00",
+              "opetuskieliKoodiUrit": [
+                "oppilaitoksenopetuskieli_1#1"
+              ],
+              "opetuskieletKuvaus": {
+                "fi": "Opetuskieli kuvaus"
+              },
+              "suunniteltuKestoKuvaus": {
+                "fi": "Fi suunniteltuKestoKuvaus",
+                "sv": "Sv suunniteltuKestoKuvaus"
+              },
+              "suunniteltuKestoVuodet": 2,
+              "suunniteltuKestoKuukaudet": 6,
+              "opetusaikaKoodiUrit": [
+                "opetusaikakk_1#1"
+              ],
+              "opetusaikaKuvaus": {
+                "fi": "Opetusaika kuvaus"
+              },
+              "opetustapaKoodiUrit": [
+                "opetuspaikkakk_1#1"
+              ],
+              "opetustapaKuvaus": {
+                "fi": "Opetustapa kuvaus"
+              },
+              "onkoMaksullinen": true,
+              "maksullisuusKuvaus": {
+                "fi": "Maksullisuus kuvaus"
+              },
+              "maksunMaara": 20,
+              "alkamiskausiKoodiUri": "kausi_1#1",
+              "alkamisvuosi": "2024",
+              "alkamisaikaKuvaus": {
+                "fi": "Alkamisaika kuvaus"
+              },
+              "onkoStipendia": true,
+              "stipendinMaara": 90,
+              "stipendinKuvaus": {
+                "fi": "Stipendin kuvaus"
+              },
+              "lisatiedot": [
+                {
+                  "otsikkoKoodiUri": "koulutuksenlisatiedot_0#1",
+                  "teksti": {
+                    "fi": "koulutuksenlisatiedot_0 kuvaus"
+                  }
+                }
+              ]
+            },
+            "asiasanat": [
+              {
+                "kieli": "fi",
+                "arvo": "koira"
+              },
+              {
+                "kieli": "fi",
+                "arvo": "eläintenhoito"
+              }
+            ],
+            "ammattinimikkeet": [
+              {
+                "kieli": "fi",
+                "arvo": "eläintenhoitaja"
+              }
+            ],
+            "yhteyshenkilot": [
+              {
+                "nimi": {
+                  "fi": "Fi nimi",
+                  "sv": "Sv nimi"
+                },
+                "puhelinnumero": {
+                  "fi": "Fi puhelinnumero",
+                  "sv": "Sv puhelinnumero"
+                },
+                "sahkoposti": {
+                  "fi": "Fi sähköposti",
+                  "sv": "Sv sähköposti"
+                },
+                "titteli": {
+                  "fi": "Fi titteli",
+                  "sv": "Sv titteli"
+                },
+                "wwwSivu": {
+                  "fi": "Fi verkkosivu",
+                  "sv": "Sv verkkosivu"
+                }
+              }
+            ],
+            "tyyppi": "yo",
+            "ylemmanKorkeakoulututkinnonOsaamisalat": [
+              {
+                "kuvaus": {
+                  "fi": "osaamisalan kuvaus"
+                },
+                "nimi": {
+                  "fi": "osaamisalan nimi"
+                },
+                "linkki": {
+                  "fi": "http://linkki.com"
+                },
+                "otsikko": {
+                  "fi": "osaamisalan otsikko"
+                }
+              }
+            ],
+            "alemmanKorkeakoulututkinnonOsaamisalat": [
+              {
+                "kuvaus": {
+                  "fi": "osaamisalan kuvaus"
+                },
+                "nimi": {
+                  "fi": "osaamisalan nimi"
+                },
+                "linkki": {
+                  "fi": "http://linkki.com"
+                },
+                "otsikko": {
+                  "fi": "osaamisalan otsikko"
+                }
+              }
+            ]
+          },
+          "muokkaaja": "1.2.246.562.24.62301161440",
+          "organisaatioOid": "1.2.246.562.10.52251087186",
+          "kielivalinta": [
+            "fi",
+            "sv"
+          ],
+          "modified": "2019-03-26T10:19"
+        }
+      },
+      {
+        "url": "https://localhost:3000/kouta-backend/haku/4.1.1.1.1.1",
+        "method": "GET",
+        "status": 200,
+        "headers": {},
+        "body": null,
+        "response": {
+          "oid": "4.1.1.1.1.1",
+          "tila": "julkaistu",
+          "nimi": {
+            "fi": "Haku"
+          },
+          "hakutapaKoodiUri": "hakutapa_0#1",
+          "hakukohteenLiittamisenTakaraja": "2019-02-08T07:05",
+          "hakukohteenMuokkaamisenTakaraja": "2019-02-08T07:05",
+          "alkamiskausiKoodiUri": "kausi_0#1",
+          "alkamisvuosi": "2024",
+          "kohdejoukkoKoodiUri": "haunkohdejoukko_0#1",
+          "kohdejoukonTarkenneKoodiUri": "haunkohdejoukontarkenne_0#1",
+          "hakulomaketyyppi": "muu",
+          "hakulomakeAtaruId": "12345",
+          "hakulomakeKuvaus": {},
+          "hakulomakeLinkki": {},
+          "metadata": {
+            "tulevaisuudenAikataulu": [
+              {
+                "alkaa": "2019-10-11T09:05",
+                "paattyy": "2019-12-25T20:30"
+              }
+            ],
+            "yhteyshenkilot": [
+              {
+                "nimi": {
+                  "fi": "nimi"
+                },
+                "titteli": {
+                  "fi": "titteli"
+                },
+                "puhelinnumero": {
+                  "fi": "puhelin"
+                },
+                "wwwSivu": {
+                  "fi": "verkkosivu"
+                },
+                "sahkoposti": {
+                  "fi": "sähkoposti"
+                }
+              }
+            ]
+          },
+          "organisaatioOid": "1.2.246.562.10.52251087186",
+          "hakuajat": [
+            {
+              "alkaa": "2019-02-08T07:05",
+              "paattyy": "2020-02-08T07:05"
+            }
+          ],
+          "ajastettuJulkaisu": "2019-12-05T06:45",
+          "muokkaaja": "1.2.246.562.24.62301161440",
+          "kielivalinta": [
+            "fi",
+            "sv"
+          ],
+          "modified": "2019-03-29T12:48"
+        }
+      },
+      {
+        "url": "https://localhost:3000/organisaatio-service/rest/organisaatio/v4/1.2.246.562.10.52251087186?includeImage=false",
+        "method": "GET",
+        "status": 200,
+        "headers": {},
+        "body": null,
+        "response": {
+          "metadata": {
+            "nimi": {},
+            "hakutoimistoEctsNimi": {},
+            "hakutoimistoEctsEmail": {},
+            "hakutoimistoEctsPuhelin": {},
+            "hakutoimistoEctsTehtavanimike": {},
+            "yhteystiedot": [
+              {
+                "kieli": "kieli_fi#1",
+                "www": "http://www.stadinammattiopisto.fi",
+                "yhteystietoOid": "14812023190550.9836378324069386",
+                "id": "3861227"
+              },
+              {
+                "kieli": "kieli_fi#1",
+                "numero": "09 310 89318",
+                "tyyppi": "puhelin",
+                "yhteystietoOid": "1.2.246.562.5.62477770688",
+                "id": "3861228"
+              },
+              {
+                "kieli": "kieli_fi#1",
+                "yhteystietoOid": "14303205263410.7259206293670477",
+                "id": "3861229",
+                "email": "hakutoimisto@edu.hel.fi"
+              },
+              {
+                "osoiteTyyppi": "posti",
+                "kieli": "kieli_fi#1",
+                "postinumeroUri": "posti_00099",
+                "yhteystietoOid": "1.2.246.562.5.20277448420",
+                "id": "3861230",
+                "postitoimipaikka": "HELSINGIN KAUPUNKI",
+                "osoite": "PL 55306"
+              },
+              {
+                "osoiteTyyppi": "kaynti",
+                "kieli": "kieli_fi#1",
+                "postinumeroUri": "posti_00550",
+                "yhteystietoOid": "1.2.246.562.5.26047810076",
+                "id": "3861231",
+                "postitoimipaikka": "HELSINKI",
+                "osoite": "Hattulantie 2, 1. krs"
+              }
+            ],
+            "hakutoimistonNimi": {
+              "kieli_fi#1": "Stadin ammatti- ja aikuisopiston hakutoimisto"
+            },
+            "luontiPvm": 1376895579333,
+            "muokkausPvm": 1376859600000,
+            "data": {
+              "KANSAINVALISET_KOULUTUSOHJELMAT": {},
+              "YLEISKUVAUS": {
+                "kieli_fi#1": "<p>Stadin ammatti- ja aikuisopisto järjestää ammatillista peruskoulutusta, ammatillista täydennyskoulutusta, oppisopimuskoulutusta ja nivelvaiheen koulutusta Helsingin kaupungin alueella 15 eri toimipaikassa. Meillä Suomen suurimmassa ammattiopistossa opiskelee noin 17 000 nuorta ja aikuista yli 50 eri ammattiin.</p> <p>Kun suoritat ammatillisen koulutuksen, saat laaja-alaiset valmiudet toimia oman alasi erilaisissa ja vaihtelevissa työtehtävissä sekä kehittää ammattitaitoasi läpi elämän. Lisäksi ammatillinen perustutkinto antaa sinulle yleisen jatko-opintokelpoisuuden ammattikorkeakouluihin ja yliopistoihin.</p> <p>Stadin ammatti- ja aikuisopistossa voit opiskella joustavasti eri oppimisratkaisuin. Opintojen suunnittelussa huomioidaan aina opiskelijan aiempi osaaminen esimerkiksi yhdistämällä oppilaitosmuotoista opiskelua ja oppisopimuskoulutusta. Lisäksi ammatilliseen perustutkintoon johtavassa koulutuksessa on mahdollista suorittaa lukio-opintoja sekä hakea ohjattuun urheiluvalmennukseen.</p> <p>Stadin ammatti- ja aikuisopiston Brygga tarjoaa nivelvaiheen koulutusta ja palveluja. Siihen kuuluvat ammatilliseen koulutukseen valmentava koulutus (VALMA), osa kaupungin perusopetuksen lisäopetuksesta (kymppiluokat), avoimet opinnot ja nuorten työpajatoiminta. Stadin osaamiskeskus puolestaan yhdistää kuntoutuksen, koulutuksen ja työllistymisen palvelut helsinkiläisille aikuisille maahanmuuttajille.</p> <p>Lisätietoa Stadin ammatti- ja aikuisopiston koulutustarjonnasta löytyy nettisivuiltamme www.stadinammattiopisto.fi</p> <p> </p>"
+              },
+              "KIELIOPINNOT": {
+                "kieli_fi#1": "<p>Kaikkiin perustutkintoihin kuuluu vähintään 2 osaamispistettä englantia (A-kieli) ja 1 osaamispistettä ruotsia. Lisäksi joissain toimipaikoissa voit valinnaisissa opinnoissa opiskella ylimääräisiä kieliä.</p>"
+              },
+              "TERVEYDENHUOLTOPALVELUT": {
+                "kieli_fi#1": "<p>Stadin ammatti- ja aikuisopistossa on sekä terveydenhoitajia että lääkäreitä opiskelijoita varten. Ensimmäisenä opiskeluvuonna terveydenhoitaja kutsuu sinut terveystarkastukseen, jossa selvitetään opiskelun tai ammatissa toimimisen kannalta tärkeät seikat. Lääkärin vastaanotolle haetaan terveydenhoitajan kautta.</p> <p>Oppilaitoksessa ei ole hammashoitolaa. Opiskelijat käyttävät oman asuinalueensa terveysaseman palveluita.</p>"
+              },
+              "TEHTAVANIMIKE": {},
+              "SAHKOPOSTIOSOITE": {},
+              "RAHOITUS": {},
+              "AIEMMIN_HANKITTU_OSAAMINEN": {
+                "kieli_fi#1": "<p>Osaamisen tunnistaminen ja tunnustaminen</p> <p>Ennalta hankittu osaaminen, kuten aiemmin suoritetut opinnot tai työkokemus, voidaan sisällyttää osaksi ammatillista tutkintoasi, mikäli osaamisesi on opetussuunnitelman mukaista. Tällöin opiskeluaikasi mahdollisesti lyhenee ja valmistut aikaisemmin.</p> <p>Osaamisen tunnistamista ja tunnustamista haetaan lomakkeella, jonka saat opettajaltasi tai opinto-ohjaajaltasi. He myös ohjaavat sen täyttämisessä.</p> <p>Opinnoista vapauttaminen</p> <p>Ruotsin kielestä voit anoa vapautusta, jos et ole opiskellut ruotsia aiemmin. Vapautusta haetaan lomakkeella, jonka saat opettajaltasi tai opinto-ohjaajaltasi. Ruotsin sijasta opiskelet jonkin muun sovitun opinnon.</p>"
+              },
+              "sosiaalinenmedia_7#1": {},
+              "sosiaalinenmedia_5#1": {
+                "kieli_fi#1": "http://www.pinterest.com/StadinAO"
+              },
+              "sosiaalinenmedia_6#1": {
+                "kieli_fi#1": "http://www.instagram.com/stadinao"
+              },
+              "OPISKELIJALIIKKUVUUS": {
+                "kieli_fi#1": "<p>Kansainvälisyys on osa Stadin ammatti- ja aikuisopiston arkea. Tarjoamme opiskelijalle mahdollisuuden lisätä kansainvälisyysosaamista opintojen aikana.  Kotikansainvälistymistä edistetään tarjoamalla kieliin ja kulttuuriin liittyviä oppimistilanteita, virtuaaliliikkuvuutta ja taitaja-toimintaa.</p> <p>Stadin ammatti- ja aikuisopistosta voi lähteä työssäoppimisjaksolle ulkomaille. Kansainväliset vaihdot täydentävät opiskelijoiden työelämävalmiuksia ammatillisen osaamisen, kielitaidon ja kulttuurien tuntemisen kautta sekä tukevat opiskelijan itsenäisyyttä, avoimuutta ja rohkeutta.</p> <p>Ulkomaanjaksoja voi suorittaa mm. Pohjoismaissa, Iso-Britanniassa, Hollannissa, Saksassa, Ranskassa, Espanjassa, Irlannissa, Virossa, Sloveniassa, Itävallassa, Venäjällä ja Kiinassa. Ulkomaanjaksolle lähdetään toisena tai kolmantena opintovuotena.</p>"
+              },
+              "VAKUUTUKSET": {
+                "kieli_fi#1": "<p>Kaikki opiskelijat on vakuutettu opiskelun aikana sattuneiden tapaturmien varalta. Tapaturma korvataan, jos se on sattunut oppitunnilla, työssäoppimisen aikana, opintokäynneillä tai koulumatkalla. Koulumatkalla vakuutus on voimassa vain, mikäli matka on tapahtunut viivytyksettä ja suorinta, tavanomaista tietä.</p> <p>Vakuutus on voimassa myös ulkomaille suuntautuvien opintomatkojen ja työssäoppimisjaksojen aikana. Oppilaitoksen vakuutukset eivät kuitenkaan ole voimassa, jos olet sairauslomalla. Pidempien sairauslomien ajaksi opinnot yleensä keskeytetään väliaikaisesti.</p>"
+              },
+              "OPISKELIJA_JARJESTOT": {
+                "kieli_fi#1": "<p>Opiskelijakuntatoiminta ja opiskelijayhdistys STAO ry</p> <p>Jokainen opiskelija kuuluu oman toimipaikkansa opiskelijakuntaan. Kustakin toimipaikasta valitaan lukuvuoden alussa opiskelijakunnan hallitus, jonka tehtävänä on tuoda opiskelijoiden ääni kuuluviin omassa toimipaikassa.</p> <p>STAO ry (Stadin ammattiin opiskelevat) on Stadin ammattiopiston opiskelijayhdistys, johon jokainen opiskelija voi liittyä. Yhdistys edistää opiskelijoiden toimintaa, osallistumista ja hyvinvointia koko oppilaitoksessa.</p>"
+              },
+              "VALINTAMENETTELY": {
+                "kieli_fi#1": "<p>Kevään yhteishaussa hakevat peruskoulunsa päättävät, ylioppilaat ja muut ilman toisen asteen ammatillista tutkintoa olevat (valintamenettelyssä noudatetaan Oph:n antamia ohjeita). Kaikki muut hakevat jatkuvassa haussa (oppilaitoksen oma valintamenettely, hakija saa valintapäätöksen kolmen viikon kuluessa hakemisesta).</p>"
+              },
+              "sosiaalinenmedia_3#1": {},
+              "sosiaalinenmedia_4#1": {
+                "kieli_fi#1": "http://www.twitter.com/stadinao"
+              },
+              "sosiaalinenmedia_1#1": {
+                "kieli_fi#1": "http://www.facebook.com/stadinammattiopisto"
+              },
+              "VASTUUHENKILOT": {},
+              "KUSTANNUKSET": {
+                "kieli_fi#1": "<p>Opintojensa aikana opiskelijat hankkivat itse esimerkiksi oppikirjoja, kansioita, muistiinpanovälineitä sekä henkilökohtaisia työvälineitä. Osassa tutkinnoista työvaatteet ja -kengät saa oppilaitoksen puolesta.</p>"
+              },
+              "OPPIMISYMPARISTO": {
+                "kieli_fi#1": "<p>Stadin ammatti- ja aikuisopiston kaikki toimipaikat sijaitsevat Helsingin kaupungin alueella. Toimipaikkojen oppimisympäristöjä uudistetaan monimuotoisiksi ja viihtyisiksi, jolloin ne tukevat opiskelijakeskeistä ja työelämälähtöistä pedagogiikkaa. Opiskelijoiden ja opettajien käytettävissä on mm. kattava, digitaalisuuden hyödyntämistä tukeva wifi.</p>"
+              },
+              "sosiaalinenmedia_2#1": {},
+              "PUHELINNUMERO": {},
+              "NIMI": {},
+              "OPISKELIJALIIKUNTA": {},
+              "VUOSIKELLO": {},
+              "OPISKELIJARUOKAILU": {
+                "kieli_fi#1": "<p>Stadin ammatti- ja aikuisopistossa on kaikissa toimipaikoissa opiskelijaravintola ja kahvila. Opiskelijoille on koulupäivinä tarjolla yksi maksuton lounasateria. Tarjolla on joka päivä myös kasvislounasvaihtoehto.</p>"
+              },
+              "VAPAA_AIKA": {},
+              "ESTEETOMYYS": {
+                "kieli_fi#1": "<p>Stadin ammatti- ja aikuisopisto on kaikille yhteinen oppilaitos, jossa jokainen pystyy ominaisuuksistaan riippumatta toimimaan yhdenvertaisesti muiden kanssa, jolloin opiskeluympäristössä ei pitäisi olla liikkumiseen, ryhmään kuulumiseen tai oppimiseen liittyviä esteitä.</p> <p><em> </em></p> <p><em>Opiskeluhuolto</em></p> <p>Opiskeluhuollon tavoitteena on edistää oppimistasi, terveyttäsi ja hyvinvointiasi opiskelun aikana. Opiskelijahuolto huolehtii myös oppilaitosyhteisön hyvinvoinnista sekä opiskeluympäristön terveellisyydestä ja turvallisuudesta. Opiskeluhuoltoa toteutetaan sekä yhteisöllisenä että yksilökohtaisena opiskeluhuoltona.</p> <p><em> </em></p> <p><em>Yhteisöllinen opiskeluhuolto</em></p> <p>Yhteisöllinen opiskeluhuolto edistää opiskelijoiden osallisuutta, oppimista, hyvinvointia ja terveyttä. Lisäksi se seuraa ja kehittää opiskeluyhteisön hyvinvointia sekä opiskeluympäristön terveellisyyttä, turvallisuutta ja esteettömyyttä. Toimipaikan hyvinvointiryhmä vastaa opiskeluhuollon suunnittelusta, kehittämisestä ja arvioinnista yhteisöllisen opiskeluhuollon osa-alueet huomioon ottaen. Ryhmää johtaa apulaisrehtori tai koulutuspäällikkö. Opetushenkilöstön lisäksi ryhmään kuuluu erityisopettaja, opinto-ohjaaja, kuraattori, psykologi, terveydenhoitaja ja opiskelijajäseniä. Ryhmään voi kuulua myös huoltajien edustaja.</p> <p><em> </em></p> <p><em>Yksilökohtainen opiskelijahuolto</em></p> <p>Yksilökohtaisella opiskelijahuollolla tarkoitetaan opiskelijan käytössä olevia palveluja, joita ovat • opiskeluterveydenhuolto • opiskeluhuollon psykologi- ja kuraattoripalvelut • yksittäistä opiskelijaa koskeva monialainen opiskeluhuolto, jota toteutetaan tapauskohtaisesti koottavassa monialaisessa asiantuntijaryhmässä. Yksilökohtaista opiskeluhuoltoa tehdään yhteistyössä opiskelijan kanssa ja hänen suostumuksellaan.</p> <p><em> </em></p> <p><em>Kun tarvitset tukea opinnoissasi</em></p> <p>Opintojesi alussa kanssasi tehdään henkilökohtainen osaamisen kehittämisen suunnitelma (HOKS). Suunnitelmaan kirjataan aiemmin hankittu ja osoitettu osaaminen, tarvittava ammattitaidon ja osaamisen hankkiminen, osaamisen osoittaminen sekä ohjaus- ja tukitoimet. Jos tarvitset erityistä tukea, suunnitelmassa sovitaan sinulle tarjottavan erityisen tuen sisällöstä ja erityisen tuen tarpeen mukaisista toimenpiteistä osaamisen hankkimisen aikana. Erityistä tukea voi saada kaikissa ammatilliseen perustutkintoon johtavissa koulutuksissa.</p>"
+              },
+              "TIETOA_ASUMISESTA": {
+                "kieli_fi#1": "<p>Stadin ammatti- ja aikuisopistolla ei ole asuntolaa. Tutkintoon johtavassa koulutuksessa oleva opiskelija voi hakea opiskelija-asuntoa esim. HOAS:lta.</p>"
+              },
+              "TYOHARJOITTELU": {
+                "kieli_fi#1": "<p>Kaikkiin perustutkintoihin kuuluu vähintään 30 osaamispistettä, n. kuusi kuukautta, työssäoppimista. Työssäoppiminen suoritetaan pääasiassa työpaikoilla ja työelämälähtöisissä oppimisympäristöissä.</p>"
+              }
+            }
+          },
+          "oid": "1.2.246.562.10.52251087186",
+          "nimi": {
+            "fi": "Stadin ammatti- ja aikuisopisto",
+            "sv": "Stadin ammatti- ja aikuisopisto",
+            "en": "Stadin ammatti- ja aikuisopisto"
+          },
+          "alkuPvm": "2013-01-01",
+          "oppilaitosKoodi": "10105",
+          "ryhmatyypit": [],
+          "kayttoryhmat": [],
+          "piilotettu": false,
+          "parentOid": "1.2.246.562.10.346830761110",
+          "postiosoite": {
+            "postinumeroUri": "posti_00099",
+            "osoiteTyyppi": "posti",
+            "yhteystietoOid": "1.2.246.562.5.69596457015",
+            "postitoimipaikka": "HELSINGIN KAUPUNKI",
+            "osoite": "PL 55308"
+          },
+          "kuvaus2": {},
+          "tyypit": [
+            "organisaatiotyyppi_02"
+          ],
+          "yhteystietoArvos": [
+            {
+              "YhteystietoArvo.arvoText": "stadiprimus@edu.hel.fi",
+              "YhteystietojenTyyppi.nimi.fi": "KOSKI-palvelun omien tietojen virheilmoituksen sähköpostiosoite",
+              "YhteystietojenTyyppi.nimi.sv": "E-postadress för felanmälan i egna uppgifter i KOSKI-tjänsten",
+              "YhteystietoElementti.tyyppi": "Email",
+              "YhteystietojenTyyppi.oid": "1.2.246.562.5.79385887983",
+              "YhteystietoElementti.oid": "1.2.246.562.5.57850489428",
+              "YhteystietoElementti.nimi": "Sähköpostiosoite",
+              "YhteystietoElementti.nimiSv": "Epostadress",
+              "YhteystietoElementti.pakollinen": "false",
+              "YhteystietojenTyyppi.nimi.en": "KOSKI-palvelun omien tietojen virheilmoituksen sähköpostiosoite",
+              "YhteystietoElementti.kaytossa": "true",
+              "YhteystietoArvo.kieli": "kieli_fi#1"
+            }
+          ],
+          "yhteystiedot": [
+            {
+              "osoiteTyyppi": "posti",
+              "kieli": "kieli_fi#1",
+              "postinumeroUri": "posti_00099",
+              "yhteystietoOid": "1.2.246.562.5.69596457015",
+              "id": "3861240",
+              "postitoimipaikka": "HELSINGIN KAUPUNKI",
+              "osoite": "PL 55308"
+            },
+            {
+              "kieli": "kieli_fi#1",
+              "yhteystietoOid": "14931031965550.42925150233306597",
+              "id": "3861238",
+              "email": "hakutoimisto@edu.hel.fi"
+            },
+            {
+              "osoiteTyyppi": "kaynti",
+              "kieli": "kieli_fi#1",
+              "postinumeroUri": "posti_00550",
+              "yhteystietoOid": "1.2.246.562.5.32847643825",
+              "id": "3861237",
+              "postitoimipaikka": "HELSINKI",
+              "osoite": "Hattulantie 2"
+            },
+            {
+              "kieli": "kieli_fi#1",
+              "numero": "09 310 8415",
+              "tyyppi": "puhelin",
+              "yhteystietoOid": "1.2.246.562.5.90059839549",
+              "id": "3861236"
+            },
+            {
+              "kieli": "kieli_fi#1",
+              "www": "http://www.stadinammattiopisto.fi",
+              "yhteystietoOid": "1.2.246.562.5.38465214716",
+              "id": "3861239"
+            }
+          ],
+          "nimet": [
+            {
+              "nimi": {
+                "fi": "Stadin ammattiopisto"
+              },
+              "alkuPvm": "2013-01-01",
+              "version": 1
+            },
+            {
+              "nimi": {
+                "fi": "Stadin ammatti- ja aikuisopisto",
+                "sv": "Stadin ammatti- ja aikuisopisto",
+                "en": "Stadin ammatti- ja aikuisopisto"
+              },
+              "alkuPvm": "2018-12-31",
+              "version": 0
+            }
+          ],
+          "vuosiluokat": [],
+          "parentOidPath": "|1.2.246.562.10.00000000001|1.2.246.562.10.346830761110|",
+          "toimipistekoodi": "10105",
+          "kotipaikkaUri": "kunta_091",
+          "kieletUris": [
+            "oppilaitoksenopetuskieli_1#1"
+          ],
+          "maaUri": "maatjavaltiot1_fin",
+          "oppilaitosTyyppiUri": "oppilaitostyyppi_21#1",
+          "muutKotipaikatUris": [],
+          "kayntiosoite": {
+            "postinumeroUri": "posti_00550",
+            "osoiteTyyppi": "kaynti",
+            "yhteystietoOid": "1.2.246.562.5.32847643825",
+            "postitoimipaikka": "HELSINKI",
+            "osoite": "Hattulantie 2"
+          },
+          "lisatiedot": [],
+          "muutOppilaitosTyyppiUris": [],
+          "version": 89,
+          "status": "AKTIIVINEN"
+        }
+      },
+      {
+        "url": "https://localhost:3000/kouta-backend/koulutus/3.1.1.1.1",
+        "method": "GET",
+        "status": 200,
+        "headers": {},
+        "body": null,
+        "response": {
+          "oid": "3.1.1.1.1",
+          "koulutustyyppi": "yo",
+          "koulutusKoodiUri": "koulutus_671112#12",
+          "tila": "julkaistu",
+          "tarjoajat": [
+            "1.2.246.562.10.45854578546"
+          ],
+          "nimi": {
+            "en": "Vocational qualification in Agriculture",
+            "fi": "Fysioterapeutti (AMK)",
+            "sv": "Fysioterapeut (YH)"
+          },
+          "metadata": {
+            "tyyppi": "yo",
+            "kuvaus": {
+              "fi": "Fi kuvaus",
+              "sv": "Sv kuvaus"
+            },
+            "lisatiedot": [
+              {
+                "otsikkoKoodiUri": "koulutuksenlisatiedot_0#1",
+                "teksti": {
+                  "fi": "koulutuksenlisatiedot_0 kuvaus"
+                }
+              }
+            ],
+            "tutkintonimikeKoodiUrit": [
+              "tutkintonimikekk_1#1",
+              "tutkintonimikekk_2#1"
+            ],
+            "opintojenLaajuusKoodiUri": "opintojenlaajuus_1#1",
+            "kuvauksenNimi": {
+              "fi": "Fi kuvauksen nimi",
+              "sv": "Sv kuvauksen nimi"
+            },
+            "koulutusalaKoodiUrit": [
+              "kansallinenkoulutusluokitus2016koulutusalataso2_1#1"
+            ]
+          },
+          "julkinen": true,
+          "muokkaaja": "1.2.246.562.24.62301161440",
+          "organisaatioOid": "1.2.246.562.10.52251087186",
+          "kielivalinta": [
+            "fi",
+            "sv"
+          ],
+          "modified": "2019-04-01T13:01",
+          "johtaaTutkintoon": true
+        }
+      },
+      {
+        "url": "https://localhost:3000/kouta-backend/valintaperuste/list?organisaatioOid=1.2.246.562.10.52251087186&hakuOid=4.1.1.1.1.1",
+        "method": "GET",
+        "status": 200,
+        "headers": {},
+        "body": null,
+        "response": [
+          {
+            "koulutustyyppi": "amm",
+            "id": "649adb37-cd4d-4846-91a9-84b58b90f928",
+            "tila": "julkaistu",
+            "hakutapaKoodiUri": "hakutapa_0#1",
+            "kohdejoukkoKoodiUri": "haunkohdejoukko_0#1",
+            "nimi": {
+              "fi": "Valintaperusteen nimi"
+            },
+            "julkinen": false,
+            "sorakuvausId": "1",
+            "metadata": {
+              "koulutustyyppi": "amm",
+              "valintatavat": [
+                {
+                  "valintatapaKoodiUri": "valintatapajono_0#1",
+                  "kuvaus": {},
+                  "nimi": {
+                    "fi": "Valintatavan nimi"
+                  },
+                  "sisalto": [
+                    {
+                      "tyyppi": "teksti",
+                      "data": {
+                        "fi": "<p>Tekstia</p>"
+                      }
+                    },
+                    {
+                      "tyyppi": "taulukko",
+                      "data": {
+                        "nimi": {},
+                        "rows": [
+                          {
+                            "index": 0,
+                            "isHeader": false,
+                            "columns": [
+                              {
+                                "index": 0,
+                                "text": {
+                                  "fi": "Solu"
+                                }
+                              }
+                            ]
+                          }
+                        ]
+                      }
+                    }
+                  ],
+                  "kaytaMuuntotaulukkoa": false,
+                  "kynnysehto": {
+                    "fi": "Kynnysehto"
+                  },
+                  "enimmaispisteet": 100,
+                  "vahimmaispisteet": 10
+                }
+              ],
+              "kielitaitovaatimukset": [],
+              "kuvaus": {
+                "fi": "<p>Loppukuvaus</p>"
+              },
+              "valintakokeidenYleiskuvaus": {
+                "fi": "<p>Valintakokeiden kuvaus - fi</p>"
+              }
+            },
+            "organisaatioOid": "1.2.246.562.10.594252633210",
+            "muokkaaja": "1.2.246.562.24.62301161440",
+            "kielivalinta": [
+              "fi",
+              "sv"
+            ],
+            "modified": "2019-04-03T13:56",
+            "valintakokeet": [
+              {
+                "nimi": {
+                  "fi": "Kokeen nimi - fi"
+                },
+                "metadata": {
+                  "tietoja": {
+                    "fi": "<p>Tietoa kokeesta - fi</p>"
+                  },
+                  "liittyyEnnakkovalmistautumista": true,
+                  "ohjeetEnnakkovalmistautumiseen": {
+                    "fi": "<p>Ohjeet ennakkovalmistautumiseen - fi</p>"
+                  },
+                  "erityisjarjestelytMahdollisia": true,
+                  "ohjeetErityisjarjestelyihin": {
+                    "fi": "<p>Ohjeet erityisjärjestelyihin - fi</p>"
+                  }
+                },
+                "tyyppiKoodiUri": "tyyppi_1#1",
+                "tilaisuudet": [
+                  {
+                    "osoite": {
+                      "osoite": {
+                        "fi": "fi osoite"
+                      },
+                      "postinumeroKoodiUri": "posti_00350#1"
+                    },
+                    "aika": {
+                      "alkaa": "2019-04-16T08:44",
+                      "paattyy": "2019-04-18T08:44"
+                    },
+                    "lisatietoja": {
+                      "fi": "fi lisatietoja"
+                    },
+                    "jarjestamispaikka": {
+                      "fi": "Jarjestamispaikka - fi"
+                    }
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "url": "https://localhost:3000/koodisto-service/rest/json/pohjakoulutusvaatimustoinenaste/koodi?onlyValidKoodis=true&koodistoVersio=",
+        "method": "GET",
+        "status": 200,
+        "headers": {},
+        "body": null,
+        "response": [
+          {
+            "koodiUri": "pohjakoulutusvaatimustoinenaste_0",
+            "resourceUri": "https://virkailija.hahtuvaopintopolku.fi/koodisto-service/rest/codeelement/pohjakoulutusvaatimustoinenaste_11",
+            "version": 1,
+            "versio": 1,
+            "koodisto": {
+              "koodistoUri": "pohjakoulutusvaatimustoinenaste",
+              "organisaatioOid": "1.2.246.562.10.00000000001",
+              "koodistoVersios": [
+                1
+              ]
+            },
+            "koodiArvo": "0",
+            "paivitysPvm": 1427461978048,
+            "voimassaAlkuPvm": "2000-01-01",
+            "voimassaLoppuPvm": null,
+            "tila": "LUONNOS",
+            "metadata": [
+              {
+                "nimi": "pohjakoulutusvaatimustoinenaste_0",
+                "kuvaus": "pohjakoulutusvaatimustoinenaste_0",
+                "lyhytNimi": "pohjakoulutusvaatimustoinenaste_0",
+                "kieli": "fi"
+              },
+              {
+                "nimi": "pohjakoulutusvaatimustoinenaste_0",
+                "kuvaus": "pohjakoulutusvaatimustoinenaste_0",
+                "lyhytNimi": "pohjakoulutusvaatimustoinenaste_0",
+                "kieli": "sv"
+              },
+              {
+                "nimi": "pohjakoulutusvaatimustoinenaste_0",
+                "kuvaus": "pohjakoulutusvaatimustoinenaste_0",
+                "lyhytNimi": "pohjakoulutusvaatimustoinenaste_0",
+                "kieli": "en"
+              }
+            ]
+          },
+          {
+            "koodiUri": "pohjakoulutusvaatimustoinenaste_1",
+            "resourceUri": "https://virkailija.hahtuvaopintopolku.fi/koodisto-service/rest/codeelement/pohjakoulutusvaatimustoinenaste_11",
+            "version": 1,
+            "versio": 1,
+            "koodisto": {
+              "koodistoUri": "pohjakoulutusvaatimustoinenaste",
+              "organisaatioOid": "1.2.246.562.10.00000000001",
+              "koodistoVersios": [
+                1
+              ]
+            },
+            "koodiArvo": "1",
+            "paivitysPvm": 1427461978048,
+            "voimassaAlkuPvm": "2000-01-01",
+            "voimassaLoppuPvm": null,
+            "tila": "LUONNOS",
+            "metadata": [
+              {
+                "nimi": "pohjakoulutusvaatimustoinenaste_1",
+                "kuvaus": "pohjakoulutusvaatimustoinenaste_1",
+                "lyhytNimi": "pohjakoulutusvaatimustoinenaste_1",
+                "kieli": "fi"
+              },
+              {
+                "nimi": "pohjakoulutusvaatimustoinenaste_1",
+                "kuvaus": "pohjakoulutusvaatimustoinenaste_1",
+                "lyhytNimi": "pohjakoulutusvaatimustoinenaste_1",
+                "kieli": "sv"
+              },
+              {
+                "nimi": "pohjakoulutusvaatimustoinenaste_1",
+                "kuvaus": "pohjakoulutusvaatimustoinenaste_1",
+                "lyhytNimi": "pohjakoulutusvaatimustoinenaste_1",
+                "kieli": "en"
+              }
+            ]
+          },
+          {
+            "koodiUri": "pohjakoulutusvaatimustoinenaste_2",
+            "resourceUri": "https://virkailija.hahtuvaopintopolku.fi/koodisto-service/rest/codeelement/pohjakoulutusvaatimustoinenaste_11",
+            "version": 1,
+            "versio": 1,
+            "koodisto": {
+              "koodistoUri": "pohjakoulutusvaatimustoinenaste",
+              "organisaatioOid": "1.2.246.562.10.00000000001",
+              "koodistoVersios": [
+                1
+              ]
+            },
+            "koodiArvo": "2",
+            "paivitysPvm": 1427461978048,
+            "voimassaAlkuPvm": "2000-01-01",
+            "voimassaLoppuPvm": null,
+            "tila": "LUONNOS",
+            "metadata": [
+              {
+                "nimi": "pohjakoulutusvaatimustoinenaste_2",
+                "kuvaus": "pohjakoulutusvaatimustoinenaste_2",
+                "lyhytNimi": "pohjakoulutusvaatimustoinenaste_2",
+                "kieli": "fi"
+              },
+              {
+                "nimi": "pohjakoulutusvaatimustoinenaste_2",
+                "kuvaus": "pohjakoulutusvaatimustoinenaste_2",
+                "lyhytNimi": "pohjakoulutusvaatimustoinenaste_2",
+                "kieli": "sv"
+              },
+              {
+                "nimi": "pohjakoulutusvaatimustoinenaste_2",
+                "kuvaus": "pohjakoulutusvaatimustoinenaste_2",
+                "lyhytNimi": "pohjakoulutusvaatimustoinenaste_2",
+                "kieli": "en"
+              }
+            ]
+          },
+          {
+            "koodiUri": "pohjakoulutusvaatimustoinenaste_3",
+            "resourceUri": "https://virkailija.hahtuvaopintopolku.fi/koodisto-service/rest/codeelement/pohjakoulutusvaatimustoinenaste_11",
+            "version": 1,
+            "versio": 1,
+            "koodisto": {
+              "koodistoUri": "pohjakoulutusvaatimustoinenaste",
+              "organisaatioOid": "1.2.246.562.10.00000000001",
+              "koodistoVersios": [
+                1
+              ]
+            },
+            "koodiArvo": "3",
+            "paivitysPvm": 1427461978048,
+            "voimassaAlkuPvm": "2000-01-01",
+            "voimassaLoppuPvm": null,
+            "tila": "LUONNOS",
+            "metadata": [
+              {
+                "nimi": "pohjakoulutusvaatimustoinenaste_3",
+                "kuvaus": "pohjakoulutusvaatimustoinenaste_3",
+                "lyhytNimi": "pohjakoulutusvaatimustoinenaste_3",
+                "kieli": "fi"
+              },
+              {
+                "nimi": "pohjakoulutusvaatimustoinenaste_3",
+                "kuvaus": "pohjakoulutusvaatimustoinenaste_3",
+                "lyhytNimi": "pohjakoulutusvaatimustoinenaste_3",
+                "kieli": "sv"
+              },
+              {
+                "nimi": "pohjakoulutusvaatimustoinenaste_3",
+                "kuvaus": "pohjakoulutusvaatimustoinenaste_3",
+                "lyhytNimi": "pohjakoulutusvaatimustoinenaste_3",
+                "kieli": "en"
+              }
+            ]
+          },
+          {
+            "koodiUri": "pohjakoulutusvaatimustoinenaste_4",
+            "resourceUri": "https://virkailija.hahtuvaopintopolku.fi/koodisto-service/rest/codeelement/pohjakoulutusvaatimustoinenaste_11",
+            "version": 1,
+            "versio": 1,
+            "koodisto": {
+              "koodistoUri": "pohjakoulutusvaatimustoinenaste",
+              "organisaatioOid": "1.2.246.562.10.00000000001",
+              "koodistoVersios": [
+                1
+              ]
+            },
+            "koodiArvo": "4",
+            "paivitysPvm": 1427461978048,
+            "voimassaAlkuPvm": "2000-01-01",
+            "voimassaLoppuPvm": null,
+            "tila": "LUONNOS",
+            "metadata": [
+              {
+                "nimi": "pohjakoulutusvaatimustoinenaste_4",
+                "kuvaus": "pohjakoulutusvaatimustoinenaste_4",
+                "lyhytNimi": "pohjakoulutusvaatimustoinenaste_4",
+                "kieli": "fi"
+              },
+              {
+                "nimi": "pohjakoulutusvaatimustoinenaste_4",
+                "kuvaus": "pohjakoulutusvaatimustoinenaste_4",
+                "lyhytNimi": "pohjakoulutusvaatimustoinenaste_4",
+                "kieli": "sv"
+              },
+              {
+                "nimi": "pohjakoulutusvaatimustoinenaste_4",
+                "kuvaus": "pohjakoulutusvaatimustoinenaste_4",
+                "lyhytNimi": "pohjakoulutusvaatimustoinenaste_4",
+                "kieli": "en"
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "url": "https://localhost:3000/koodisto-service/rest/json/kausi/koodi?onlyValidKoodis=true&koodistoVersio=",
+        "method": "GET",
+        "status": 200,
+        "headers": {},
+        "body": null,
+        "response": [
+          {
+            "koodiUri": "kausi_0",
+            "resourceUri": "https://virkailija.hahtuvaopintopolku.fi/koodisto-service/rest/codeelement/kausi_11",
+            "version": 1,
+            "versio": 1,
+            "koodisto": {
+              "koodistoUri": "kausi",
+              "organisaatioOid": "1.2.246.562.10.00000000001",
+              "koodistoVersios": [
+                1
+              ]
+            },
+            "koodiArvo": "0",
+            "paivitysPvm": 1427461978048,
+            "voimassaAlkuPvm": "2000-01-01",
+            "voimassaLoppuPvm": null,
+            "tila": "LUONNOS",
+            "metadata": [
+              {
+                "nimi": "kausi_0",
+                "kuvaus": "kausi_0",
+                "lyhytNimi": "kausi_0",
+                "kieli": "fi"
+              },
+              {
+                "nimi": "kausi_0",
+                "kuvaus": "kausi_0",
+                "lyhytNimi": "kausi_0",
+                "kieli": "sv"
+              },
+              {
+                "nimi": "kausi_0",
+                "kuvaus": "kausi_0",
+                "lyhytNimi": "kausi_0",
+                "kieli": "en"
+              }
+            ]
+          },
+          {
+            "koodiUri": "kausi_1",
+            "resourceUri": "https://virkailija.hahtuvaopintopolku.fi/koodisto-service/rest/codeelement/kausi_11",
+            "version": 1,
+            "versio": 1,
+            "koodisto": {
+              "koodistoUri": "kausi",
+              "organisaatioOid": "1.2.246.562.10.00000000001",
+              "koodistoVersios": [
+                1
+              ]
+            },
+            "koodiArvo": "1",
+            "paivitysPvm": 1427461978048,
+            "voimassaAlkuPvm": "2000-01-01",
+            "voimassaLoppuPvm": null,
+            "tila": "LUONNOS",
+            "metadata": [
+              {
+                "nimi": "kausi_1",
+                "kuvaus": "kausi_1",
+                "lyhytNimi": "kausi_1",
+                "kieli": "fi"
+              },
+              {
+                "nimi": "kausi_1",
+                "kuvaus": "kausi_1",
+                "lyhytNimi": "kausi_1",
+                "kieli": "sv"
+              },
+              {
+                "nimi": "kausi_1",
+                "kuvaus": "kausi_1",
+                "lyhytNimi": "kausi_1",
+                "kieli": "en"
+              }
+            ]
+          },
+          {
+            "koodiUri": "kausi_2",
+            "resourceUri": "https://virkailija.hahtuvaopintopolku.fi/koodisto-service/rest/codeelement/kausi_11",
+            "version": 1,
+            "versio": 1,
+            "koodisto": {
+              "koodistoUri": "kausi",
+              "organisaatioOid": "1.2.246.562.10.00000000001",
+              "koodistoVersios": [
+                1
+              ]
+            },
+            "koodiArvo": "2",
+            "paivitysPvm": 1427461978048,
+            "voimassaAlkuPvm": "2000-01-01",
+            "voimassaLoppuPvm": null,
+            "tila": "LUONNOS",
+            "metadata": [
+              {
+                "nimi": "kausi_2",
+                "kuvaus": "kausi_2",
+                "lyhytNimi": "kausi_2",
+                "kieli": "fi"
+              },
+              {
+                "nimi": "kausi_2",
+                "kuvaus": "kausi_2",
+                "lyhytNimi": "kausi_2",
+                "kieli": "sv"
+              },
+              {
+                "nimi": "kausi_2",
+                "kuvaus": "kausi_2",
+                "lyhytNimi": "kausi_2",
+                "kieli": "en"
+              }
+            ]
+          },
+          {
+            "koodiUri": "kausi_3",
+            "resourceUri": "https://virkailija.hahtuvaopintopolku.fi/koodisto-service/rest/codeelement/kausi_11",
+            "version": 1,
+            "versio": 1,
+            "koodisto": {
+              "koodistoUri": "kausi",
+              "organisaatioOid": "1.2.246.562.10.00000000001",
+              "koodistoVersios": [
+                1
+              ]
+            },
+            "koodiArvo": "3",
+            "paivitysPvm": 1427461978048,
+            "voimassaAlkuPvm": "2000-01-01",
+            "voimassaLoppuPvm": null,
+            "tila": "LUONNOS",
+            "metadata": [
+              {
+                "nimi": "kausi_3",
+                "kuvaus": "kausi_3",
+                "lyhytNimi": "kausi_3",
+                "kieli": "fi"
+              },
+              {
+                "nimi": "kausi_3",
+                "kuvaus": "kausi_3",
+                "lyhytNimi": "kausi_3",
+                "kieli": "sv"
+              },
+              {
+                "nimi": "kausi_3",
+                "kuvaus": "kausi_3",
+                "lyhytNimi": "kausi_3",
+                "kieli": "en"
+              }
+            ]
+          },
+          {
+            "koodiUri": "kausi_4",
+            "resourceUri": "https://virkailija.hahtuvaopintopolku.fi/koodisto-service/rest/codeelement/kausi_11",
+            "version": 1,
+            "versio": 1,
+            "koodisto": {
+              "koodistoUri": "kausi",
+              "organisaatioOid": "1.2.246.562.10.00000000001",
+              "koodistoVersios": [
+                1
+              ]
+            },
+            "koodiArvo": "4",
+            "paivitysPvm": 1427461978048,
+            "voimassaAlkuPvm": "2000-01-01",
+            "voimassaLoppuPvm": null,
+            "tila": "LUONNOS",
+            "metadata": [
+              {
+                "nimi": "kausi_4",
+                "kuvaus": "kausi_4",
+                "lyhytNimi": "kausi_4",
+                "kieli": "fi"
+              },
+              {
+                "nimi": "kausi_4",
+                "kuvaus": "kausi_4",
+                "lyhytNimi": "kausi_4",
+                "kieli": "sv"
+              },
+              {
+                "nimi": "kausi_4",
+                "kuvaus": "kausi_4",
+                "lyhytNimi": "kausi_4",
+                "kieli": "en"
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "url": "https://localhost:3000/koodisto-service/rest/json/liitetyypitamm/koodi?onlyValidKoodis=true&koodistoVersio=",
+        "method": "GET",
+        "status": 200,
+        "headers": {},
+        "body": null,
+        "response": [
+          {
+            "koodiUri": "liitetyypitamm_0",
+            "resourceUri": "https://virkailija.hahtuvaopintopolku.fi/koodisto-service/rest/codeelement/liitetyypitamm_11",
+            "version": 1,
+            "versio": 1,
+            "koodisto": {
+              "koodistoUri": "liitetyypitamm",
+              "organisaatioOid": "1.2.246.562.10.00000000001",
+              "koodistoVersios": [
+                1
+              ]
+            },
+            "koodiArvo": "0",
+            "paivitysPvm": 1427461978048,
+            "voimassaAlkuPvm": "2000-01-01",
+            "voimassaLoppuPvm": null,
+            "tila": "LUONNOS",
+            "metadata": [
+              {
+                "nimi": "liitetyypitamm_0",
+                "kuvaus": "liitetyypitamm_0",
+                "lyhytNimi": "liitetyypitamm_0",
+                "kieli": "fi"
+              },
+              {
+                "nimi": "liitetyypitamm_0",
+                "kuvaus": "liitetyypitamm_0",
+                "lyhytNimi": "liitetyypitamm_0",
+                "kieli": "sv"
+              },
+              {
+                "nimi": "liitetyypitamm_0",
+                "kuvaus": "liitetyypitamm_0",
+                "lyhytNimi": "liitetyypitamm_0",
+                "kieli": "en"
+              }
+            ]
+          },
+          {
+            "koodiUri": "liitetyypitamm_1",
+            "resourceUri": "https://virkailija.hahtuvaopintopolku.fi/koodisto-service/rest/codeelement/liitetyypitamm_11",
+            "version": 1,
+            "versio": 1,
+            "koodisto": {
+              "koodistoUri": "liitetyypitamm",
+              "organisaatioOid": "1.2.246.562.10.00000000001",
+              "koodistoVersios": [
+                1
+              ]
+            },
+            "koodiArvo": "1",
+            "paivitysPvm": 1427461978048,
+            "voimassaAlkuPvm": "2000-01-01",
+            "voimassaLoppuPvm": null,
+            "tila": "LUONNOS",
+            "metadata": [
+              {
+                "nimi": "liitetyypitamm_1",
+                "kuvaus": "liitetyypitamm_1",
+                "lyhytNimi": "liitetyypitamm_1",
+                "kieli": "fi"
+              },
+              {
+                "nimi": "liitetyypitamm_1",
+                "kuvaus": "liitetyypitamm_1",
+                "lyhytNimi": "liitetyypitamm_1",
+                "kieli": "sv"
+              },
+              {
+                "nimi": "liitetyypitamm_1",
+                "kuvaus": "liitetyypitamm_1",
+                "lyhytNimi": "liitetyypitamm_1",
+                "kieli": "en"
+              }
+            ]
+          },
+          {
+            "koodiUri": "liitetyypitamm_2",
+            "resourceUri": "https://virkailija.hahtuvaopintopolku.fi/koodisto-service/rest/codeelement/liitetyypitamm_11",
+            "version": 1,
+            "versio": 1,
+            "koodisto": {
+              "koodistoUri": "liitetyypitamm",
+              "organisaatioOid": "1.2.246.562.10.00000000001",
+              "koodistoVersios": [
+                1
+              ]
+            },
+            "koodiArvo": "2",
+            "paivitysPvm": 1427461978048,
+            "voimassaAlkuPvm": "2000-01-01",
+            "voimassaLoppuPvm": null,
+            "tila": "LUONNOS",
+            "metadata": [
+              {
+                "nimi": "liitetyypitamm_2",
+                "kuvaus": "liitetyypitamm_2",
+                "lyhytNimi": "liitetyypitamm_2",
+                "kieli": "fi"
+              },
+              {
+                "nimi": "liitetyypitamm_2",
+                "kuvaus": "liitetyypitamm_2",
+                "lyhytNimi": "liitetyypitamm_2",
+                "kieli": "sv"
+              },
+              {
+                "nimi": "liitetyypitamm_2",
+                "kuvaus": "liitetyypitamm_2",
+                "lyhytNimi": "liitetyypitamm_2",
+                "kieli": "en"
+              }
+            ]
+          },
+          {
+            "koodiUri": "liitetyypitamm_3",
+            "resourceUri": "https://virkailija.hahtuvaopintopolku.fi/koodisto-service/rest/codeelement/liitetyypitamm_11",
+            "version": 1,
+            "versio": 1,
+            "koodisto": {
+              "koodistoUri": "liitetyypitamm",
+              "organisaatioOid": "1.2.246.562.10.00000000001",
+              "koodistoVersios": [
+                1
+              ]
+            },
+            "koodiArvo": "3",
+            "paivitysPvm": 1427461978048,
+            "voimassaAlkuPvm": "2000-01-01",
+            "voimassaLoppuPvm": null,
+            "tila": "LUONNOS",
+            "metadata": [
+              {
+                "nimi": "liitetyypitamm_3",
+                "kuvaus": "liitetyypitamm_3",
+                "lyhytNimi": "liitetyypitamm_3",
+                "kieli": "fi"
+              },
+              {
+                "nimi": "liitetyypitamm_3",
+                "kuvaus": "liitetyypitamm_3",
+                "lyhytNimi": "liitetyypitamm_3",
+                "kieli": "sv"
+              },
+              {
+                "nimi": "liitetyypitamm_3",
+                "kuvaus": "liitetyypitamm_3",
+                "lyhytNimi": "liitetyypitamm_3",
+                "kieli": "en"
+              }
+            ]
+          },
+          {
+            "koodiUri": "liitetyypitamm_4",
+            "resourceUri": "https://virkailija.hahtuvaopintopolku.fi/koodisto-service/rest/codeelement/liitetyypitamm_11",
+            "version": 1,
+            "versio": 1,
+            "koodisto": {
+              "koodistoUri": "liitetyypitamm",
+              "organisaatioOid": "1.2.246.562.10.00000000001",
+              "koodistoVersios": [
+                1
+              ]
+            },
+            "koodiArvo": "4",
+            "paivitysPvm": 1427461978048,
+            "voimassaAlkuPvm": "2000-01-01",
+            "voimassaLoppuPvm": null,
+            "tila": "LUONNOS",
+            "metadata": [
+              {
+                "nimi": "liitetyypitamm_4",
+                "kuvaus": "liitetyypitamm_4",
+                "lyhytNimi": "liitetyypitamm_4",
+                "kieli": "fi"
+              },
+              {
+                "nimi": "liitetyypitamm_4",
+                "kuvaus": "liitetyypitamm_4",
+                "lyhytNimi": "liitetyypitamm_4",
+                "kieli": "sv"
+              },
+              {
+                "nimi": "liitetyypitamm_4",
+                "kuvaus": "liitetyypitamm_4",
+                "lyhytNimi": "liitetyypitamm_4",
+                "kieli": "en"
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "url": "https://localhost:3000/organisaatio-service/rest/organisaatio/v4/findbyoids",
+        "method": "POST",
+        "status": 200,
+        "headers": {},
+        "body": [
+          "1.2.246.562.10.52251087186"
+        ],
+        "response": [
+          {
+            "metadata": {
+              "nimi": {},
+              "hakutoimistoEctsNimi": {},
+              "hakutoimistoEctsEmail": {},
+              "hakutoimistoEctsPuhelin": {},
+              "hakutoimistoEctsTehtavanimike": {},
+              "yhteystiedot": [
+                {
+                  "kieli": "kieli_fi#1",
+                  "www": "http://www.stadinammattiopisto.fi",
+                  "yhteystietoOid": "14812023190550.9836378324069386",
+                  "id": "3861227"
+                },
+                {
+                  "kieli": "kieli_fi#1",
+                  "numero": "09 310 89318",
+                  "tyyppi": "puhelin",
+                  "yhteystietoOid": "1.2.246.562.5.62477770688",
+                  "id": "3861228"
+                },
+                {
+                  "kieli": "kieli_fi#1",
+                  "yhteystietoOid": "14303205263410.7259206293670477",
+                  "id": "3861229",
+                  "email": "hakutoimisto@edu.hel.fi"
+                },
+                {
+                  "osoiteTyyppi": "posti",
+                  "kieli": "kieli_fi#1",
+                  "postinumeroUri": "posti_00099",
+                  "yhteystietoOid": "1.2.246.562.5.20277448420",
+                  "id": "3861230",
+                  "postitoimipaikka": "HELSINGIN KAUPUNKI",
+                  "osoite": "PL 55306"
+                },
+                {
+                  "osoiteTyyppi": "kaynti",
+                  "kieli": "kieli_fi#1",
+                  "postinumeroUri": "posti_00550",
+                  "yhteystietoOid": "1.2.246.562.5.26047810076",
+                  "id": "3861231",
+                  "postitoimipaikka": "HELSINKI",
+                  "osoite": "Hattulantie 2, 1. krs"
+                }
+              ],
+              "hakutoimistonNimi": {
+                "kieli_fi#1": "Stadin ammatti- ja aikuisopiston hakutoimisto"
+              },
+              "luontiPvm": 1376895579333,
+              "muokkausPvm": 1376859600000,
+              "data": {
+                "KANSAINVALISET_KOULUTUSOHJELMAT": {},
+                "YLEISKUVAUS": {
+                  "kieli_fi#1": "<p>Stadin ammatti- ja aikuisopisto järjestää ammatillista peruskoulutusta, ammatillista täydennyskoulutusta, oppisopimuskoulutusta ja nivelvaiheen koulutusta Helsingin kaupungin alueella 15 eri toimipaikassa. Meillä Suomen suurimmassa ammattiopistossa opiskelee noin 17 000 nuorta ja aikuista yli 50 eri ammattiin.</p> <p>Kun suoritat ammatillisen koulutuksen, saat laaja-alaiset valmiudet toimia oman alasi erilaisissa ja vaihtelevissa työtehtävissä sekä kehittää ammattitaitoasi läpi elämän. Lisäksi ammatillinen perustutkinto antaa sinulle yleisen jatko-opintokelpoisuuden ammattikorkeakouluihin ja yliopistoihin.</p> <p>Stadin ammatti- ja aikuisopistossa voit opiskella joustavasti eri oppimisratkaisuin. Opintojen suunnittelussa huomioidaan aina opiskelijan aiempi osaaminen esimerkiksi yhdistämällä oppilaitosmuotoista opiskelua ja oppisopimuskoulutusta. Lisäksi ammatilliseen perustutkintoon johtavassa koulutuksessa on mahdollista suorittaa lukio-opintoja sekä hakea ohjattuun urheiluvalmennukseen.</p> <p>Stadin ammatti- ja aikuisopiston Brygga tarjoaa nivelvaiheen koulutusta ja palveluja. Siihen kuuluvat ammatilliseen koulutukseen valmentava koulutus (VALMA), osa kaupungin perusopetuksen lisäopetuksesta (kymppiluokat), avoimet opinnot ja nuorten työpajatoiminta. Stadin osaamiskeskus puolestaan yhdistää kuntoutuksen, koulutuksen ja työllistymisen palvelut helsinkiläisille aikuisille maahanmuuttajille.</p> <p>Lisätietoa Stadin ammatti- ja aikuisopiston koulutustarjonnasta löytyy nettisivuiltamme www.stadinammattiopisto.fi</p> <p> </p>"
+                },
+                "KIELIOPINNOT": {
+                  "kieli_fi#1": "<p>Kaikkiin perustutkintoihin kuuluu vähintään 2 osaamispistettä englantia (A-kieli) ja 1 osaamispistettä ruotsia. Lisäksi joissain toimipaikoissa voit valinnaisissa opinnoissa opiskella ylimääräisiä kieliä.</p>"
+                },
+                "TERVEYDENHUOLTOPALVELUT": {
+                  "kieli_fi#1": "<p>Stadin ammatti- ja aikuisopistossa on sekä terveydenhoitajia että lääkäreitä opiskelijoita varten. Ensimmäisenä opiskeluvuonna terveydenhoitaja kutsuu sinut terveystarkastukseen, jossa selvitetään opiskelun tai ammatissa toimimisen kannalta tärkeät seikat. Lääkärin vastaanotolle haetaan terveydenhoitajan kautta.</p> <p>Oppilaitoksessa ei ole hammashoitolaa. Opiskelijat käyttävät oman asuinalueensa terveysaseman palveluita.</p>"
+                },
+                "TEHTAVANIMIKE": {},
+                "SAHKOPOSTIOSOITE": {},
+                "RAHOITUS": {},
+                "AIEMMIN_HANKITTU_OSAAMINEN": {
+                  "kieli_fi#1": "<p>Osaamisen tunnistaminen ja tunnustaminen</p> <p>Ennalta hankittu osaaminen, kuten aiemmin suoritetut opinnot tai työkokemus, voidaan sisällyttää osaksi ammatillista tutkintoasi, mikäli osaamisesi on opetussuunnitelman mukaista. Tällöin opiskeluaikasi mahdollisesti lyhenee ja valmistut aikaisemmin.</p> <p>Osaamisen tunnistamista ja tunnustamista haetaan lomakkeella, jonka saat opettajaltasi tai opinto-ohjaajaltasi. He myös ohjaavat sen täyttämisessä.</p> <p>Opinnoista vapauttaminen</p> <p>Ruotsin kielestä voit anoa vapautusta, jos et ole opiskellut ruotsia aiemmin. Vapautusta haetaan lomakkeella, jonka saat opettajaltasi tai opinto-ohjaajaltasi. Ruotsin sijasta opiskelet jonkin muun sovitun opinnon.</p>"
+                },
+                "sosiaalinenmedia_7#1": {},
+                "sosiaalinenmedia_5#1": {
+                  "kieli_fi#1": "http://www.pinterest.com/StadinAO"
+                },
+                "sosiaalinenmedia_6#1": {
+                  "kieli_fi#1": "http://www.instagram.com/stadinao"
+                },
+                "OPISKELIJALIIKKUVUUS": {
+                  "kieli_fi#1": "<p>Kansainvälisyys on osa Stadin ammatti- ja aikuisopiston arkea. Tarjoamme opiskelijalle mahdollisuuden lisätä kansainvälisyysosaamista opintojen aikana.  Kotikansainvälistymistä edistetään tarjoamalla kieliin ja kulttuuriin liittyviä oppimistilanteita, virtuaaliliikkuvuutta ja taitaja-toimintaa.</p> <p>Stadin ammatti- ja aikuisopistosta voi lähteä työssäoppimisjaksolle ulkomaille. Kansainväliset vaihdot täydentävät opiskelijoiden työelämävalmiuksia ammatillisen osaamisen, kielitaidon ja kulttuurien tuntemisen kautta sekä tukevat opiskelijan itsenäisyyttä, avoimuutta ja rohkeutta.</p> <p>Ulkomaanjaksoja voi suorittaa mm. Pohjoismaissa, Iso-Britanniassa, Hollannissa, Saksassa, Ranskassa, Espanjassa, Irlannissa, Virossa, Sloveniassa, Itävallassa, Venäjällä ja Kiinassa. Ulkomaanjaksolle lähdetään toisena tai kolmantena opintovuotena.</p>"
+                },
+                "VAKUUTUKSET": {
+                  "kieli_fi#1": "<p>Kaikki opiskelijat on vakuutettu opiskelun aikana sattuneiden tapaturmien varalta. Tapaturma korvataan, jos se on sattunut oppitunnilla, työssäoppimisen aikana, opintokäynneillä tai koulumatkalla. Koulumatkalla vakuutus on voimassa vain, mikäli matka on tapahtunut viivytyksettä ja suorinta, tavanomaista tietä.</p> <p>Vakuutus on voimassa myös ulkomaille suuntautuvien opintomatkojen ja työssäoppimisjaksojen aikana. Oppilaitoksen vakuutukset eivät kuitenkaan ole voimassa, jos olet sairauslomalla. Pidempien sairauslomien ajaksi opinnot yleensä keskeytetään väliaikaisesti.</p>"
+                },
+                "OPISKELIJA_JARJESTOT": {
+                  "kieli_fi#1": "<p>Opiskelijakuntatoiminta ja opiskelijayhdistys STAO ry</p> <p>Jokainen opiskelija kuuluu oman toimipaikkansa opiskelijakuntaan. Kustakin toimipaikasta valitaan lukuvuoden alussa opiskelijakunnan hallitus, jonka tehtävänä on tuoda opiskelijoiden ääni kuuluviin omassa toimipaikassa.</p> <p>STAO ry (Stadin ammattiin opiskelevat) on Stadin ammattiopiston opiskelijayhdistys, johon jokainen opiskelija voi liittyä. Yhdistys edistää opiskelijoiden toimintaa, osallistumista ja hyvinvointia koko oppilaitoksessa.</p>"
+                },
+                "VALINTAMENETTELY": {
+                  "kieli_fi#1": "<p>Kevään yhteishaussa hakevat peruskoulunsa päättävät, ylioppilaat ja muut ilman toisen asteen ammatillista tutkintoa olevat (valintamenettelyssä noudatetaan Oph:n antamia ohjeita). Kaikki muut hakevat jatkuvassa haussa (oppilaitoksen oma valintamenettely, hakija saa valintapäätöksen kolmen viikon kuluessa hakemisesta).</p>"
+                },
+                "sosiaalinenmedia_3#1": {},
+                "sosiaalinenmedia_4#1": {
+                  "kieli_fi#1": "http://www.twitter.com/stadinao"
+                },
+                "sosiaalinenmedia_1#1": {
+                  "kieli_fi#1": "http://www.facebook.com/stadinammattiopisto"
+                },
+                "VASTUUHENKILOT": {},
+                "KUSTANNUKSET": {
+                  "kieli_fi#1": "<p>Opintojensa aikana opiskelijat hankkivat itse esimerkiksi oppikirjoja, kansioita, muistiinpanovälineitä sekä henkilökohtaisia työvälineitä. Osassa tutkinnoista työvaatteet ja -kengät saa oppilaitoksen puolesta.</p>"
+                },
+                "OPPIMISYMPARISTO": {
+                  "kieli_fi#1": "<p>Stadin ammatti- ja aikuisopiston kaikki toimipaikat sijaitsevat Helsingin kaupungin alueella. Toimipaikkojen oppimisympäristöjä uudistetaan monimuotoisiksi ja viihtyisiksi, jolloin ne tukevat opiskelijakeskeistä ja työelämälähtöistä pedagogiikkaa. Opiskelijoiden ja opettajien käytettävissä on mm. kattava, digitaalisuuden hyödyntämistä tukeva wifi.</p>"
+                },
+                "sosiaalinenmedia_2#1": {},
+                "PUHELINNUMERO": {},
+                "NIMI": {},
+                "OPISKELIJALIIKUNTA": {},
+                "VUOSIKELLO": {},
+                "OPISKELIJARUOKAILU": {
+                  "kieli_fi#1": "<p>Stadin ammatti- ja aikuisopistossa on kaikissa toimipaikoissa opiskelijaravintola ja kahvila. Opiskelijoille on koulupäivinä tarjolla yksi maksuton lounasateria. Tarjolla on joka päivä myös kasvislounasvaihtoehto.</p>"
+                },
+                "VAPAA_AIKA": {},
+                "ESTEETOMYYS": {
+                  "kieli_fi#1": "<p>Stadin ammatti- ja aikuisopisto on kaikille yhteinen oppilaitos, jossa jokainen pystyy ominaisuuksistaan riippumatta toimimaan yhdenvertaisesti muiden kanssa, jolloin opiskeluympäristössä ei pitäisi olla liikkumiseen, ryhmään kuulumiseen tai oppimiseen liittyviä esteitä.</p> <p><em> </em></p> <p><em>Opiskeluhuolto</em></p> <p>Opiskeluhuollon tavoitteena on edistää oppimistasi, terveyttäsi ja hyvinvointiasi opiskelun aikana. Opiskelijahuolto huolehtii myös oppilaitosyhteisön hyvinvoinnista sekä opiskeluympäristön terveellisyydestä ja turvallisuudesta. Opiskeluhuoltoa toteutetaan sekä yhteisöllisenä että yksilökohtaisena opiskeluhuoltona.</p> <p><em> </em></p> <p><em>Yhteisöllinen opiskeluhuolto</em></p> <p>Yhteisöllinen opiskeluhuolto edistää opiskelijoiden osallisuutta, oppimista, hyvinvointia ja terveyttä. Lisäksi se seuraa ja kehittää opiskeluyhteisön hyvinvointia sekä opiskeluympäristön terveellisyyttä, turvallisuutta ja esteettömyyttä. Toimipaikan hyvinvointiryhmä vastaa opiskeluhuollon suunnittelusta, kehittämisestä ja arvioinnista yhteisöllisen opiskeluhuollon osa-alueet huomioon ottaen. Ryhmää johtaa apulaisrehtori tai koulutuspäällikkö. Opetushenkilöstön lisäksi ryhmään kuuluu erityisopettaja, opinto-ohjaaja, kuraattori, psykologi, terveydenhoitaja ja opiskelijajäseniä. Ryhmään voi kuulua myös huoltajien edustaja.</p> <p><em> </em></p> <p><em>Yksilökohtainen opiskelijahuolto</em></p> <p>Yksilökohtaisella opiskelijahuollolla tarkoitetaan opiskelijan käytössä olevia palveluja, joita ovat • opiskeluterveydenhuolto • opiskeluhuollon psykologi- ja kuraattoripalvelut • yksittäistä opiskelijaa koskeva monialainen opiskeluhuolto, jota toteutetaan tapauskohtaisesti koottavassa monialaisessa asiantuntijaryhmässä. Yksilökohtaista opiskeluhuoltoa tehdään yhteistyössä opiskelijan kanssa ja hänen suostumuksellaan.</p> <p><em> </em></p> <p><em>Kun tarvitset tukea opinnoissasi</em></p> <p>Opintojesi alussa kanssasi tehdään henkilökohtainen osaamisen kehittämisen suunnitelma (HOKS). Suunnitelmaan kirjataan aiemmin hankittu ja osoitettu osaaminen, tarvittava ammattitaidon ja osaamisen hankkiminen, osaamisen osoittaminen sekä ohjaus- ja tukitoimet. Jos tarvitset erityistä tukea, suunnitelmassa sovitaan sinulle tarjottavan erityisen tuen sisällöstä ja erityisen tuen tarpeen mukaisista toimenpiteistä osaamisen hankkimisen aikana. Erityistä tukea voi saada kaikissa ammatilliseen perustutkintoon johtavissa koulutuksissa.</p>"
+                },
+                "TIETOA_ASUMISESTA": {
+                  "kieli_fi#1": "<p>Stadin ammatti- ja aikuisopistolla ei ole asuntolaa. Tutkintoon johtavassa koulutuksessa oleva opiskelija voi hakea opiskelija-asuntoa esim. HOAS:lta.</p>"
+                },
+                "TYOHARJOITTELU": {
+                  "kieli_fi#1": "<p>Kaikkiin perustutkintoihin kuuluu vähintään 30 osaamispistettä, n. kuusi kuukautta, työssäoppimista. Työssäoppiminen suoritetaan pääasiassa työpaikoilla ja työelämälähtöisissä oppimisympäristöissä.</p>"
+                }
+              }
+            },
+            "oid": "1.2.246.562.10.52251087186",
+            "nimi": {
+              "fi": "Stadin ammatti- ja aikuisopisto",
+              "sv": "Stadin ammatti- ja aikuisopisto",
+              "en": "Stadin ammatti- ja aikuisopisto"
+            },
+            "alkuPvm": "2013-01-01",
+            "oppilaitosKoodi": "10105",
+            "ryhmatyypit": [],
+            "kayttoryhmat": [],
+            "piilotettu": false,
+            "parentOid": "1.2.246.562.10.346830761110",
+            "postiosoite": {
+              "postinumeroUri": "posti_00099",
+              "osoiteTyyppi": "posti",
+              "yhteystietoOid": "1.2.246.562.5.69596457015",
+              "postitoimipaikka": "HELSINGIN KAUPUNKI",
+              "osoite": "PL 55308"
+            },
+            "kuvaus2": {},
+            "tyypit": [
+              "organisaatiotyyppi_02"
+            ],
+            "yhteystietoArvos": [
+              {
+                "YhteystietoArvo.arvoText": "stadiprimus@edu.hel.fi",
+                "YhteystietojenTyyppi.nimi.fi": "KOSKI-palvelun omien tietojen virheilmoituksen sähköpostiosoite",
+                "YhteystietojenTyyppi.nimi.sv": "E-postadress för felanmälan i egna uppgifter i KOSKI-tjänsten",
+                "YhteystietoElementti.tyyppi": "Email",
+                "YhteystietojenTyyppi.oid": "1.2.246.562.5.79385887983",
+                "YhteystietoElementti.oid": "1.2.246.562.5.57850489428",
+                "YhteystietoElementti.nimi": "Sähköpostiosoite",
+                "YhteystietoElementti.nimiSv": "Epostadress",
+                "YhteystietoElementti.pakollinen": "false",
+                "YhteystietojenTyyppi.nimi.en": "KOSKI-palvelun omien tietojen virheilmoituksen sähköpostiosoite",
+                "YhteystietoElementti.kaytossa": "true",
+                "YhteystietoArvo.kieli": "kieli_fi#1"
+              }
+            ],
+            "yhteystiedot": [
+              {
+                "osoiteTyyppi": "posti",
+                "kieli": "kieli_fi#1",
+                "postinumeroUri": "posti_00099",
+                "yhteystietoOid": "1.2.246.562.5.69596457015",
+                "id": "3861240",
+                "postitoimipaikka": "HELSINGIN KAUPUNKI",
+                "osoite": "PL 55308"
+              },
+              {
+                "kieli": "kieli_fi#1",
+                "yhteystietoOid": "14931031965550.42925150233306597",
+                "id": "3861238",
+                "email": "hakutoimisto@edu.hel.fi"
+              },
+              {
+                "osoiteTyyppi": "kaynti",
+                "kieli": "kieli_fi#1",
+                "postinumeroUri": "posti_00550",
+                "yhteystietoOid": "1.2.246.562.5.32847643825",
+                "id": "3861237",
+                "postitoimipaikka": "HELSINKI",
+                "osoite": "Hattulantie 2"
+              },
+              {
+                "kieli": "kieli_fi#1",
+                "numero": "09 310 8415",
+                "tyyppi": "puhelin",
+                "yhteystietoOid": "1.2.246.562.5.90059839549",
+                "id": "3861236"
+              },
+              {
+                "kieli": "kieli_fi#1",
+                "www": "http://www.stadinammattiopisto.fi",
+                "yhteystietoOid": "1.2.246.562.5.38465214716",
+                "id": "3861239"
+              }
+            ],
+            "nimet": [
+              {
+                "nimi": {
+                  "fi": "Stadin ammattiopisto"
+                },
+                "alkuPvm": "2013-01-01",
+                "version": 1
+              },
+              {
+                "nimi": {
+                  "fi": "Stadin ammatti- ja aikuisopisto",
+                  "sv": "Stadin ammatti- ja aikuisopisto",
+                  "en": "Stadin ammatti- ja aikuisopisto"
+                },
+                "alkuPvm": "2018-12-31",
+                "version": 0
+              }
+            ],
+            "vuosiluokat": [],
+            "parentOidPath": "|1.2.246.562.10.00000000001|1.2.246.562.10.346830761110|",
+            "toimipistekoodi": "10105",
+            "kotipaikkaUri": "kunta_091",
+            "kieletUris": [
+              "oppilaitoksenopetuskieli_1#1"
+            ],
+            "maaUri": "maatjavaltiot1_fin",
+            "oppilaitosTyyppiUri": "oppilaitostyyppi_21#1",
+            "muutKotipaikatUris": [],
+            "kayntiosoite": {
+              "postinumeroUri": "posti_00550",
+              "osoiteTyyppi": "kaynti",
+              "yhteystietoOid": "1.2.246.562.5.32847643825",
+              "postitoimipaikka": "HELSINKI",
+              "osoite": "Hattulantie 2"
+            },
+            "lisatiedot": [],
+            "muutOppilaitosTyyppiUris": [],
+            "version": 89,
+            "status": "AKTIIVINEN"
+          }
+        ]
+      },
+      {
+        "url": "https://localhost:3000/organisaatio-service/rest/organisaatio/v4/hierarkia/hae?oid=1.2.246.562.10.52251087186&aktiiviset=true&suunnitellut=true&lakkautetut=false",
+        "method": "GET",
+        "status": 200,
+        "headers": {},
+        "body": null,
+        "response": {
+          "numHits": 16,
+          "organisaatiot": [
+            {
+              "oid": "1.2.246.562.10.346830761110",
+              "alkuPvm": 268005600000,
+              "parentOid": "1.2.246.562.10.00000000001",
+              "parentOidPath": "1.2.246.562.10.346830761110/1.2.246.562.10.00000000001",
+              "ytunnus": "0201256-6",
+              "toimipistekoodi": "",
+              "match": false,
+              "nimi": {
+                "fi": "Helsingin kaupunki",
+                "sv": "Helsingfors stad"
+              },
+              "kieletUris": [
+                "oppilaitoksenopetuskieli_1#1",
+                "oppilaitoksenopetuskieli_2#1",
+                "oppilaitoksenopetuskieli_3#1"
+              ],
+              "kotipaikkaUri": "kunta_091",
+              "children": [
+                {
+                  "oid": "1.2.246.562.10.52251087186",
+                  "alkuPvm": 1356991200000,
+                  "parentOid": "1.2.246.562.10.346830761110",
+                  "parentOidPath": "1.2.246.562.10.52251087186/1.2.246.562.10.346830761110/1.2.246.562.10.00000000001",
+                  "oppilaitosKoodi": "10105",
+                  "oppilaitostyyppi": "oppilaitostyyppi_21#1",
+                  "toimipistekoodi": "10105",
+                  "match": true,
+                  "nimi": {
+                    "fi": "Stadin ammatti- ja aikuisopisto",
+                    "sv": "Stadin ammatti- ja aikuisopisto",
+                    "en": "Stadin ammatti- ja aikuisopisto"
+                  },
+                  "kieletUris": [
+                    "oppilaitoksenopetuskieli_1#1"
+                  ],
+                  "kotipaikkaUri": "kunta_091",
+                  "children": [
+                    {
+                      "oid": "1.2.246.562.10.55355715099",
+                      "alkuPvm": 1356991200000,
+                      "parentOid": "1.2.246.562.10.52251087186",
+                      "parentOidPath": "1.2.246.562.10.55355715099/1.2.246.562.10.52251087186/1.2.246.562.10.346830761110/1.2.246.562.10.00000000001",
+                      "toimipistekoodi": "1010504",
+                      "match": false,
+                      "nimi": {
+                        "fi": "Stadin ammatti- ja aikuisopisto, Ilkantien toimipaikka"
+                      },
+                      "kieletUris": [
+                        "oppilaitoksenopetuskieli_1#1"
+                      ],
+                      "kotipaikkaUri": "kunta_091",
+                      "children": [],
+                      "aliOrganisaatioMaara": 0,
+                      "organisaatiotyypit": [
+                        "organisaatiotyyppi_03"
+                      ],
+                      "status": "AKTIIVINEN"
+                    },
+                    {
+                      "oid": "1.2.246.562.10.93115250668",
+                      "alkuPvm": 1413234000000,
+                      "parentOid": "1.2.246.562.10.52251087186",
+                      "parentOidPath": "1.2.246.562.10.93115250668/1.2.246.562.10.52251087186/1.2.246.562.10.346830761110/1.2.246.562.10.00000000001",
+                      "toimipistekoodi": "1010515",
+                      "match": false,
+                      "nimi": {
+                        "fi": "Stadin ammatti- ja aikuisopisto, Meritalon toimipaikka"
+                      },
+                      "kieletUris": [
+                        "oppilaitoksenopetuskieli_1#1"
+                      ],
+                      "kotipaikkaUri": "kunta_091",
+                      "children": [],
+                      "aliOrganisaatioMaara": 0,
+                      "organisaatiotyypit": [
+                        "organisaatiotyyppi_03"
+                      ],
+                      "status": "AKTIIVINEN"
+                    },
+                    {
+                      "oid": "1.2.246.562.10.45854578546",
+                      "alkuPvm": 1413234000000,
+                      "parentOid": "1.2.246.562.10.52251087186",
+                      "parentOidPath": "1.2.246.562.10.45854578546/1.2.246.562.10.52251087186/1.2.246.562.10.346830761110/1.2.246.562.10.00000000001",
+                      "toimipistekoodi": "1010516",
+                      "match": false,
+                      "nimi": {
+                        "fi": "Stadin ammatti- ja aikuisopisto, Myllypuron toimipaikka"
+                      },
+                      "kieletUris": [
+                        "oppilaitoksenopetuskieli_1#1"
+                      ],
+                      "kotipaikkaUri": "kunta_091",
+                      "children": [],
+                      "aliOrganisaatioMaara": 0,
+                      "organisaatiotyypit": [
+                        "organisaatiotyyppi_03"
+                      ],
+                      "status": "AKTIIVINEN"
+                    },
+                    {
+                      "oid": "1.2.246.562.10.60465978314",
+                      "alkuPvm": 1356991200000,
+                      "parentOid": "1.2.246.562.10.52251087186",
+                      "parentOidPath": "1.2.246.562.10.60465978314/1.2.246.562.10.52251087186/1.2.246.562.10.346830761110/1.2.246.562.10.00000000001",
+                      "toimipistekoodi": "1010503",
+                      "match": false,
+                      "nimi": {
+                        "fi": "Stadin ammatti- ja aikuisopisto, Holkkitien toimipaikka"
+                      },
+                      "kieletUris": [
+                        "oppilaitoksenopetuskieli_1#1"
+                      ],
+                      "kotipaikkaUri": "kunta_091",
+                      "children": [],
+                      "aliOrganisaatioMaara": 0,
+                      "organisaatiotyypit": [
+                        "organisaatiotyyppi_03"
+                      ],
+                      "status": "AKTIIVINEN"
+                    },
+                    {
+                      "oid": "1.2.246.562.10.23017513880",
+                      "alkuPvm": 1470603600000,
+                      "parentOid": "1.2.246.562.10.52251087186",
+                      "parentOidPath": "1.2.246.562.10.23017513880/1.2.246.562.10.52251087186/1.2.246.562.10.346830761110/1.2.246.562.10.00000000001",
+                      "toimipistekoodi": "1010517",
+                      "match": false,
+                      "nimi": {
+                        "fi": "Stadin ammatti- ja aikuisopisto, Hattulantien toimipaikka"
+                      },
+                      "kieletUris": [
+                        "oppilaitoksenopetuskieli_1#1"
+                      ],
+                      "kotipaikkaUri": "kunta_091",
+                      "children": [],
+                      "aliOrganisaatioMaara": 0,
+                      "organisaatiotyypit": [
+                        "organisaatiotyyppi_03"
+                      ],
+                      "status": "AKTIIVINEN"
+                    },
+                    {
+                      "oid": "1.2.246.562.10.16538823663",
+                      "alkuPvm": 1356991200000,
+                      "parentOid": "1.2.246.562.10.52251087186",
+                      "parentOidPath": "1.2.246.562.10.16538823663/1.2.246.562.10.52251087186/1.2.246.562.10.346830761110/1.2.246.562.10.00000000001",
+                      "toimipistekoodi": "1010510",
+                      "match": false,
+                      "nimi": {
+                        "fi": "Stadin ammatti- ja aikuisopisto, Sturenkadun toimipaikka"
+                      },
+                      "kieletUris": [
+                        "oppilaitoksenopetuskieli_1#1"
+                      ],
+                      "kotipaikkaUri": "kunta_091",
+                      "children": [],
+                      "aliOrganisaatioMaara": 0,
+                      "organisaatiotyypit": [
+                        "organisaatiotyyppi_03"
+                      ],
+                      "status": "AKTIIVINEN"
+                    },
+                    {
+                      "oid": "1.2.246.562.10.20866993056",
+                      "alkuPvm": 1356991200000,
+                      "parentOid": "1.2.246.562.10.52251087186",
+                      "parentOidPath": "1.2.246.562.10.20866993056/1.2.246.562.10.52251087186/1.2.246.562.10.346830761110/1.2.246.562.10.00000000001",
+                      "toimipistekoodi": "1010505",
+                      "match": false,
+                      "nimi": {
+                        "fi": "Stadin ammatti- ja aikuisopisto, Kullervonkadun toimipaikka"
+                      },
+                      "kieletUris": [
+                        "oppilaitoksenopetuskieli_1#1"
+                      ],
+                      "kotipaikkaUri": "kunta_091",
+                      "children": [],
+                      "aliOrganisaatioMaara": 0,
+                      "organisaatiotyypit": [
+                        "organisaatiotyyppi_03"
+                      ],
+                      "status": "AKTIIVINEN"
+                    },
+                    {
+                      "oid": "1.2.246.562.10.56139411567",
+                      "alkuPvm": 1356991200000,
+                      "parentOid": "1.2.246.562.10.52251087186",
+                      "parentOidPath": "1.2.246.562.10.56139411567/1.2.246.562.10.52251087186/1.2.246.562.10.346830761110/1.2.246.562.10.00000000001",
+                      "toimipistekoodi": "1010501",
+                      "match": false,
+                      "nimi": {
+                        "fi": "Stadin ammatti- ja aikuisopisto, Abraham Wetterin tien toimipaikka"
+                      },
+                      "kieletUris": [
+                        "oppilaitoksenopetuskieli_1#1"
+                      ],
+                      "kotipaikkaUri": "kunta_091",
+                      "children": [],
+                      "aliOrganisaatioMaara": 0,
+                      "organisaatiotyypit": [
+                        "organisaatiotyyppi_03"
+                      ],
+                      "status": "AKTIIVINEN"
+                    },
+                    {
+                      "oid": "1.2.246.562.10.55711304158",
+                      "alkuPvm": 1356991200000,
+                      "parentOid": "1.2.246.562.10.52251087186",
+                      "parentOidPath": "1.2.246.562.10.55711304158/1.2.246.562.10.52251087186/1.2.246.562.10.346830761110/1.2.246.562.10.00000000001",
+                      "toimipistekoodi": "1010519",
+                      "match": false,
+                      "nimi": {
+                        "fi": "Stadin ammatti- ja aikuisopisto, Teollisuuskadun toimipaikka"
+                      },
+                      "kieletUris": [
+                        "oppilaitoksenopetuskieli_1#1"
+                      ],
+                      "kotipaikkaUri": "kunta_091",
+                      "children": [],
+                      "aliOrganisaatioMaara": 0,
+                      "organisaatiotyypit": [
+                        "organisaatiotyyppi_03"
+                      ],
+                      "status": "AKTIIVINEN"
+                    },
+                    {
+                      "oid": "1.2.246.562.10.656909794910",
+                      "alkuPvm": 1356991200000,
+                      "parentOid": "1.2.246.562.10.52251087186",
+                      "parentOidPath": "1.2.246.562.10.656909794910/1.2.246.562.10.52251087186/1.2.246.562.10.346830761110/1.2.246.562.10.00000000001",
+                      "toimipistekoodi": "1010508",
+                      "match": false,
+                      "nimi": {
+                        "fi": "Stadin ammatti- ja aikuisopisto, Prinsessantien toimipaikka"
+                      },
+                      "kieletUris": [
+                        "oppilaitoksenopetuskieli_1#1"
+                      ],
+                      "kotipaikkaUri": "kunta_091",
+                      "children": [],
+                      "aliOrganisaatioMaara": 0,
+                      "organisaatiotyypit": [
+                        "organisaatiotyyppi_03"
+                      ],
+                      "status": "AKTIIVINEN"
+                    },
+                    {
+                      "oid": "1.2.246.562.10.78321186062",
+                      "alkuPvm": 1356991200000,
+                      "parentOid": "1.2.246.562.10.52251087186",
+                      "parentOidPath": "1.2.246.562.10.78321186062/1.2.246.562.10.52251087186/1.2.246.562.10.346830761110/1.2.246.562.10.00000000001",
+                      "toimipistekoodi": "1010509",
+                      "match": false,
+                      "nimi": {
+                        "fi": "Stadin ammatti- ja aikuisopisto, Savonkadun toimipaikka"
+                      },
+                      "kieletUris": [
+                        "oppilaitoksenopetuskieli_1#1"
+                      ],
+                      "kotipaikkaUri": "kunta_091",
+                      "children": [],
+                      "aliOrganisaatioMaara": 0,
+                      "organisaatiotyypit": [
+                        "organisaatiotyyppi_03"
+                      ],
+                      "status": "AKTIIVINEN"
+                    },
+                    {
+                      "oid": "1.2.246.562.10.879177258610",
+                      "alkuPvm": 1356991200000,
+                      "parentOid": "1.2.246.562.10.52251087186",
+                      "parentOidPath": "1.2.246.562.10.879177258610/1.2.246.562.10.52251087186/1.2.246.562.10.346830761110/1.2.246.562.10.00000000001",
+                      "toimipistekoodi": "1010507",
+                      "match": false,
+                      "nimi": {
+                        "fi": "Stadin ammatti- ja aikuisopisto, Muotoilijankadun toimipaikka",
+                        "en": "Helsinki City College, Muotoilijankatu"
+                      },
+                      "kieletUris": [
+                        "oppilaitoksenopetuskieli_1#1"
+                      ],
+                      "kotipaikkaUri": "kunta_091",
+                      "children": [],
+                      "aliOrganisaatioMaara": 0,
+                      "organisaatiotyypit": [
+                        "organisaatiotyyppi_03"
+                      ],
+                      "status": "AKTIIVINEN"
+                    },
+                    {
+                      "oid": "1.2.246.562.10.20485193278",
+                      "alkuPvm": 1356991200000,
+                      "parentOid": "1.2.246.562.10.52251087186",
+                      "parentOidPath": "1.2.246.562.10.20485193278/1.2.246.562.10.52251087186/1.2.246.562.10.346830761110/1.2.246.562.10.00000000001",
+                      "toimipistekoodi": "1010502",
+                      "match": false,
+                      "nimi": {
+                        "fi": "Stadin ammatti- ja aikuisopisto, Vilppulantien toimipaikka"
+                      },
+                      "kieletUris": [
+                        "oppilaitoksenopetuskieli_1#1"
+                      ],
+                      "kotipaikkaUri": "kunta_091",
+                      "children": [],
+                      "aliOrganisaatioMaara": 0,
+                      "organisaatiotyypit": [
+                        "organisaatiotyyppi_03"
+                      ],
+                      "status": "AKTIIVINEN"
+                    },
+                    {
+                      "oid": "1.2.246.562.10.2013081415065445951365",
+                      "alkuPvm": 1375304400000,
+                      "parentOid": "1.2.246.562.10.52251087186",
+                      "parentOidPath": "1.2.246.562.10.2013081415065445951365/1.2.246.562.10.52251087186/1.2.246.562.10.346830761110/1.2.246.562.10.00000000001",
+                      "toimipistekoodi": "1010514",
+                      "match": false,
+                      "nimi": {
+                        "fi": "Stadin ammatti- ja aikuisopisto, Pälkäneentien toimipaikka"
+                      },
+                      "kieletUris": [
+                        "oppilaitoksenopetuskieli_1#1"
+                      ],
+                      "kotipaikkaUri": "kunta_091",
+                      "children": [],
+                      "aliOrganisaatioMaara": 0,
+                      "organisaatiotyypit": [
+                        "organisaatiotyyppi_03"
+                      ],
+                      "status": "AKTIIVINEN"
+                    }
+                  ],
+                  "aliOrganisaatioMaara": 14,
+                  "organisaatiotyypit": [
+                    "organisaatiotyyppi_02"
+                  ],
+                  "status": "AKTIIVINEN"
+                }
+              ],
+              "aliOrganisaatioMaara": 621,
+              "organisaatiotyypit": [
+                "organisaatiotyyppi_01",
+                "organisaatiotyyppi_07"
+              ],
+              "status": "AKTIIVINEN"
+            }
+          ]
+        }
+      },
+      {
+        "url": "https://localhost:3000/lomake-editori/api/forms",
+        "method": "GET",
+        "status": 200,
+        "headers": {},
+        "body": null,
+        "response": {
+          "forms": [
+            {
+              "name": {
+                "fi": "Lomake 1"
+              },
+              "key": "lomake_1"
+            }
+          ]
+        }
+      }
+    ]
+  },
+  "should be able to edit hakukohde": {
+    "timestamp": 1603393054191,
+    "routes": [
+      {
+        "url": "https://localhost:3000/kouta-backend/auth/session",
+        "method": "GET",
+        "status": 200,
+        "headers": {},
+        "body": null,
+        "response": {}
+      },
+      {
+        "url": "https://localhost:3000/kouta-backend/auth/session",
+        "method": "GET",
+        "status": 200,
+        "headers": {},
+        "body": null,
+        "response": {}
+      },
+      {
+        "url": "https://localhost:3000/kayttooikeus-service/cas/me",
+        "method": "GET",
+        "status": 200,
+        "headers": {},
+        "body": null,
+        "response": {
+          "uid": "johndoe",
+          "oid": "1.2.246.562.24.62301161440",
+          "firstName": "John",
+          "lastName": "Doe",
+          "lang": "fi",
+          "roles": "[\"APP_KOUTA\",\"APP_KOUTA_OPHPAAKAYTTAJA\",\"APP_KOUTA_OPHPAAKAYTTAJA_1.2.246.562.10.00000000001\"]"
+        }
+      },
+      {
+        "url": "https://localhost:3000/kouta-backend/hakukohde/6.1.1.1.1.1",
+        "method": "GET",
+        "status": 200,
+        "headers": {},
+        "body": null,
+        "response": {
+          "oid": "6.1.1.1.1.1",
+          "toteutusOid": "2.1.1.1.1.1",
+          "hakuOid": "4.1.1.1.1.1",
+          "tila": "tallennettu",
+          "nimi": {
+            "fi": "Hakukohteen nimi"
+          },
+          "alkamiskausiKoodiUri": "kausi_0#1",
+          "alkamisvuosi": "2024",
+          "hakulomake": {},
+          "aloituspaikat": 150,
+          "ensikertalaisenAloituspaikat": 49,
+          "kaytetaanHaunAlkamiskautta": false,
+          "pohjakoulutusvaatimusKoodiUrit": [
+            "pohjakoulutusvaatimustoinenaste_0#1"
+          ],
+          "pohjakoulutusvaatimusTarkenne": {
+            "fi": "<p>Fi tarkenne</p>"
+          },
+          "muuPohjakoulutusvaatimus": {},
+          "toinenAsteOnkoKaksoistutkinto": true,
+          "kaytetaanHaunAikataulua": false,
+          "liitteetOnkoSamaToimitusaika": false,
+          "liitteetOnkoSamaToimitusosoite": false,
+          "liitteidenToimitusosoite": null,
+          "liitteidenToimitustapa": null,
+          "liitteet": [
+            {
+              "id": "927ac923-a839-4354-9db4-f95d276d9902",
+              "tyyppiKoodiUri": "liitetyypitamm_0#1",
+              "nimi": {
+                "fi": "Nimi"
+              },
+              "kuvaus": {
+                "fi": "Kuvaus"
+              },
+              "toimitusaika": "2011-11-11T10:30",
+              "toimitusosoite": {
+                "osoite": {
+                  "osoite": {
+                    "fi": "Osoite"
+                  },
+                  "postinumeroKoodiUri": "posti_0#2"
+                },
+                "sahkoposti": "sahkoposti@email.com"
+              },
+              "toimitustapa": "osoite"
+            }
+          ],
+          "metadata": {
+            "valintakokeidenYleiskuvaus": {
+              "fi": "<p>Valintakokeiden kuvaus - fi</p>"
+            }
+          },
+          "valintakokeet": [
+            {
+              "nimi": {
+                "fi": "Kokeen nimi - fi"
+              },
+              "metadata": {
+                "tietoja": {
+                  "fi": "<p>Tietoa kokeesta - fi</p>"
+                },
+                "liittyyEnnakkovalmistautumista": true,
+                "ohjeetEnnakkovalmistautumiseen": {
+                  "fi": "<p>Ohjeet ennakkovalmistautumiseen - fi</p>"
+                },
+                "erityisjarjestelytMahdollisia": true,
+                "ohjeetErityisjarjestelyihin": {
+                  "fi": "<p>Ohjeet erityisjärjestelyihin - fi</p>"
+                }
+              },
+              "tyyppiKoodiUri": "tyyppi_1#1",
+              "tilaisuudet": [
+                {
+                  "osoite": {
+                    "osoite": {
+                      "fi": "fi osoite"
+                    },
+                    "postinumeroKoodiUri": "posti_00350#1"
+                  },
+                  "aika": {
+                    "alkaa": "2019-04-16T08:44",
+                    "paattyy": "2019-04-18T08:44"
+                  },
+                  "lisatietoja": {
+                    "fi": "fi lisatietoja"
+                  },
+                  "jarjestamispaikka": {
+                    "fi": "Jarjestamispaikka - fi"
+                  }
+                }
+              ]
+            }
+          ],
+          "hakuajat": [
+            {
+              "alkaa": "2011-11-11T10:30",
+              "paattyy": "2011-11-12T11:45"
+            }
+          ],
+          "muokkaaja": "1.2.246.562.24.62301161440",
+          "organisaatioOid": "1.2.246.562.10.52251087186",
+          "kielivalinta": [
+            "fi",
+            "sv"
+          ],
+          "modified": "2019-04-04T08:28",
+          "kaytetaanHaunHakulomaketta": false,
+          "hakulomaketyyppi": "ataru",
+          "hakulomakeAtaruId": "12345",
+          "hakulomakeKuvaus": {},
+          "hakulomakeLinkki": {},
+          "valintaperusteId": "649adb37-cd4d-4846-91a9-84b58b90f928"
+        }
+      },
+      {
+        "url": "https://localhost:3000/kouta-backend/toteutus/2.1.1.1.1.1",
+        "method": "GET",
+        "status": 200,
+        "headers": {},
+        "body": null,
+        "response": {
+          "oid": "2.1.1.1.1.1",
+          "koulutusOid": "3.1.1.1.1",
+          "tila": "julkaistu",
+          "tarjoajat": [
+            "1.2.246.562.10.45854578546"
+          ],
+          "nimi": {
+            "fi": "Koulutuskeskus Salpaus, jatkuva haku, eläintenhoitaja"
+          },
+          "metadata": {
+            "kuvaus": {},
+            "opetus": {
+              "koulutuksenAlkamispaivamaara": "2019-08-23T00:00",
+              "koulutuksenPaattymispaivamaara": "2019-08-26T00:00",
+              "opetuskieliKoodiUrit": [
+                "oppilaitoksenopetuskieli_1#1"
+              ],
+              "opetuskieletKuvaus": {
+                "fi": "Opetuskieli kuvaus"
+              },
+              "suunniteltuKestoKuvaus": {
+                "fi": "Fi suunniteltuKestoKuvaus",
+                "sv": "Sv suunniteltuKestoKuvaus"
+              },
+              "suunniteltuKestoVuodet": 2,
+              "suunniteltuKestoKuukaudet": 6,
+              "opetusaikaKoodiUrit": [
+                "opetusaikakk_1#1"
+              ],
+              "opetusaikaKuvaus": {
+                "fi": "Opetusaika kuvaus"
+              },
+              "opetustapaKoodiUrit": [
+                "opetuspaikkakk_1#1"
+              ],
+              "opetustapaKuvaus": {
+                "fi": "Opetustapa kuvaus"
+              },
+              "onkoMaksullinen": true,
+              "maksullisuusKuvaus": {
+                "fi": "Maksullisuus kuvaus"
+              },
+              "maksunMaara": 20,
+              "alkamiskausiKoodiUri": "kausi_1#1",
+              "alkamisvuosi": "2024",
+              "alkamisaikaKuvaus": {
+                "fi": "Alkamisaika kuvaus"
+              },
+              "onkoStipendia": true,
+              "stipendinMaara": 90,
+              "stipendinKuvaus": {
+                "fi": "Stipendin kuvaus"
+              },
+              "lisatiedot": [
+                {
+                  "otsikkoKoodiUri": "koulutuksenlisatiedot_0#1",
+                  "teksti": {
+                    "fi": "koulutuksenlisatiedot_0 kuvaus"
+                  }
+                }
+              ]
+            },
+            "asiasanat": [
+              {
+                "kieli": "fi",
+                "arvo": "koira"
+              },
+              {
+                "kieli": "fi",
+                "arvo": "eläintenhoito"
+              }
+            ],
+            "ammattinimikkeet": [
+              {
+                "kieli": "fi",
+                "arvo": "eläintenhoitaja"
+              }
+            ],
+            "yhteyshenkilot": [
+              {
+                "nimi": {
+                  "fi": "Fi nimi",
+                  "sv": "Sv nimi"
+                },
+                "puhelinnumero": {
+                  "fi": "Fi puhelinnumero",
+                  "sv": "Sv puhelinnumero"
+                },
+                "sahkoposti": {
+                  "fi": "Fi sähköposti",
+                  "sv": "Sv sähköposti"
+                },
+                "titteli": {
+                  "fi": "Fi titteli",
+                  "sv": "Sv titteli"
+                },
+                "wwwSivu": {
+                  "fi": "Fi verkkosivu",
+                  "sv": "Sv verkkosivu"
+                }
+              }
+            ],
+            "tyyppi": "amm",
+            "osaamisalat": [
+              {
+                "koodiUri": "osaamisala_0",
+                "linkki": {
+                  "fi": "https://www.salpaus.fi/koulutusesittely/elaintenhoitaja/"
+                },
+                "otsikko": {
+                  "fi": "Otsikko"
+                }
+              }
+            ]
+          },
+          "muokkaaja": "1.2.246.562.24.62301161440",
+          "organisaatioOid": "1.2.246.562.10.52251087186",
+          "kielivalinta": [
+            "fi",
+            "sv"
+          ],
+          "modified": "2019-03-26T10:19"
+        }
+      },
+      {
+        "url": "https://localhost:3000/kouta-backend/haku/4.1.1.1.1.1",
+        "method": "GET",
+        "status": 200,
+        "headers": {},
+        "body": null,
+        "response": {
+          "oid": "4.1.1.1.1.1",
+          "tila": "julkaistu",
+          "nimi": {
+            "fi": "Haku"
+          },
+          "hakutapaKoodiUri": "hakutapa_0#1",
+          "hakukohteenLiittamisenTakaraja": "2019-02-08T07:05",
+          "hakukohteenMuokkaamisenTakaraja": "2019-02-08T07:05",
+          "alkamiskausiKoodiUri": "kausi_0#1",
+          "alkamisvuosi": "2024",
+          "kohdejoukkoKoodiUri": "haunkohdejoukko_0#1",
+          "kohdejoukonTarkenneKoodiUri": "haunkohdejoukontarkenne_0#1",
+          "hakulomaketyyppi": "muu",
+          "hakulomakeAtaruId": "12345",
+          "hakulomakeKuvaus": {},
+          "hakulomakeLinkki": {},
+          "metadata": {
+            "tulevaisuudenAikataulu": [
+              {
+                "alkaa": "2019-10-11T09:05",
+                "paattyy": "2019-12-25T20:30"
+              }
+            ],
+            "yhteyshenkilot": [
+              {
+                "nimi": {
+                  "fi": "nimi"
+                },
+                "titteli": {
+                  "fi": "titteli"
+                },
+                "puhelinnumero": {
+                  "fi": "puhelin"
+                },
+                "wwwSivu": {
+                  "fi": "verkkosivu"
+                },
+                "sahkoposti": {
+                  "fi": "sähkoposti"
+                }
+              }
+            ]
+          },
+          "organisaatioOid": "1.2.246.562.10.52251087186",
+          "hakuajat": [
+            {
+              "alkaa": "2019-02-08T07:05",
+              "paattyy": "2020-02-08T07:05"
+            }
+          ],
+          "ajastettuJulkaisu": "2019-12-05T06:45",
+          "muokkaaja": "1.2.246.562.24.62301161440",
+          "kielivalinta": [
+            "fi",
+            "sv"
+          ],
+          "modified": "2019-03-29T12:48"
+        }
+      },
+      {
+        "url": "https://localhost:3000/kouta-backend/koulutus/3.1.1.1.1",
+        "method": "GET",
+        "status": 200,
+        "headers": {},
+        "body": null,
+        "response": {
+          "oid": "3.1.1.1.1",
+          "koulutustyyppi": "amm",
+          "koulutusKoodiUri": "koulutus_351107#12",
+          "tila": "julkaistu",
+          "tarjoajat": [
+            "1.2.246.562.10.45854578546"
+          ],
+          "nimi": {
+            "en": "Vocational qualification in Mining",
+            "fi": "Kaivosalan perustutkinto",
+            "sv": "Grundexamen inom gruvbranschen"
+          },
+          "metadata": {
+            "tyyppi": "amm",
+            "kuvaus": {},
+            "lisatiedot": [
+              {
+                "otsikkoKoodiUri": "koulutuksenlisatiedot_0#1",
+                "teksti": {
+                  "fi": "koulutuksenlisatiedot_0 kuvaus"
+                }
+              }
+            ]
+          },
+          "julkinen": true,
+          "muokkaaja": "1.2.246.562.24.26603962037",
+          "organisaatioOid": "1.2.246.562.10.52251087186",
+          "kielivalinta": [
+            "fi",
+            "sv"
+          ],
+          "modified": "2020-09-21T16:27",
+          "johtaaTutkintoon": false,
+          "esikatselu": true,
+          "ePerusteId": 6777660
+        }
+      },
+      {
+        "url": "https://localhost:3000/kouta-backend/valintaperuste/list?organisaatioOid=1.2.246.562.10.52251087186&hakuOid=4.1.1.1.1.1",
+        "method": "GET",
+        "status": 200,
+        "headers": {},
+        "body": null,
+        "response": [
+          {
+            "koulutustyyppi": "amm",
+            "id": "649adb37-cd4d-4846-91a9-84b58b90f928",
+            "tila": "julkaistu",
+            "hakutapaKoodiUri": "hakutapa_0#1",
+            "kohdejoukkoKoodiUri": "haunkohdejoukko_0#1",
+            "nimi": {
+              "fi": "Valintaperusteen nimi"
+            },
+            "julkinen": false,
+            "sorakuvausId": "1",
+            "metadata": {
+              "koulutustyyppi": "amm",
+              "valintatavat": [
+                {
+                  "valintatapaKoodiUri": "valintatapajono_0#1",
+                  "kuvaus": {},
+                  "nimi": {
+                    "fi": "Valintatavan nimi"
+                  },
+                  "sisalto": [
+                    {
+                      "tyyppi": "teksti",
+                      "data": {
+                        "fi": "<p>Tekstia</p>"
+                      }
+                    },
+                    {
+                      "tyyppi": "taulukko",
+                      "data": {
+                        "nimi": {},
+                        "rows": [
+                          {
+                            "index": 0,
+                            "isHeader": false,
+                            "columns": [
+                              {
+                                "index": 0,
+                                "text": {
+                                  "fi": "Solu"
+                                }
+                              }
+                            ]
+                          }
+                        ]
+                      }
+                    }
+                  ],
+                  "kaytaMuuntotaulukkoa": false,
+                  "kynnysehto": {
+                    "fi": "Kynnysehto"
+                  },
+                  "enimmaispisteet": 100,
+                  "vahimmaispisteet": 10
+                }
+              ],
+              "kielitaitovaatimukset": [],
+              "kuvaus": {
+                "fi": "<p>Loppukuvaus</p>"
+              },
+              "valintakokeidenYleiskuvaus": {
+                "fi": "<p>Valintakokeiden kuvaus - fi</p>"
+              }
+            },
+            "organisaatioOid": "1.2.246.562.10.594252633210",
+            "muokkaaja": "1.2.246.562.24.62301161440",
+            "kielivalinta": [
+              "fi",
+              "sv"
+            ],
+            "modified": "2019-04-03T13:56",
+            "valintakokeet": [
+              {
+                "nimi": {
+                  "fi": "Kokeen nimi - fi"
+                },
+                "metadata": {
+                  "tietoja": {
+                    "fi": "<p>Tietoa kokeesta - fi</p>"
+                  },
+                  "liittyyEnnakkovalmistautumista": true,
+                  "ohjeetEnnakkovalmistautumiseen": {
+                    "fi": "<p>Ohjeet ennakkovalmistautumiseen - fi</p>"
+                  },
+                  "erityisjarjestelytMahdollisia": true,
+                  "ohjeetErityisjarjestelyihin": {
+                    "fi": "<p>Ohjeet erityisjärjestelyihin - fi</p>"
+                  }
+                },
+                "tyyppiKoodiUri": "tyyppi_1#1",
+                "tilaisuudet": [
+                  {
+                    "osoite": {
+                      "osoite": {
+                        "fi": "fi osoite"
+                      },
+                      "postinumeroKoodiUri": "posti_00350#1"
+                    },
+                    "aika": {
+                      "alkaa": "2019-04-16T08:44",
+                      "paattyy": "2019-04-18T08:44"
+                    },
+                    "lisatietoja": {
+                      "fi": "fi lisatietoja"
+                    },
+                    "jarjestamispaikka": {
+                      "fi": "Jarjestamispaikka - fi"
+                    }
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "url": "https://localhost:3000/koodisto-service/rest/json/pohjakoulutusvaatimustoinenaste/koodi?onlyValidKoodis=true&koodistoVersio=",
+        "method": "GET",
+        "status": 200,
+        "headers": {},
+        "body": null,
+        "response": [
+          {
+            "koodiUri": "pohjakoulutusvaatimustoinenaste_0",
+            "resourceUri": "https://virkailija.hahtuvaopintopolku.fi/koodisto-service/rest/codeelement/pohjakoulutusvaatimustoinenaste_11",
+            "version": 1,
+            "versio": 1,
+            "koodisto": {
+              "koodistoUri": "pohjakoulutusvaatimustoinenaste",
+              "organisaatioOid": "1.2.246.562.10.00000000001",
+              "koodistoVersios": [
+                1
+              ]
+            },
+            "koodiArvo": "0",
+            "paivitysPvm": 1427461978048,
+            "voimassaAlkuPvm": "2000-01-01",
+            "voimassaLoppuPvm": null,
+            "tila": "LUONNOS",
+            "metadata": [
+              {
+                "nimi": "pohjakoulutusvaatimustoinenaste_0",
+                "kuvaus": "pohjakoulutusvaatimustoinenaste_0",
+                "lyhytNimi": "pohjakoulutusvaatimustoinenaste_0",
+                "kieli": "fi"
+              },
+              {
+                "nimi": "pohjakoulutusvaatimustoinenaste_0",
+                "kuvaus": "pohjakoulutusvaatimustoinenaste_0",
+                "lyhytNimi": "pohjakoulutusvaatimustoinenaste_0",
+                "kieli": "sv"
+              },
+              {
+                "nimi": "pohjakoulutusvaatimustoinenaste_0",
+                "kuvaus": "pohjakoulutusvaatimustoinenaste_0",
+                "lyhytNimi": "pohjakoulutusvaatimustoinenaste_0",
+                "kieli": "en"
+              }
+            ]
+          },
+          {
+            "koodiUri": "pohjakoulutusvaatimustoinenaste_1",
+            "resourceUri": "https://virkailija.hahtuvaopintopolku.fi/koodisto-service/rest/codeelement/pohjakoulutusvaatimustoinenaste_11",
+            "version": 1,
+            "versio": 1,
+            "koodisto": {
+              "koodistoUri": "pohjakoulutusvaatimustoinenaste",
+              "organisaatioOid": "1.2.246.562.10.00000000001",
+              "koodistoVersios": [
+                1
+              ]
+            },
+            "koodiArvo": "1",
+            "paivitysPvm": 1427461978048,
+            "voimassaAlkuPvm": "2000-01-01",
+            "voimassaLoppuPvm": null,
+            "tila": "LUONNOS",
+            "metadata": [
+              {
+                "nimi": "pohjakoulutusvaatimustoinenaste_1",
+                "kuvaus": "pohjakoulutusvaatimustoinenaste_1",
+                "lyhytNimi": "pohjakoulutusvaatimustoinenaste_1",
+                "kieli": "fi"
+              },
+              {
+                "nimi": "pohjakoulutusvaatimustoinenaste_1",
+                "kuvaus": "pohjakoulutusvaatimustoinenaste_1",
+                "lyhytNimi": "pohjakoulutusvaatimustoinenaste_1",
+                "kieli": "sv"
+              },
+              {
+                "nimi": "pohjakoulutusvaatimustoinenaste_1",
+                "kuvaus": "pohjakoulutusvaatimustoinenaste_1",
+                "lyhytNimi": "pohjakoulutusvaatimustoinenaste_1",
+                "kieli": "en"
+              }
+            ]
+          },
+          {
+            "koodiUri": "pohjakoulutusvaatimustoinenaste_2",
+            "resourceUri": "https://virkailija.hahtuvaopintopolku.fi/koodisto-service/rest/codeelement/pohjakoulutusvaatimustoinenaste_11",
+            "version": 1,
+            "versio": 1,
+            "koodisto": {
+              "koodistoUri": "pohjakoulutusvaatimustoinenaste",
+              "organisaatioOid": "1.2.246.562.10.00000000001",
+              "koodistoVersios": [
+                1
+              ]
+            },
+            "koodiArvo": "2",
+            "paivitysPvm": 1427461978048,
+            "voimassaAlkuPvm": "2000-01-01",
+            "voimassaLoppuPvm": null,
+            "tila": "LUONNOS",
+            "metadata": [
+              {
+                "nimi": "pohjakoulutusvaatimustoinenaste_2",
+                "kuvaus": "pohjakoulutusvaatimustoinenaste_2",
+                "lyhytNimi": "pohjakoulutusvaatimustoinenaste_2",
+                "kieli": "fi"
+              },
+              {
+                "nimi": "pohjakoulutusvaatimustoinenaste_2",
+                "kuvaus": "pohjakoulutusvaatimustoinenaste_2",
+                "lyhytNimi": "pohjakoulutusvaatimustoinenaste_2",
+                "kieli": "sv"
+              },
+              {
+                "nimi": "pohjakoulutusvaatimustoinenaste_2",
+                "kuvaus": "pohjakoulutusvaatimustoinenaste_2",
+                "lyhytNimi": "pohjakoulutusvaatimustoinenaste_2",
+                "kieli": "en"
+              }
+            ]
+          },
+          {
+            "koodiUri": "pohjakoulutusvaatimustoinenaste_3",
+            "resourceUri": "https://virkailija.hahtuvaopintopolku.fi/koodisto-service/rest/codeelement/pohjakoulutusvaatimustoinenaste_11",
+            "version": 1,
+            "versio": 1,
+            "koodisto": {
+              "koodistoUri": "pohjakoulutusvaatimustoinenaste",
+              "organisaatioOid": "1.2.246.562.10.00000000001",
+              "koodistoVersios": [
+                1
+              ]
+            },
+            "koodiArvo": "3",
+            "paivitysPvm": 1427461978048,
+            "voimassaAlkuPvm": "2000-01-01",
+            "voimassaLoppuPvm": null,
+            "tila": "LUONNOS",
+            "metadata": [
+              {
+                "nimi": "pohjakoulutusvaatimustoinenaste_3",
+                "kuvaus": "pohjakoulutusvaatimustoinenaste_3",
+                "lyhytNimi": "pohjakoulutusvaatimustoinenaste_3",
+                "kieli": "fi"
+              },
+              {
+                "nimi": "pohjakoulutusvaatimustoinenaste_3",
+                "kuvaus": "pohjakoulutusvaatimustoinenaste_3",
+                "lyhytNimi": "pohjakoulutusvaatimustoinenaste_3",
+                "kieli": "sv"
+              },
+              {
+                "nimi": "pohjakoulutusvaatimustoinenaste_3",
+                "kuvaus": "pohjakoulutusvaatimustoinenaste_3",
+                "lyhytNimi": "pohjakoulutusvaatimustoinenaste_3",
+                "kieli": "en"
+              }
+            ]
+          },
+          {
+            "koodiUri": "pohjakoulutusvaatimustoinenaste_4",
+            "resourceUri": "https://virkailija.hahtuvaopintopolku.fi/koodisto-service/rest/codeelement/pohjakoulutusvaatimustoinenaste_11",
+            "version": 1,
+            "versio": 1,
+            "koodisto": {
+              "koodistoUri": "pohjakoulutusvaatimustoinenaste",
+              "organisaatioOid": "1.2.246.562.10.00000000001",
+              "koodistoVersios": [
+                1
+              ]
+            },
+            "koodiArvo": "4",
+            "paivitysPvm": 1427461978048,
+            "voimassaAlkuPvm": "2000-01-01",
+            "voimassaLoppuPvm": null,
+            "tila": "LUONNOS",
+            "metadata": [
+              {
+                "nimi": "pohjakoulutusvaatimustoinenaste_4",
+                "kuvaus": "pohjakoulutusvaatimustoinenaste_4",
+                "lyhytNimi": "pohjakoulutusvaatimustoinenaste_4",
+                "kieli": "fi"
+              },
+              {
+                "nimi": "pohjakoulutusvaatimustoinenaste_4",
+                "kuvaus": "pohjakoulutusvaatimustoinenaste_4",
+                "lyhytNimi": "pohjakoulutusvaatimustoinenaste_4",
+                "kieli": "sv"
+              },
+              {
+                "nimi": "pohjakoulutusvaatimustoinenaste_4",
+                "kuvaus": "pohjakoulutusvaatimustoinenaste_4",
+                "lyhytNimi": "pohjakoulutusvaatimustoinenaste_4",
+                "kieli": "en"
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "url": "https://localhost:3000/koodisto-service/rest/json/kausi/koodi?onlyValidKoodis=true&koodistoVersio=",
+        "method": "GET",
+        "status": 200,
+        "headers": {},
+        "body": null,
+        "response": [
+          {
+            "koodiUri": "kausi_0",
+            "resourceUri": "https://virkailija.hahtuvaopintopolku.fi/koodisto-service/rest/codeelement/kausi_11",
+            "version": 1,
+            "versio": 1,
+            "koodisto": {
+              "koodistoUri": "kausi",
+              "organisaatioOid": "1.2.246.562.10.00000000001",
+              "koodistoVersios": [
+                1
+              ]
+            },
+            "koodiArvo": "0",
+            "paivitysPvm": 1427461978048,
+            "voimassaAlkuPvm": "2000-01-01",
+            "voimassaLoppuPvm": null,
+            "tila": "LUONNOS",
+            "metadata": [
+              {
+                "nimi": "kausi_0",
+                "kuvaus": "kausi_0",
+                "lyhytNimi": "kausi_0",
+                "kieli": "fi"
+              },
+              {
+                "nimi": "kausi_0",
+                "kuvaus": "kausi_0",
+                "lyhytNimi": "kausi_0",
+                "kieli": "sv"
+              },
+              {
+                "nimi": "kausi_0",
+                "kuvaus": "kausi_0",
+                "lyhytNimi": "kausi_0",
+                "kieli": "en"
+              }
+            ]
+          },
+          {
+            "koodiUri": "kausi_1",
+            "resourceUri": "https://virkailija.hahtuvaopintopolku.fi/koodisto-service/rest/codeelement/kausi_11",
+            "version": 1,
+            "versio": 1,
+            "koodisto": {
+              "koodistoUri": "kausi",
+              "organisaatioOid": "1.2.246.562.10.00000000001",
+              "koodistoVersios": [
+                1
+              ]
+            },
+            "koodiArvo": "1",
+            "paivitysPvm": 1427461978048,
+            "voimassaAlkuPvm": "2000-01-01",
+            "voimassaLoppuPvm": null,
+            "tila": "LUONNOS",
+            "metadata": [
+              {
+                "nimi": "kausi_1",
+                "kuvaus": "kausi_1",
+                "lyhytNimi": "kausi_1",
+                "kieli": "fi"
+              },
+              {
+                "nimi": "kausi_1",
+                "kuvaus": "kausi_1",
+                "lyhytNimi": "kausi_1",
+                "kieli": "sv"
+              },
+              {
+                "nimi": "kausi_1",
+                "kuvaus": "kausi_1",
+                "lyhytNimi": "kausi_1",
+                "kieli": "en"
+              }
+            ]
+          },
+          {
+            "koodiUri": "kausi_2",
+            "resourceUri": "https://virkailija.hahtuvaopintopolku.fi/koodisto-service/rest/codeelement/kausi_11",
+            "version": 1,
+            "versio": 1,
+            "koodisto": {
+              "koodistoUri": "kausi",
+              "organisaatioOid": "1.2.246.562.10.00000000001",
+              "koodistoVersios": [
+                1
+              ]
+            },
+            "koodiArvo": "2",
+            "paivitysPvm": 1427461978048,
+            "voimassaAlkuPvm": "2000-01-01",
+            "voimassaLoppuPvm": null,
+            "tila": "LUONNOS",
+            "metadata": [
+              {
+                "nimi": "kausi_2",
+                "kuvaus": "kausi_2",
+                "lyhytNimi": "kausi_2",
+                "kieli": "fi"
+              },
+              {
+                "nimi": "kausi_2",
+                "kuvaus": "kausi_2",
+                "lyhytNimi": "kausi_2",
+                "kieli": "sv"
+              },
+              {
+                "nimi": "kausi_2",
+                "kuvaus": "kausi_2",
+                "lyhytNimi": "kausi_2",
+                "kieli": "en"
+              }
+            ]
+          },
+          {
+            "koodiUri": "kausi_3",
+            "resourceUri": "https://virkailija.hahtuvaopintopolku.fi/koodisto-service/rest/codeelement/kausi_11",
+            "version": 1,
+            "versio": 1,
+            "koodisto": {
+              "koodistoUri": "kausi",
+              "organisaatioOid": "1.2.246.562.10.00000000001",
+              "koodistoVersios": [
+                1
+              ]
+            },
+            "koodiArvo": "3",
+            "paivitysPvm": 1427461978048,
+            "voimassaAlkuPvm": "2000-01-01",
+            "voimassaLoppuPvm": null,
+            "tila": "LUONNOS",
+            "metadata": [
+              {
+                "nimi": "kausi_3",
+                "kuvaus": "kausi_3",
+                "lyhytNimi": "kausi_3",
+                "kieli": "fi"
+              },
+              {
+                "nimi": "kausi_3",
+                "kuvaus": "kausi_3",
+                "lyhytNimi": "kausi_3",
+                "kieli": "sv"
+              },
+              {
+                "nimi": "kausi_3",
+                "kuvaus": "kausi_3",
+                "lyhytNimi": "kausi_3",
+                "kieli": "en"
+              }
+            ]
+          },
+          {
+            "koodiUri": "kausi_4",
+            "resourceUri": "https://virkailija.hahtuvaopintopolku.fi/koodisto-service/rest/codeelement/kausi_11",
+            "version": 1,
+            "versio": 1,
+            "koodisto": {
+              "koodistoUri": "kausi",
+              "organisaatioOid": "1.2.246.562.10.00000000001",
+              "koodistoVersios": [
+                1
+              ]
+            },
+            "koodiArvo": "4",
+            "paivitysPvm": 1427461978048,
+            "voimassaAlkuPvm": "2000-01-01",
+            "voimassaLoppuPvm": null,
+            "tila": "LUONNOS",
+            "metadata": [
+              {
+                "nimi": "kausi_4",
+                "kuvaus": "kausi_4",
+                "lyhytNimi": "kausi_4",
+                "kieli": "fi"
+              },
+              {
+                "nimi": "kausi_4",
+                "kuvaus": "kausi_4",
+                "lyhytNimi": "kausi_4",
+                "kieli": "sv"
+              },
+              {
+                "nimi": "kausi_4",
+                "kuvaus": "kausi_4",
+                "lyhytNimi": "kausi_4",
+                "kieli": "en"
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "url": "https://localhost:3000/lomake-editori/api/forms",
+        "method": "GET",
+        "status": 200,
+        "headers": {},
+        "body": null,
+        "response": {
+          "forms": [
+            {
+              "name": {
+                "fi": "Lomake 1"
+              },
+              "key": "lomake_1"
+            }
+          ]
+        }
+      },
+      {
+        "url": "https://localhost:3000/koodisto-service/rest/codeelement/posti_00350/1",
+        "method": "GET",
+        "status": 200,
+        "headers": {},
+        "body": null,
+        "response": {
+          "koodiUri": "posti_00350",
+          "resourceUri": "https://virkailija.hahtuvaopintopolku.fi/koodisto-service/rest/codeelement/posti_00350/1",
+          "version": 1,
+          "versio": 1,
+          "koodisto": {
+            "koodistoUri": "posti",
+            "organisaatioOid": "1.2.246.562.10.00000000001",
+            "koodistoVersios": [
+              1
+            ]
+          },
+          "koodiArvo": "00350",
+          "paivitysPvm": 1427461978048,
+          "voimassaAlkuPvm": "2000-01-01",
+          "voimassaLoppuPvm": null,
+          "tila": "LUONNOS",
+          "metadata": [
+            {
+              "nimi": "posti_00350",
+              "kuvaus": "posti_00350",
+              "lyhytNimi": "posti_00350",
+              "kieli": "fi"
+            },
+            {
+              "nimi": "posti_00350",
+              "kuvaus": "posti_00350",
+              "lyhytNimi": "posti_00350",
+              "kieli": "sv"
+            },
+            {
+              "nimi": "posti_00350",
+              "kuvaus": "posti_00350",
+              "lyhytNimi": "posti_00350",
+              "kieli": "en"
+            }
+          ]
+        }
+      },
+      {
+        "url": "https://localhost:3000/koodisto-service/rest/json/valintakokeentyyppi/koodi?onlyValidKoodis=true&koodistoVersio=",
+        "method": "GET",
+        "status": 200,
+        "headers": {},
+        "body": null,
+        "response": [
+          {
+            "koodiUri": "valintakokeentyyppi_0",
+            "resourceUri": "https://virkailija.hahtuvaopintopolku.fi/koodisto-service/rest/codeelement/valintakokeentyyppi_11",
+            "version": 1,
+            "versio": 1,
+            "koodisto": {
+              "koodistoUri": "valintakokeentyyppi",
+              "organisaatioOid": "1.2.246.562.10.00000000001",
+              "koodistoVersios": [
+                1
+              ]
+            },
+            "koodiArvo": "0",
+            "paivitysPvm": 1427461978048,
+            "voimassaAlkuPvm": "2000-01-01",
+            "voimassaLoppuPvm": null,
+            "tila": "LUONNOS",
+            "metadata": [
+              {
+                "nimi": "valintakokeentyyppi_0",
+                "kuvaus": "valintakokeentyyppi_0",
+                "lyhytNimi": "valintakokeentyyppi_0",
+                "kieli": "fi"
+              },
+              {
+                "nimi": "valintakokeentyyppi_0",
+                "kuvaus": "valintakokeentyyppi_0",
+                "lyhytNimi": "valintakokeentyyppi_0",
+                "kieli": "sv"
+              },
+              {
+                "nimi": "valintakokeentyyppi_0",
+                "kuvaus": "valintakokeentyyppi_0",
+                "lyhytNimi": "valintakokeentyyppi_0",
+                "kieli": "en"
+              }
+            ]
+          },
+          {
+            "koodiUri": "valintakokeentyyppi_1",
+            "resourceUri": "https://virkailija.hahtuvaopintopolku.fi/koodisto-service/rest/codeelement/valintakokeentyyppi_11",
+            "version": 1,
+            "versio": 1,
+            "koodisto": {
+              "koodistoUri": "valintakokeentyyppi",
+              "organisaatioOid": "1.2.246.562.10.00000000001",
+              "koodistoVersios": [
+                1
+              ]
+            },
+            "koodiArvo": "1",
+            "paivitysPvm": 1427461978048,
+            "voimassaAlkuPvm": "2000-01-01",
+            "voimassaLoppuPvm": null,
+            "tila": "LUONNOS",
+            "metadata": [
+              {
+                "nimi": "valintakokeentyyppi_1",
+                "kuvaus": "valintakokeentyyppi_1",
+                "lyhytNimi": "valintakokeentyyppi_1",
+                "kieli": "fi"
+              },
+              {
+                "nimi": "valintakokeentyyppi_1",
+                "kuvaus": "valintakokeentyyppi_1",
+                "lyhytNimi": "valintakokeentyyppi_1",
+                "kieli": "sv"
+              },
+              {
+                "nimi": "valintakokeentyyppi_1",
+                "kuvaus": "valintakokeentyyppi_1",
+                "lyhytNimi": "valintakokeentyyppi_1",
+                "kieli": "en"
+              }
+            ]
+          },
+          {
+            "koodiUri": "valintakokeentyyppi_2",
+            "resourceUri": "https://virkailija.hahtuvaopintopolku.fi/koodisto-service/rest/codeelement/valintakokeentyyppi_11",
+            "version": 1,
+            "versio": 1,
+            "koodisto": {
+              "koodistoUri": "valintakokeentyyppi",
+              "organisaatioOid": "1.2.246.562.10.00000000001",
+              "koodistoVersios": [
+                1
+              ]
+            },
+            "koodiArvo": "2",
+            "paivitysPvm": 1427461978048,
+            "voimassaAlkuPvm": "2000-01-01",
+            "voimassaLoppuPvm": null,
+            "tila": "LUONNOS",
+            "metadata": [
+              {
+                "nimi": "valintakokeentyyppi_2",
+                "kuvaus": "valintakokeentyyppi_2",
+                "lyhytNimi": "valintakokeentyyppi_2",
+                "kieli": "fi"
+              },
+              {
+                "nimi": "valintakokeentyyppi_2",
+                "kuvaus": "valintakokeentyyppi_2",
+                "lyhytNimi": "valintakokeentyyppi_2",
+                "kieli": "sv"
+              },
+              {
+                "nimi": "valintakokeentyyppi_2",
+                "kuvaus": "valintakokeentyyppi_2",
+                "lyhytNimi": "valintakokeentyyppi_2",
+                "kieli": "en"
+              }
+            ]
+          },
+          {
+            "koodiUri": "valintakokeentyyppi_3",
+            "resourceUri": "https://virkailija.hahtuvaopintopolku.fi/koodisto-service/rest/codeelement/valintakokeentyyppi_11",
+            "version": 1,
+            "versio": 1,
+            "koodisto": {
+              "koodistoUri": "valintakokeentyyppi",
+              "organisaatioOid": "1.2.246.562.10.00000000001",
+              "koodistoVersios": [
+                1
+              ]
+            },
+            "koodiArvo": "3",
+            "paivitysPvm": 1427461978048,
+            "voimassaAlkuPvm": "2000-01-01",
+            "voimassaLoppuPvm": null,
+            "tila": "LUONNOS",
+            "metadata": [
+              {
+                "nimi": "valintakokeentyyppi_3",
+                "kuvaus": "valintakokeentyyppi_3",
+                "lyhytNimi": "valintakokeentyyppi_3",
+                "kieli": "fi"
+              },
+              {
+                "nimi": "valintakokeentyyppi_3",
+                "kuvaus": "valintakokeentyyppi_3",
+                "lyhytNimi": "valintakokeentyyppi_3",
+                "kieli": "sv"
+              },
+              {
+                "nimi": "valintakokeentyyppi_3",
+                "kuvaus": "valintakokeentyyppi_3",
+                "lyhytNimi": "valintakokeentyyppi_3",
+                "kieli": "en"
+              }
+            ]
+          },
+          {
+            "koodiUri": "valintakokeentyyppi_4",
+            "resourceUri": "https://virkailija.hahtuvaopintopolku.fi/koodisto-service/rest/codeelement/valintakokeentyyppi_11",
+            "version": 1,
+            "versio": 1,
+            "koodisto": {
+              "koodistoUri": "valintakokeentyyppi",
+              "organisaatioOid": "1.2.246.562.10.00000000001",
+              "koodistoVersios": [
+                1
+              ]
+            },
+            "koodiArvo": "4",
+            "paivitysPvm": 1427461978048,
+            "voimassaAlkuPvm": "2000-01-01",
+            "voimassaLoppuPvm": null,
+            "tila": "LUONNOS",
+            "metadata": [
+              {
+                "nimi": "valintakokeentyyppi_4",
+                "kuvaus": "valintakokeentyyppi_4",
+                "lyhytNimi": "valintakokeentyyppi_4",
+                "kieli": "fi"
+              },
+              {
+                "nimi": "valintakokeentyyppi_4",
+                "kuvaus": "valintakokeentyyppi_4",
+                "lyhytNimi": "valintakokeentyyppi_4",
+                "kieli": "sv"
+              },
+              {
+                "nimi": "valintakokeentyyppi_4",
+                "kuvaus": "valintakokeentyyppi_4",
+                "lyhytNimi": "valintakokeentyyppi_4",
+                "kieli": "en"
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "url": "https://localhost:3000/koodisto-service/rest/codeelement/posti_0/2",
+        "method": "GET",
+        "status": 200,
+        "headers": {},
+        "body": null,
+        "response": {
+          "koodiUri": "posti_0",
+          "resourceUri": "https://virkailija.hahtuvaopintopolku.fi/koodisto-service/rest/codeelement/posti_0/2",
+          "version": 2,
+          "versio": 2,
+          "koodisto": {
+            "koodistoUri": "posti",
+            "organisaatioOid": "1.2.246.562.10.00000000001",
+            "koodistoVersios": [
+              2
+            ]
+          },
+          "koodiArvo": "0",
+          "paivitysPvm": 1427461978048,
+          "voimassaAlkuPvm": "2000-01-01",
+          "voimassaLoppuPvm": null,
+          "tila": "LUONNOS",
+          "metadata": [
+            {
+              "nimi": "posti_0",
+              "kuvaus": "posti_0",
+              "lyhytNimi": "posti_0",
+              "kieli": "fi"
+            },
+            {
+              "nimi": "posti_0",
+              "kuvaus": "posti_0",
+              "lyhytNimi": "posti_0",
+              "kieli": "sv"
+            },
+            {
+              "nimi": "posti_0",
+              "kuvaus": "posti_0",
+              "lyhytNimi": "posti_0",
+              "kieli": "en"
+            }
+          ]
+        }
+      },
+      {
+        "url": "https://localhost:3000/koodisto-service/rest/json/liitetyypitamm/koodi?onlyValidKoodis=true&koodistoVersio=",
+        "method": "GET",
+        "status": 200,
+        "headers": {},
+        "body": null,
+        "response": [
+          {
+            "koodiUri": "liitetyypitamm_0",
+            "resourceUri": "https://virkailija.hahtuvaopintopolku.fi/koodisto-service/rest/codeelement/liitetyypitamm_11",
+            "version": 1,
+            "versio": 1,
+            "koodisto": {
+              "koodistoUri": "liitetyypitamm",
+              "organisaatioOid": "1.2.246.562.10.00000000001",
+              "koodistoVersios": [
+                1
+              ]
+            },
+            "koodiArvo": "0",
+            "paivitysPvm": 1427461978048,
+            "voimassaAlkuPvm": "2000-01-01",
+            "voimassaLoppuPvm": null,
+            "tila": "LUONNOS",
+            "metadata": [
+              {
+                "nimi": "liitetyypitamm_0",
+                "kuvaus": "liitetyypitamm_0",
+                "lyhytNimi": "liitetyypitamm_0",
+                "kieli": "fi"
+              },
+              {
+                "nimi": "liitetyypitamm_0",
+                "kuvaus": "liitetyypitamm_0",
+                "lyhytNimi": "liitetyypitamm_0",
+                "kieli": "sv"
+              },
+              {
+                "nimi": "liitetyypitamm_0",
+                "kuvaus": "liitetyypitamm_0",
+                "lyhytNimi": "liitetyypitamm_0",
+                "kieli": "en"
+              }
+            ]
+          },
+          {
+            "koodiUri": "liitetyypitamm_1",
+            "resourceUri": "https://virkailija.hahtuvaopintopolku.fi/koodisto-service/rest/codeelement/liitetyypitamm_11",
+            "version": 1,
+            "versio": 1,
+            "koodisto": {
+              "koodistoUri": "liitetyypitamm",
+              "organisaatioOid": "1.2.246.562.10.00000000001",
+              "koodistoVersios": [
+                1
+              ]
+            },
+            "koodiArvo": "1",
+            "paivitysPvm": 1427461978048,
+            "voimassaAlkuPvm": "2000-01-01",
+            "voimassaLoppuPvm": null,
+            "tila": "LUONNOS",
+            "metadata": [
+              {
+                "nimi": "liitetyypitamm_1",
+                "kuvaus": "liitetyypitamm_1",
+                "lyhytNimi": "liitetyypitamm_1",
+                "kieli": "fi"
+              },
+              {
+                "nimi": "liitetyypitamm_1",
+                "kuvaus": "liitetyypitamm_1",
+                "lyhytNimi": "liitetyypitamm_1",
+                "kieli": "sv"
+              },
+              {
+                "nimi": "liitetyypitamm_1",
+                "kuvaus": "liitetyypitamm_1",
+                "lyhytNimi": "liitetyypitamm_1",
+                "kieli": "en"
+              }
+            ]
+          },
+          {
+            "koodiUri": "liitetyypitamm_2",
+            "resourceUri": "https://virkailija.hahtuvaopintopolku.fi/koodisto-service/rest/codeelement/liitetyypitamm_11",
+            "version": 1,
+            "versio": 1,
+            "koodisto": {
+              "koodistoUri": "liitetyypitamm",
+              "organisaatioOid": "1.2.246.562.10.00000000001",
+              "koodistoVersios": [
+                1
+              ]
+            },
+            "koodiArvo": "2",
+            "paivitysPvm": 1427461978048,
+            "voimassaAlkuPvm": "2000-01-01",
+            "voimassaLoppuPvm": null,
+            "tila": "LUONNOS",
+            "metadata": [
+              {
+                "nimi": "liitetyypitamm_2",
+                "kuvaus": "liitetyypitamm_2",
+                "lyhytNimi": "liitetyypitamm_2",
+                "kieli": "fi"
+              },
+              {
+                "nimi": "liitetyypitamm_2",
+                "kuvaus": "liitetyypitamm_2",
+                "lyhytNimi": "liitetyypitamm_2",
+                "kieli": "sv"
+              },
+              {
+                "nimi": "liitetyypitamm_2",
+                "kuvaus": "liitetyypitamm_2",
+                "lyhytNimi": "liitetyypitamm_2",
+                "kieli": "en"
+              }
+            ]
+          },
+          {
+            "koodiUri": "liitetyypitamm_3",
+            "resourceUri": "https://virkailija.hahtuvaopintopolku.fi/koodisto-service/rest/codeelement/liitetyypitamm_11",
+            "version": 1,
+            "versio": 1,
+            "koodisto": {
+              "koodistoUri": "liitetyypitamm",
+              "organisaatioOid": "1.2.246.562.10.00000000001",
+              "koodistoVersios": [
+                1
+              ]
+            },
+            "koodiArvo": "3",
+            "paivitysPvm": 1427461978048,
+            "voimassaAlkuPvm": "2000-01-01",
+            "voimassaLoppuPvm": null,
+            "tila": "LUONNOS",
+            "metadata": [
+              {
+                "nimi": "liitetyypitamm_3",
+                "kuvaus": "liitetyypitamm_3",
+                "lyhytNimi": "liitetyypitamm_3",
+                "kieli": "fi"
+              },
+              {
+                "nimi": "liitetyypitamm_3",
+                "kuvaus": "liitetyypitamm_3",
+                "lyhytNimi": "liitetyypitamm_3",
+                "kieli": "sv"
+              },
+              {
+                "nimi": "liitetyypitamm_3",
+                "kuvaus": "liitetyypitamm_3",
+                "lyhytNimi": "liitetyypitamm_3",
+                "kieli": "en"
+              }
+            ]
+          },
+          {
+            "koodiUri": "liitetyypitamm_4",
+            "resourceUri": "https://virkailija.hahtuvaopintopolku.fi/koodisto-service/rest/codeelement/liitetyypitamm_11",
+            "version": 1,
+            "versio": 1,
+            "koodisto": {
+              "koodistoUri": "liitetyypitamm",
+              "organisaatioOid": "1.2.246.562.10.00000000001",
+              "koodistoVersios": [
+                1
+              ]
+            },
+            "koodiArvo": "4",
+            "paivitysPvm": 1427461978048,
+            "voimassaAlkuPvm": "2000-01-01",
+            "voimassaLoppuPvm": null,
+            "tila": "LUONNOS",
+            "metadata": [
+              {
+                "nimi": "liitetyypitamm_4",
+                "kuvaus": "liitetyypitamm_4",
+                "lyhytNimi": "liitetyypitamm_4",
+                "kieli": "fi"
+              },
+              {
+                "nimi": "liitetyypitamm_4",
+                "kuvaus": "liitetyypitamm_4",
+                "lyhytNimi": "liitetyypitamm_4",
+                "kieli": "sv"
+              },
+              {
+                "nimi": "liitetyypitamm_4",
+                "kuvaus": "liitetyypitamm_4",
+                "lyhytNimi": "liitetyypitamm_4",
+                "kieli": "en"
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "url": "https://localhost:3000/organisaatio-service/rest/organisaatio/v4/hierarkia/hae?oid=1.2.246.562.10.52251087186&aktiiviset=true&suunnitellut=true&lakkautetut=false",
+        "method": "GET",
+        "status": 200,
+        "headers": {},
+        "body": null,
+        "response": {
+          "numHits": 16,
+          "organisaatiot": [
+            {
+              "oid": "1.2.246.562.10.346830761110",
+              "alkuPvm": 268005600000,
+              "parentOid": "1.2.246.562.10.00000000001",
+              "parentOidPath": "1.2.246.562.10.346830761110/1.2.246.562.10.00000000001",
+              "ytunnus": "0201256-6",
+              "toimipistekoodi": "",
+              "match": false,
+              "nimi": {
+                "fi": "Helsingin kaupunki",
+                "sv": "Helsingfors stad"
+              },
+              "kieletUris": [
+                "oppilaitoksenopetuskieli_1#1",
+                "oppilaitoksenopetuskieli_2#1",
+                "oppilaitoksenopetuskieli_3#1"
+              ],
+              "kotipaikkaUri": "kunta_091",
+              "children": [
+                {
+                  "oid": "1.2.246.562.10.52251087186",
+                  "alkuPvm": 1356991200000,
+                  "parentOid": "1.2.246.562.10.346830761110",
+                  "parentOidPath": "1.2.246.562.10.52251087186/1.2.246.562.10.346830761110/1.2.246.562.10.00000000001",
+                  "oppilaitosKoodi": "10105",
+                  "oppilaitostyyppi": "oppilaitostyyppi_21#1",
+                  "toimipistekoodi": "10105",
+                  "match": true,
+                  "nimi": {
+                    "fi": "Stadin ammatti- ja aikuisopisto",
+                    "sv": "Stadin ammatti- ja aikuisopisto",
+                    "en": "Stadin ammatti- ja aikuisopisto"
+                  },
+                  "kieletUris": [
+                    "oppilaitoksenopetuskieli_1#1"
+                  ],
+                  "kotipaikkaUri": "kunta_091",
+                  "children": [
+                    {
+                      "oid": "1.2.246.562.10.879177258610",
+                      "alkuPvm": 1356991200000,
+                      "parentOid": "1.2.246.562.10.52251087186",
+                      "parentOidPath": "1.2.246.562.10.879177258610/1.2.246.562.10.52251087186/1.2.246.562.10.346830761110/1.2.246.562.10.00000000001",
+                      "toimipistekoodi": "1010507",
+                      "match": false,
+                      "nimi": {
+                        "fi": "Stadin ammatti- ja aikuisopisto, Muotoilijankadun toimipaikka",
+                        "en": "Helsinki City College, Muotoilijankatu"
+                      },
+                      "kieletUris": [
+                        "oppilaitoksenopetuskieli_1#1"
+                      ],
+                      "kotipaikkaUri": "kunta_091",
+                      "children": [],
+                      "aliOrganisaatioMaara": 0,
+                      "organisaatiotyypit": [
+                        "organisaatiotyyppi_03"
+                      ],
+                      "status": "AKTIIVINEN"
+                    },
+                    {
+                      "oid": "1.2.246.562.10.23017513880",
+                      "alkuPvm": 1470603600000,
+                      "parentOid": "1.2.246.562.10.52251087186",
+                      "parentOidPath": "1.2.246.562.10.23017513880/1.2.246.562.10.52251087186/1.2.246.562.10.346830761110/1.2.246.562.10.00000000001",
+                      "toimipistekoodi": "1010517",
+                      "match": false,
+                      "nimi": {
+                        "fi": "Stadin ammatti- ja aikuisopisto, Hattulantien toimipaikka"
+                      },
+                      "kieletUris": [
+                        "oppilaitoksenopetuskieli_1#1"
+                      ],
+                      "kotipaikkaUri": "kunta_091",
+                      "children": [],
+                      "aliOrganisaatioMaara": 0,
+                      "organisaatiotyypit": [
+                        "organisaatiotyyppi_03"
+                      ],
+                      "status": "AKTIIVINEN"
+                    },
+                    {
+                      "oid": "1.2.246.562.10.656909794910",
+                      "alkuPvm": 1356991200000,
+                      "parentOid": "1.2.246.562.10.52251087186",
+                      "parentOidPath": "1.2.246.562.10.656909794910/1.2.246.562.10.52251087186/1.2.246.562.10.346830761110/1.2.246.562.10.00000000001",
+                      "toimipistekoodi": "1010508",
+                      "match": false,
+                      "nimi": {
+                        "fi": "Stadin ammatti- ja aikuisopisto, Prinsessantien toimipaikka"
+                      },
+                      "kieletUris": [
+                        "oppilaitoksenopetuskieli_1#1"
+                      ],
+                      "kotipaikkaUri": "kunta_091",
+                      "children": [],
+                      "aliOrganisaatioMaara": 0,
+                      "organisaatiotyypit": [
+                        "organisaatiotyyppi_03"
+                      ],
+                      "status": "AKTIIVINEN"
+                    },
+                    {
+                      "oid": "1.2.246.562.10.93115250668",
+                      "alkuPvm": 1413234000000,
+                      "parentOid": "1.2.246.562.10.52251087186",
+                      "parentOidPath": "1.2.246.562.10.93115250668/1.2.246.562.10.52251087186/1.2.246.562.10.346830761110/1.2.246.562.10.00000000001",
+                      "toimipistekoodi": "1010515",
+                      "match": false,
+                      "nimi": {
+                        "fi": "Stadin ammatti- ja aikuisopisto, Meritalon toimipaikka"
+                      },
+                      "kieletUris": [
+                        "oppilaitoksenopetuskieli_1#1"
+                      ],
+                      "kotipaikkaUri": "kunta_091",
+                      "children": [],
+                      "aliOrganisaatioMaara": 0,
+                      "organisaatiotyypit": [
+                        "organisaatiotyyppi_03"
+                      ],
+                      "status": "AKTIIVINEN"
+                    },
+                    {
+                      "oid": "1.2.246.562.10.60465978314",
+                      "alkuPvm": 1356991200000,
+                      "parentOid": "1.2.246.562.10.52251087186",
+                      "parentOidPath": "1.2.246.562.10.60465978314/1.2.246.562.10.52251087186/1.2.246.562.10.346830761110/1.2.246.562.10.00000000001",
+                      "toimipistekoodi": "1010503",
+                      "match": false,
+                      "nimi": {
+                        "fi": "Stadin ammatti- ja aikuisopisto, Holkkitien toimipaikka"
+                      },
+                      "kieletUris": [
+                        "oppilaitoksenopetuskieli_1#1"
+                      ],
+                      "kotipaikkaUri": "kunta_091",
+                      "children": [],
+                      "aliOrganisaatioMaara": 0,
+                      "organisaatiotyypit": [
+                        "organisaatiotyyppi_03"
+                      ],
+                      "status": "AKTIIVINEN"
+                    },
+                    {
+                      "oid": "1.2.246.562.10.55355715099",
+                      "alkuPvm": 1356991200000,
+                      "parentOid": "1.2.246.562.10.52251087186",
+                      "parentOidPath": "1.2.246.562.10.55355715099/1.2.246.562.10.52251087186/1.2.246.562.10.346830761110/1.2.246.562.10.00000000001",
+                      "toimipistekoodi": "1010504",
+                      "match": false,
+                      "nimi": {
+                        "fi": "Stadin ammatti- ja aikuisopisto, Ilkantien toimipaikka"
+                      },
+                      "kieletUris": [
+                        "oppilaitoksenopetuskieli_1#1"
+                      ],
+                      "kotipaikkaUri": "kunta_091",
+                      "children": [],
+                      "aliOrganisaatioMaara": 0,
+                      "organisaatiotyypit": [
+                        "organisaatiotyyppi_03"
+                      ],
+                      "status": "AKTIIVINEN"
+                    },
+                    {
+                      "oid": "1.2.246.562.10.20485193278",
+                      "alkuPvm": 1356991200000,
+                      "parentOid": "1.2.246.562.10.52251087186",
+                      "parentOidPath": "1.2.246.562.10.20485193278/1.2.246.562.10.52251087186/1.2.246.562.10.346830761110/1.2.246.562.10.00000000001",
+                      "toimipistekoodi": "1010502",
+                      "match": false,
+                      "nimi": {
+                        "fi": "Stadin ammatti- ja aikuisopisto, Vilppulantien toimipaikka"
+                      },
+                      "kieletUris": [
+                        "oppilaitoksenopetuskieli_1#1"
+                      ],
+                      "kotipaikkaUri": "kunta_091",
+                      "children": [],
+                      "aliOrganisaatioMaara": 0,
+                      "organisaatiotyypit": [
+                        "organisaatiotyyppi_03"
+                      ],
+                      "status": "AKTIIVINEN"
+                    },
+                    {
+                      "oid": "1.2.246.562.10.2013081415065445951365",
+                      "alkuPvm": 1375304400000,
+                      "parentOid": "1.2.246.562.10.52251087186",
+                      "parentOidPath": "1.2.246.562.10.2013081415065445951365/1.2.246.562.10.52251087186/1.2.246.562.10.346830761110/1.2.246.562.10.00000000001",
+                      "toimipistekoodi": "1010514",
+                      "match": false,
+                      "nimi": {
+                        "fi": "Stadin ammatti- ja aikuisopisto, Pälkäneentien toimipaikka"
+                      },
+                      "kieletUris": [
+                        "oppilaitoksenopetuskieli_1#1"
+                      ],
+                      "kotipaikkaUri": "kunta_091",
+                      "children": [],
+                      "aliOrganisaatioMaara": 0,
+                      "organisaatiotyypit": [
+                        "organisaatiotyyppi_03"
+                      ],
+                      "status": "AKTIIVINEN"
+                    },
+                    {
+                      "oid": "1.2.246.562.10.45854578546",
+                      "alkuPvm": 1413234000000,
+                      "parentOid": "1.2.246.562.10.52251087186",
+                      "parentOidPath": "1.2.246.562.10.45854578546/1.2.246.562.10.52251087186/1.2.246.562.10.346830761110/1.2.246.562.10.00000000001",
+                      "toimipistekoodi": "1010516",
+                      "match": false,
+                      "nimi": {
+                        "fi": "Stadin ammatti- ja aikuisopisto, Myllypuron toimipaikka"
+                      },
+                      "kieletUris": [
+                        "oppilaitoksenopetuskieli_1#1"
+                      ],
+                      "kotipaikkaUri": "kunta_091",
+                      "children": [],
+                      "aliOrganisaatioMaara": 0,
+                      "organisaatiotyypit": [
+                        "organisaatiotyyppi_03"
+                      ],
+                      "status": "AKTIIVINEN"
+                    },
+                    {
+                      "oid": "1.2.246.562.10.16538823663",
+                      "alkuPvm": 1356991200000,
+                      "parentOid": "1.2.246.562.10.52251087186",
+                      "parentOidPath": "1.2.246.562.10.16538823663/1.2.246.562.10.52251087186/1.2.246.562.10.346830761110/1.2.246.562.10.00000000001",
+                      "toimipistekoodi": "1010510",
+                      "match": false,
+                      "nimi": {
+                        "fi": "Stadin ammatti- ja aikuisopisto, Sturenkadun toimipaikka"
+                      },
+                      "kieletUris": [
+                        "oppilaitoksenopetuskieli_1#1"
+                      ],
+                      "kotipaikkaUri": "kunta_091",
+                      "children": [],
+                      "aliOrganisaatioMaara": 0,
+                      "organisaatiotyypit": [
+                        "organisaatiotyyppi_03"
+                      ],
+                      "status": "AKTIIVINEN"
+                    },
+                    {
+                      "oid": "1.2.246.562.10.20866993056",
+                      "alkuPvm": 1356991200000,
+                      "parentOid": "1.2.246.562.10.52251087186",
+                      "parentOidPath": "1.2.246.562.10.20866993056/1.2.246.562.10.52251087186/1.2.246.562.10.346830761110/1.2.246.562.10.00000000001",
+                      "toimipistekoodi": "1010505",
+                      "match": false,
+                      "nimi": {
+                        "fi": "Stadin ammatti- ja aikuisopisto, Kullervonkadun toimipaikka"
+                      },
+                      "kieletUris": [
+                        "oppilaitoksenopetuskieli_1#1"
+                      ],
+                      "kotipaikkaUri": "kunta_091",
+                      "children": [],
+                      "aliOrganisaatioMaara": 0,
+                      "organisaatiotyypit": [
+                        "organisaatiotyyppi_03"
+                      ],
+                      "status": "AKTIIVINEN"
+                    },
+                    {
+                      "oid": "1.2.246.562.10.78321186062",
+                      "alkuPvm": 1356991200000,
+                      "parentOid": "1.2.246.562.10.52251087186",
+                      "parentOidPath": "1.2.246.562.10.78321186062/1.2.246.562.10.52251087186/1.2.246.562.10.346830761110/1.2.246.562.10.00000000001",
+                      "toimipistekoodi": "1010509",
+                      "match": false,
+                      "nimi": {
+                        "fi": "Stadin ammatti- ja aikuisopisto, Savonkadun toimipaikka"
+                      },
+                      "kieletUris": [
+                        "oppilaitoksenopetuskieli_1#1"
+                      ],
+                      "kotipaikkaUri": "kunta_091",
+                      "children": [],
+                      "aliOrganisaatioMaara": 0,
+                      "organisaatiotyypit": [
+                        "organisaatiotyyppi_03"
+                      ],
+                      "status": "AKTIIVINEN"
+                    },
+                    {
+                      "oid": "1.2.246.562.10.55711304158",
+                      "alkuPvm": 1356991200000,
+                      "parentOid": "1.2.246.562.10.52251087186",
+                      "parentOidPath": "1.2.246.562.10.55711304158/1.2.246.562.10.52251087186/1.2.246.562.10.346830761110/1.2.246.562.10.00000000001",
+                      "toimipistekoodi": "1010519",
+                      "match": false,
+                      "nimi": {
+                        "fi": "Stadin ammatti- ja aikuisopisto, Teollisuuskadun toimipaikka"
+                      },
+                      "kieletUris": [
+                        "oppilaitoksenopetuskieli_1#1"
+                      ],
+                      "kotipaikkaUri": "kunta_091",
+                      "children": [],
+                      "aliOrganisaatioMaara": 0,
+                      "organisaatiotyypit": [
+                        "organisaatiotyyppi_03"
+                      ],
+                      "status": "AKTIIVINEN"
+                    },
+                    {
+                      "oid": "1.2.246.562.10.56139411567",
+                      "alkuPvm": 1356991200000,
+                      "parentOid": "1.2.246.562.10.52251087186",
+                      "parentOidPath": "1.2.246.562.10.56139411567/1.2.246.562.10.52251087186/1.2.246.562.10.346830761110/1.2.246.562.10.00000000001",
+                      "toimipistekoodi": "1010501",
+                      "match": false,
+                      "nimi": {
+                        "fi": "Stadin ammatti- ja aikuisopisto, Abraham Wetterin tien toimipaikka"
+                      },
+                      "kieletUris": [
+                        "oppilaitoksenopetuskieli_1#1"
+                      ],
+                      "kotipaikkaUri": "kunta_091",
+                      "children": [],
+                      "aliOrganisaatioMaara": 0,
+                      "organisaatiotyypit": [
+                        "organisaatiotyyppi_03"
+                      ],
+                      "status": "AKTIIVINEN"
+                    }
+                  ],
+                  "aliOrganisaatioMaara": 14,
+                  "organisaatiotyypit": [
+                    "organisaatiotyyppi_02"
+                  ],
+                  "status": "AKTIIVINEN"
+                }
+              ],
+              "aliOrganisaatioMaara": 621,
+              "organisaatiotyypit": [
+                "organisaatiotyyppi_01",
+                "organisaatiotyyppi_07"
+              ],
+              "status": "AKTIIVINEN"
+            }
+          ]
+        }
+      },
+      {
+        "url": "https://localhost:3000/organisaatio-service/rest/organisaatio/v4/findbyoids",
+        "method": "POST",
+        "status": 200,
+        "headers": {},
+        "body": [
+          "1.2.246.562.10.52251087186"
+        ],
+        "response": [
+          {
+            "metadata": {
+              "nimi": {},
+              "hakutoimistoEctsNimi": {},
+              "hakutoimistoEctsEmail": {},
+              "hakutoimistoEctsPuhelin": {},
+              "hakutoimistoEctsTehtavanimike": {},
+              "yhteystiedot": [
+                {
+                  "kieli": "kieli_fi#1",
+                  "www": "http://www.stadinammattiopisto.fi",
+                  "yhteystietoOid": "14812023190550.9836378324069386",
+                  "id": "3861227"
+                },
+                {
+                  "kieli": "kieli_fi#1",
+                  "numero": "09 310 89318",
+                  "tyyppi": "puhelin",
+                  "yhteystietoOid": "1.2.246.562.5.62477770688",
+                  "id": "3861228"
+                },
+                {
+                  "kieli": "kieli_fi#1",
+                  "yhteystietoOid": "14303205263410.7259206293670477",
+                  "id": "3861229",
+                  "email": "hakutoimisto@edu.hel.fi"
+                },
+                {
+                  "osoiteTyyppi": "posti",
+                  "kieli": "kieli_fi#1",
+                  "postinumeroUri": "posti_00099",
+                  "yhteystietoOid": "1.2.246.562.5.20277448420",
+                  "id": "3861230",
+                  "postitoimipaikka": "HELSINGIN KAUPUNKI",
+                  "osoite": "PL 55306"
+                },
+                {
+                  "osoiteTyyppi": "kaynti",
+                  "kieli": "kieli_fi#1",
+                  "postinumeroUri": "posti_00550",
+                  "yhteystietoOid": "1.2.246.562.5.26047810076",
+                  "id": "3861231",
+                  "postitoimipaikka": "HELSINKI",
+                  "osoite": "Hattulantie 2, 1. krs"
+                }
+              ],
+              "hakutoimistonNimi": {
+                "kieli_fi#1": "Stadin ammatti- ja aikuisopiston hakutoimisto"
+              },
+              "luontiPvm": 1376895579333,
+              "muokkausPvm": 1376859600000,
+              "data": {
+                "KANSAINVALISET_KOULUTUSOHJELMAT": {},
+                "YLEISKUVAUS": {
+                  "kieli_fi#1": "<p>Stadin ammatti- ja aikuisopisto järjestää ammatillista peruskoulutusta, ammatillista täydennyskoulutusta, oppisopimuskoulutusta ja nivelvaiheen koulutusta Helsingin kaupungin alueella 15 eri toimipaikassa. Meillä Suomen suurimmassa ammattiopistossa opiskelee noin 17 000 nuorta ja aikuista yli 50 eri ammattiin.</p> <p>Kun suoritat ammatillisen koulutuksen, saat laaja-alaiset valmiudet toimia oman alasi erilaisissa ja vaihtelevissa työtehtävissä sekä kehittää ammattitaitoasi läpi elämän. Lisäksi ammatillinen perustutkinto antaa sinulle yleisen jatko-opintokelpoisuuden ammattikorkeakouluihin ja yliopistoihin.</p> <p>Stadin ammatti- ja aikuisopistossa voit opiskella joustavasti eri oppimisratkaisuin. Opintojen suunnittelussa huomioidaan aina opiskelijan aiempi osaaminen esimerkiksi yhdistämällä oppilaitosmuotoista opiskelua ja oppisopimuskoulutusta. Lisäksi ammatilliseen perustutkintoon johtavassa koulutuksessa on mahdollista suorittaa lukio-opintoja sekä hakea ohjattuun urheiluvalmennukseen.</p> <p>Stadin ammatti- ja aikuisopiston Brygga tarjoaa nivelvaiheen koulutusta ja palveluja. Siihen kuuluvat ammatilliseen koulutukseen valmentava koulutus (VALMA), osa kaupungin perusopetuksen lisäopetuksesta (kymppiluokat), avoimet opinnot ja nuorten työpajatoiminta. Stadin osaamiskeskus puolestaan yhdistää kuntoutuksen, koulutuksen ja työllistymisen palvelut helsinkiläisille aikuisille maahanmuuttajille.</p> <p>Lisätietoa Stadin ammatti- ja aikuisopiston koulutustarjonnasta löytyy nettisivuiltamme www.stadinammattiopisto.fi</p> <p> </p>"
+                },
+                "KIELIOPINNOT": {
+                  "kieli_fi#1": "<p>Kaikkiin perustutkintoihin kuuluu vähintään 2 osaamispistettä englantia (A-kieli) ja 1 osaamispistettä ruotsia. Lisäksi joissain toimipaikoissa voit valinnaisissa opinnoissa opiskella ylimääräisiä kieliä.</p>"
+                },
+                "TERVEYDENHUOLTOPALVELUT": {
+                  "kieli_fi#1": "<p>Stadin ammatti- ja aikuisopistossa on sekä terveydenhoitajia että lääkäreitä opiskelijoita varten. Ensimmäisenä opiskeluvuonna terveydenhoitaja kutsuu sinut terveystarkastukseen, jossa selvitetään opiskelun tai ammatissa toimimisen kannalta tärkeät seikat. Lääkärin vastaanotolle haetaan terveydenhoitajan kautta.</p> <p>Oppilaitoksessa ei ole hammashoitolaa. Opiskelijat käyttävät oman asuinalueensa terveysaseman palveluita.</p>"
+                },
+                "TEHTAVANIMIKE": {},
+                "SAHKOPOSTIOSOITE": {},
+                "RAHOITUS": {},
+                "AIEMMIN_HANKITTU_OSAAMINEN": {
+                  "kieli_fi#1": "<p>Osaamisen tunnistaminen ja tunnustaminen</p> <p>Ennalta hankittu osaaminen, kuten aiemmin suoritetut opinnot tai työkokemus, voidaan sisällyttää osaksi ammatillista tutkintoasi, mikäli osaamisesi on opetussuunnitelman mukaista. Tällöin opiskeluaikasi mahdollisesti lyhenee ja valmistut aikaisemmin.</p> <p>Osaamisen tunnistamista ja tunnustamista haetaan lomakkeella, jonka saat opettajaltasi tai opinto-ohjaajaltasi. He myös ohjaavat sen täyttämisessä.</p> <p>Opinnoista vapauttaminen</p> <p>Ruotsin kielestä voit anoa vapautusta, jos et ole opiskellut ruotsia aiemmin. Vapautusta haetaan lomakkeella, jonka saat opettajaltasi tai opinto-ohjaajaltasi. Ruotsin sijasta opiskelet jonkin muun sovitun opinnon.</p>"
+                },
+                "sosiaalinenmedia_7#1": {},
+                "sosiaalinenmedia_5#1": {
+                  "kieli_fi#1": "http://www.pinterest.com/StadinAO"
+                },
+                "sosiaalinenmedia_6#1": {
+                  "kieli_fi#1": "http://www.instagram.com/stadinao"
+                },
+                "OPISKELIJALIIKKUVUUS": {
+                  "kieli_fi#1": "<p>Kansainvälisyys on osa Stadin ammatti- ja aikuisopiston arkea. Tarjoamme opiskelijalle mahdollisuuden lisätä kansainvälisyysosaamista opintojen aikana.  Kotikansainvälistymistä edistetään tarjoamalla kieliin ja kulttuuriin liittyviä oppimistilanteita, virtuaaliliikkuvuutta ja taitaja-toimintaa.</p> <p>Stadin ammatti- ja aikuisopistosta voi lähteä työssäoppimisjaksolle ulkomaille. Kansainväliset vaihdot täydentävät opiskelijoiden työelämävalmiuksia ammatillisen osaamisen, kielitaidon ja kulttuurien tuntemisen kautta sekä tukevat opiskelijan itsenäisyyttä, avoimuutta ja rohkeutta.</p> <p>Ulkomaanjaksoja voi suorittaa mm. Pohjoismaissa, Iso-Britanniassa, Hollannissa, Saksassa, Ranskassa, Espanjassa, Irlannissa, Virossa, Sloveniassa, Itävallassa, Venäjällä ja Kiinassa. Ulkomaanjaksolle lähdetään toisena tai kolmantena opintovuotena.</p>"
+                },
+                "VAKUUTUKSET": {
+                  "kieli_fi#1": "<p>Kaikki opiskelijat on vakuutettu opiskelun aikana sattuneiden tapaturmien varalta. Tapaturma korvataan, jos se on sattunut oppitunnilla, työssäoppimisen aikana, opintokäynneillä tai koulumatkalla. Koulumatkalla vakuutus on voimassa vain, mikäli matka on tapahtunut viivytyksettä ja suorinta, tavanomaista tietä.</p> <p>Vakuutus on voimassa myös ulkomaille suuntautuvien opintomatkojen ja työssäoppimisjaksojen aikana. Oppilaitoksen vakuutukset eivät kuitenkaan ole voimassa, jos olet sairauslomalla. Pidempien sairauslomien ajaksi opinnot yleensä keskeytetään väliaikaisesti.</p>"
+                },
+                "OPISKELIJA_JARJESTOT": {
+                  "kieli_fi#1": "<p>Opiskelijakuntatoiminta ja opiskelijayhdistys STAO ry</p> <p>Jokainen opiskelija kuuluu oman toimipaikkansa opiskelijakuntaan. Kustakin toimipaikasta valitaan lukuvuoden alussa opiskelijakunnan hallitus, jonka tehtävänä on tuoda opiskelijoiden ääni kuuluviin omassa toimipaikassa.</p> <p>STAO ry (Stadin ammattiin opiskelevat) on Stadin ammattiopiston opiskelijayhdistys, johon jokainen opiskelija voi liittyä. Yhdistys edistää opiskelijoiden toimintaa, osallistumista ja hyvinvointia koko oppilaitoksessa.</p>"
+                },
+                "VALINTAMENETTELY": {
+                  "kieli_fi#1": "<p>Kevään yhteishaussa hakevat peruskoulunsa päättävät, ylioppilaat ja muut ilman toisen asteen ammatillista tutkintoa olevat (valintamenettelyssä noudatetaan Oph:n antamia ohjeita). Kaikki muut hakevat jatkuvassa haussa (oppilaitoksen oma valintamenettely, hakija saa valintapäätöksen kolmen viikon kuluessa hakemisesta).</p>"
+                },
+                "sosiaalinenmedia_3#1": {},
+                "sosiaalinenmedia_4#1": {
+                  "kieli_fi#1": "http://www.twitter.com/stadinao"
+                },
+                "sosiaalinenmedia_1#1": {
+                  "kieli_fi#1": "http://www.facebook.com/stadinammattiopisto"
+                },
+                "VASTUUHENKILOT": {},
+                "KUSTANNUKSET": {
+                  "kieli_fi#1": "<p>Opintojensa aikana opiskelijat hankkivat itse esimerkiksi oppikirjoja, kansioita, muistiinpanovälineitä sekä henkilökohtaisia työvälineitä. Osassa tutkinnoista työvaatteet ja -kengät saa oppilaitoksen puolesta.</p>"
+                },
+                "OPPIMISYMPARISTO": {
+                  "kieli_fi#1": "<p>Stadin ammatti- ja aikuisopiston kaikki toimipaikat sijaitsevat Helsingin kaupungin alueella. Toimipaikkojen oppimisympäristöjä uudistetaan monimuotoisiksi ja viihtyisiksi, jolloin ne tukevat opiskelijakeskeistä ja työelämälähtöistä pedagogiikkaa. Opiskelijoiden ja opettajien käytettävissä on mm. kattava, digitaalisuuden hyödyntämistä tukeva wifi.</p>"
+                },
+                "sosiaalinenmedia_2#1": {},
+                "PUHELINNUMERO": {},
+                "NIMI": {},
+                "OPISKELIJALIIKUNTA": {},
+                "VUOSIKELLO": {},
+                "OPISKELIJARUOKAILU": {
+                  "kieli_fi#1": "<p>Stadin ammatti- ja aikuisopistossa on kaikissa toimipaikoissa opiskelijaravintola ja kahvila. Opiskelijoille on koulupäivinä tarjolla yksi maksuton lounasateria. Tarjolla on joka päivä myös kasvislounasvaihtoehto.</p>"
+                },
+                "VAPAA_AIKA": {},
+                "ESTEETOMYYS": {
+                  "kieli_fi#1": "<p>Stadin ammatti- ja aikuisopisto on kaikille yhteinen oppilaitos, jossa jokainen pystyy ominaisuuksistaan riippumatta toimimaan yhdenvertaisesti muiden kanssa, jolloin opiskeluympäristössä ei pitäisi olla liikkumiseen, ryhmään kuulumiseen tai oppimiseen liittyviä esteitä.</p> <p><em> </em></p> <p><em>Opiskeluhuolto</em></p> <p>Opiskeluhuollon tavoitteena on edistää oppimistasi, terveyttäsi ja hyvinvointiasi opiskelun aikana. Opiskelijahuolto huolehtii myös oppilaitosyhteisön hyvinvoinnista sekä opiskeluympäristön terveellisyydestä ja turvallisuudesta. Opiskeluhuoltoa toteutetaan sekä yhteisöllisenä että yksilökohtaisena opiskeluhuoltona.</p> <p><em> </em></p> <p><em>Yhteisöllinen opiskeluhuolto</em></p> <p>Yhteisöllinen opiskeluhuolto edistää opiskelijoiden osallisuutta, oppimista, hyvinvointia ja terveyttä. Lisäksi se seuraa ja kehittää opiskeluyhteisön hyvinvointia sekä opiskeluympäristön terveellisyyttä, turvallisuutta ja esteettömyyttä. Toimipaikan hyvinvointiryhmä vastaa opiskeluhuollon suunnittelusta, kehittämisestä ja arvioinnista yhteisöllisen opiskeluhuollon osa-alueet huomioon ottaen. Ryhmää johtaa apulaisrehtori tai koulutuspäällikkö. Opetushenkilöstön lisäksi ryhmään kuuluu erityisopettaja, opinto-ohjaaja, kuraattori, psykologi, terveydenhoitaja ja opiskelijajäseniä. Ryhmään voi kuulua myös huoltajien edustaja.</p> <p><em> </em></p> <p><em>Yksilökohtainen opiskelijahuolto</em></p> <p>Yksilökohtaisella opiskelijahuollolla tarkoitetaan opiskelijan käytössä olevia palveluja, joita ovat • opiskeluterveydenhuolto • opiskeluhuollon psykologi- ja kuraattoripalvelut • yksittäistä opiskelijaa koskeva monialainen opiskeluhuolto, jota toteutetaan tapauskohtaisesti koottavassa monialaisessa asiantuntijaryhmässä. Yksilökohtaista opiskeluhuoltoa tehdään yhteistyössä opiskelijan kanssa ja hänen suostumuksellaan.</p> <p><em> </em></p> <p><em>Kun tarvitset tukea opinnoissasi</em></p> <p>Opintojesi alussa kanssasi tehdään henkilökohtainen osaamisen kehittämisen suunnitelma (HOKS). Suunnitelmaan kirjataan aiemmin hankittu ja osoitettu osaaminen, tarvittava ammattitaidon ja osaamisen hankkiminen, osaamisen osoittaminen sekä ohjaus- ja tukitoimet. Jos tarvitset erityistä tukea, suunnitelmassa sovitaan sinulle tarjottavan erityisen tuen sisällöstä ja erityisen tuen tarpeen mukaisista toimenpiteistä osaamisen hankkimisen aikana. Erityistä tukea voi saada kaikissa ammatilliseen perustutkintoon johtavissa koulutuksissa.</p>"
+                },
+                "TIETOA_ASUMISESTA": {
+                  "kieli_fi#1": "<p>Stadin ammatti- ja aikuisopistolla ei ole asuntolaa. Tutkintoon johtavassa koulutuksessa oleva opiskelija voi hakea opiskelija-asuntoa esim. HOAS:lta.</p>"
+                },
+                "TYOHARJOITTELU": {
+                  "kieli_fi#1": "<p>Kaikkiin perustutkintoihin kuuluu vähintään 30 osaamispistettä, n. kuusi kuukautta, työssäoppimista. Työssäoppiminen suoritetaan pääasiassa työpaikoilla ja työelämälähtöisissä oppimisympäristöissä.</p>"
+                }
+              }
+            },
+            "oid": "1.2.246.562.10.52251087186",
+            "nimi": {
+              "fi": "Stadin ammatti- ja aikuisopisto",
+              "sv": "Stadin ammatti- ja aikuisopisto",
+              "en": "Stadin ammatti- ja aikuisopisto"
+            },
+            "alkuPvm": "2013-01-01",
+            "oppilaitosKoodi": "10105",
+            "ryhmatyypit": [],
+            "kayttoryhmat": [],
+            "piilotettu": false,
+            "parentOid": "1.2.246.562.10.346830761110",
+            "postiosoite": {
+              "postinumeroUri": "posti_00099",
+              "osoiteTyyppi": "posti",
+              "yhteystietoOid": "1.2.246.562.5.69596457015",
+              "postitoimipaikka": "HELSINGIN KAUPUNKI",
+              "osoite": "PL 55308"
+            },
+            "kuvaus2": {},
+            "tyypit": [
+              "organisaatiotyyppi_02"
+            ],
+            "yhteystietoArvos": [
+              {
+                "YhteystietoArvo.arvoText": "stadiprimus@edu.hel.fi",
+                "YhteystietojenTyyppi.nimi.fi": "KOSKI-palvelun omien tietojen virheilmoituksen sähköpostiosoite",
+                "YhteystietojenTyyppi.nimi.sv": "E-postadress för felanmälan i egna uppgifter i KOSKI-tjänsten",
+                "YhteystietoElementti.tyyppi": "Email",
+                "YhteystietojenTyyppi.oid": "1.2.246.562.5.79385887983",
+                "YhteystietoElementti.oid": "1.2.246.562.5.57850489428",
+                "YhteystietoElementti.nimi": "Sähköpostiosoite",
+                "YhteystietoElementti.nimiSv": "Epostadress",
+                "YhteystietoElementti.pakollinen": "false",
+                "YhteystietojenTyyppi.nimi.en": "KOSKI-palvelun omien tietojen virheilmoituksen sähköpostiosoite",
+                "YhteystietoElementti.kaytossa": "true",
+                "YhteystietoArvo.kieli": "kieli_fi#1"
+              }
+            ],
+            "yhteystiedot": [
+              {
+                "osoiteTyyppi": "posti",
+                "kieli": "kieli_fi#1",
+                "postinumeroUri": "posti_00099",
+                "yhteystietoOid": "1.2.246.562.5.69596457015",
+                "id": "3861240",
+                "postitoimipaikka": "HELSINGIN KAUPUNKI",
+                "osoite": "PL 55308"
+              },
+              {
+                "kieli": "kieli_fi#1",
+                "yhteystietoOid": "14931031965550.42925150233306597",
+                "id": "3861238",
+                "email": "hakutoimisto@edu.hel.fi"
+              },
+              {
+                "osoiteTyyppi": "kaynti",
+                "kieli": "kieli_fi#1",
+                "postinumeroUri": "posti_00550",
+                "yhteystietoOid": "1.2.246.562.5.32847643825",
+                "id": "3861237",
+                "postitoimipaikka": "HELSINKI",
+                "osoite": "Hattulantie 2"
+              },
+              {
+                "kieli": "kieli_fi#1",
+                "numero": "09 310 8415",
+                "tyyppi": "puhelin",
+                "yhteystietoOid": "1.2.246.562.5.90059839549",
+                "id": "3861236"
+              },
+              {
+                "kieli": "kieli_fi#1",
+                "www": "http://www.stadinammattiopisto.fi",
+                "yhteystietoOid": "1.2.246.562.5.38465214716",
+                "id": "3861239"
+              }
+            ],
+            "nimet": [
+              {
+                "nimi": {
+                  "fi": "Stadin ammattiopisto"
+                },
+                "alkuPvm": "2013-01-01",
+                "version": 1
+              },
+              {
+                "nimi": {
+                  "fi": "Stadin ammatti- ja aikuisopisto",
+                  "sv": "Stadin ammatti- ja aikuisopisto",
+                  "en": "Stadin ammatti- ja aikuisopisto"
+                },
+                "alkuPvm": "2018-12-31",
+                "version": 0
+              }
+            ],
+            "vuosiluokat": [],
+            "parentOidPath": "|1.2.246.562.10.00000000001|1.2.246.562.10.346830761110|",
+            "toimipistekoodi": "10105",
+            "kotipaikkaUri": "kunta_091",
+            "kieletUris": [
+              "oppilaitoksenopetuskieli_1#1"
+            ],
+            "maaUri": "maatjavaltiot1_fin",
+            "oppilaitosTyyppiUri": "oppilaitostyyppi_21#1",
+            "muutKotipaikatUris": [],
+            "kayntiosoite": {
+              "postinumeroUri": "posti_00550",
+              "osoiteTyyppi": "kaynti",
+              "yhteystietoOid": "1.2.246.562.5.32847643825",
+              "postitoimipaikka": "HELSINKI",
+              "osoite": "Hattulantie 2"
+            },
+            "lisatiedot": [],
+            "muutOppilaitosTyyppiUris": [],
+            "version": 89,
+            "status": "AKTIIVINEN"
+          }
+        ]
+      },
+      {
+        "url": "https://localhost:3000/kouta-backend/toteutus/2.1.1.1.1.1",
+        "method": "GET",
+        "status": 200,
+        "headers": {},
+        "body": null,
+        "response": {
+          "oid": "2.1.1.1.1.1",
+          "koulutusOid": "3.1.1.1.1",
+          "tila": "julkaistu",
+          "tarjoajat": [
+            "1.2.246.562.10.45854578546"
+          ],
+          "nimi": {
+            "fi": "Koulutuskeskus Salpaus, jatkuva haku, eläintenhoitaja"
+          },
+          "metadata": {
+            "kuvaus": {},
+            "opetus": {
+              "koulutuksenAlkamispaivamaara": "2019-08-23T00:00",
+              "koulutuksenPaattymispaivamaara": "2019-08-26T00:00",
+              "opetuskieliKoodiUrit": [
+                "oppilaitoksenopetuskieli_1#1"
+              ],
+              "opetuskieletKuvaus": {
+                "fi": "Opetuskieli kuvaus"
+              },
+              "suunniteltuKestoKuvaus": {
+                "fi": "Fi suunniteltuKestoKuvaus",
+                "sv": "Sv suunniteltuKestoKuvaus"
+              },
+              "suunniteltuKestoVuodet": 2,
+              "suunniteltuKestoKuukaudet": 6,
+              "opetusaikaKoodiUrit": [
+                "opetusaikakk_1#1"
+              ],
+              "opetusaikaKuvaus": {
+                "fi": "Opetusaika kuvaus"
+              },
+              "opetustapaKoodiUrit": [
+                "opetuspaikkakk_1#1"
+              ],
+              "opetustapaKuvaus": {
+                "fi": "Opetustapa kuvaus"
+              },
+              "onkoMaksullinen": true,
+              "maksullisuusKuvaus": {
+                "fi": "Maksullisuus kuvaus"
+              },
+              "maksunMaara": 20,
+              "alkamiskausiKoodiUri": "kausi_1#1",
+              "alkamisvuosi": "2024",
+              "alkamisaikaKuvaus": {
+                "fi": "Alkamisaika kuvaus"
+              },
+              "onkoStipendia": true,
+              "stipendinMaara": 90,
+              "stipendinKuvaus": {
+                "fi": "Stipendin kuvaus"
+              },
+              "lisatiedot": [
+                {
+                  "otsikkoKoodiUri": "koulutuksenlisatiedot_0#1",
+                  "teksti": {
+                    "fi": "koulutuksenlisatiedot_0 kuvaus"
+                  }
+                }
+              ]
+            },
+            "asiasanat": [
+              {
+                "kieli": "fi",
+                "arvo": "koira"
+              },
+              {
+                "kieli": "fi",
+                "arvo": "eläintenhoito"
+              }
+            ],
+            "ammattinimikkeet": [
+              {
+                "kieli": "fi",
+                "arvo": "eläintenhoitaja"
+              }
+            ],
+            "yhteyshenkilot": [
+              {
+                "nimi": {
+                  "fi": "Fi nimi",
+                  "sv": "Sv nimi"
+                },
+                "puhelinnumero": {
+                  "fi": "Fi puhelinnumero",
+                  "sv": "Sv puhelinnumero"
+                },
+                "sahkoposti": {
+                  "fi": "Fi sähköposti",
+                  "sv": "Sv sähköposti"
+                },
+                "titteli": {
+                  "fi": "Fi titteli",
+                  "sv": "Sv titteli"
+                },
+                "wwwSivu": {
+                  "fi": "Fi verkkosivu",
+                  "sv": "Sv verkkosivu"
+                }
+              }
+            ],
+            "tyyppi": "amm",
+            "osaamisalat": [
+              {
+                "koodiUri": "osaamisala_0",
+                "linkki": {
+                  "fi": "https://www.salpaus.fi/koulutusesittely/elaintenhoitaja/"
+                },
+                "otsikko": {
+                  "fi": "Otsikko"
+                }
+              }
+            ]
+          },
+          "muokkaaja": "1.2.246.562.24.62301161440",
+          "organisaatioOid": "1.2.246.562.10.52251087186",
+          "kielivalinta": [
+            "fi",
+            "sv"
+          ],
+          "modified": "2019-03-26T10:19"
+        }
+      },
+      {
+        "url": "https://localhost:3000/kouta-backend/haku/4.1.1.1.1.1",
+        "method": "GET",
+        "status": 200,
+        "headers": {},
+        "body": null,
+        "response": {
+          "oid": "4.1.1.1.1.1",
+          "tila": "julkaistu",
+          "nimi": {
+            "fi": "Haku"
+          },
+          "hakutapaKoodiUri": "hakutapa_0#1",
+          "hakukohteenLiittamisenTakaraja": "2019-02-08T07:05",
+          "hakukohteenMuokkaamisenTakaraja": "2019-02-08T07:05",
+          "alkamiskausiKoodiUri": "kausi_0#1",
+          "alkamisvuosi": "2024",
+          "kohdejoukkoKoodiUri": "haunkohdejoukko_0#1",
+          "kohdejoukonTarkenneKoodiUri": "haunkohdejoukontarkenne_0#1",
+          "hakulomaketyyppi": "muu",
+          "hakulomakeAtaruId": "12345",
+          "hakulomakeKuvaus": {},
+          "hakulomakeLinkki": {},
+          "metadata": {
+            "tulevaisuudenAikataulu": [
+              {
+                "alkaa": "2019-10-11T09:05",
+                "paattyy": "2019-12-25T20:30"
+              }
+            ],
+            "yhteyshenkilot": [
+              {
+                "nimi": {
+                  "fi": "nimi"
+                },
+                "titteli": {
+                  "fi": "titteli"
+                },
+                "puhelinnumero": {
+                  "fi": "puhelin"
+                },
+                "wwwSivu": {
+                  "fi": "verkkosivu"
+                },
+                "sahkoposti": {
+                  "fi": "sähkoposti"
+                }
+              }
+            ]
+          },
+          "organisaatioOid": "1.2.246.562.10.52251087186",
+          "hakuajat": [
+            {
+              "alkaa": "2019-02-08T07:05",
+              "paattyy": "2020-02-08T07:05"
+            }
+          ],
+          "ajastettuJulkaisu": "2019-12-05T06:45",
+          "muokkaaja": "1.2.246.562.24.62301161440",
+          "kielivalinta": [
+            "fi",
+            "sv"
+          ],
+          "modified": "2019-03-29T12:48"
+        }
+      },
+      {
+        "url": "https://localhost:3000/kouta-backend/valintaperuste/649adb37-cd4d-4846-91a9-84b58b90f928",
+        "method": "GET",
+        "status": 200,
+        "headers": {},
+        "body": null,
+        "response": {
+          "koulutustyyppi": "amm",
+          "id": "649adb37-cd4d-4846-91a9-84b58b90f928",
+          "tila": "julkaistu",
+          "hakutapaKoodiUri": "hakutapa_0#1",
+          "kohdejoukkoKoodiUri": "haunkohdejoukko_0#1",
+          "nimi": {
+            "fi": "Valintaperusteen nimi"
+          },
+          "julkinen": false,
+          "sorakuvausId": "1",
+          "metadata": {
+            "koulutustyyppi": "amm",
+            "valintatavat": [
+              {
+                "valintatapaKoodiUri": "valintatapajono_0#1",
+                "kuvaus": {},
+                "nimi": {
+                  "fi": "Valintatavan nimi"
+                },
+                "sisalto": [
+                  {
+                    "tyyppi": "teksti",
+                    "data": {
+                      "fi": "<p>Tekstia</p>"
+                    }
+                  },
+                  {
+                    "tyyppi": "taulukko",
+                    "data": {
+                      "nimi": {},
+                      "rows": [
+                        {
+                          "index": 0,
+                          "isHeader": false,
+                          "columns": [
+                            {
+                              "index": 0,
+                              "text": {
+                                "fi": "Solu"
+                              }
+                            }
+                          ]
+                        }
+                      ]
+                    }
+                  }
+                ],
+                "kaytaMuuntotaulukkoa": false,
+                "kynnysehto": {
+                  "fi": "Kynnysehto"
+                },
+                "enimmaispisteet": 100,
+                "vahimmaispisteet": 10
+              }
+            ],
+            "kielitaitovaatimukset": [],
+            "kuvaus": {
+              "fi": "<p>Loppukuvaus</p>"
+            },
+            "valintakokeidenYleiskuvaus": {
+              "fi": "<p>Valintakokeiden kuvaus - fi</p>"
+            }
+          },
+          "organisaatioOid": "1.2.246.562.10.594252633210",
+          "muokkaaja": "1.2.246.562.24.62301161440",
+          "kielivalinta": [
+            "fi",
+            "sv"
+          ],
+          "modified": "2019-04-03T13:56",
+          "valintakokeet": [
+            {
+              "nimi": {
+                "fi": "Kokeen nimi - fi"
+              },
+              "metadata": {
+                "tietoja": {
+                  "fi": "<p>Tietoa kokeesta - fi</p>"
+                },
+                "liittyyEnnakkovalmistautumista": true,
+                "ohjeetEnnakkovalmistautumiseen": {
+                  "fi": "<p>Ohjeet ennakkovalmistautumiseen - fi</p>"
+                },
+                "erityisjarjestelytMahdollisia": true,
+                "ohjeetErityisjarjestelyihin": {
+                  "fi": "<p>Ohjeet erityisjärjestelyihin - fi</p>"
+                }
+              },
+              "tyyppiKoodiUri": "tyyppi_1#1",
+              "tilaisuudet": [
+                {
+                  "osoite": {
+                    "osoite": {
+                      "fi": "fi osoite"
+                    },
+                    "postinumeroKoodiUri": "posti_00350#1"
+                  },
+                  "aika": {
+                    "alkaa": "2019-04-16T08:44",
+                    "paattyy": "2019-04-18T08:44"
+                  },
+                  "lisatietoja": {
+                    "fi": "fi lisatietoja"
+                  },
+                  "jarjestamispaikka": {
+                    "fi": "Jarjestamispaikka - fi"
+                  }
+                }
+              ]
+            }
+          ]
+        }
+      },
+      {
+        "url": "https://localhost:3000/kouta-backend/hakukohde",
+        "method": "POST",
+        "status": 200,
+        "headers": {},
+        "body": {
+          "oid": "6.1.1.1.1.1",
+          "toteutusOid": "2.1.1.1.1.1",
+          "hakuOid": "4.1.1.1.1.1",
+          "tila": "tallennettu",
+          "nimi": {
+            "fi": "Hakukohteen nimi"
+          },
+          "alkamiskausiKoodiUri": "kausi_0#1",
+          "alkamisvuosi": 2024,
+          "hakulomake": {},
+          "aloituspaikat": 150,
+          "ensikertalaisenAloituspaikat": 49,
+          "kaytetaanHaunAlkamiskautta": false,
+          "pohjakoulutusvaatimusKoodiUrit": [
+            "pohjakoulutusvaatimustoinenaste_0#1"
+          ],
+          "pohjakoulutusvaatimusTarkenne": {
+            "fi": "<p>Fi tarkenne</p>"
+          },
+          "muuPohjakoulutusvaatimus": {},
+          "toinenAsteOnkoKaksoistutkinto": true,
+          "kaytetaanHaunAikataulua": false,
+          "liitteetOnkoSamaToimitusaika": false,
+          "liitteetOnkoSamaToimitusosoite": false,
+          "liitteidenToimitusosoite": null,
+          "liitteidenToimitustapa": null,
+          "liitteet": [
+            {
+              "toimitustapa": "osoite",
+              "tyyppiKoodiUri": "liitetyypitamm_0#1",
+              "nimi": {
+                "fi": "Nimi"
+              },
+              "toimitusaika": "2011-11-11T10:30",
+              "toimitusosoite": {
+                "osoite": {
+                  "osoite": {
+                    "fi": "Osoite"
+                  },
+                  "postinumeroKoodiUri": "posti_0#2"
+                },
+                "sahkoposti": "sahkoposti@email.com"
+              },
+              "kuvaus": {
+                "fi": "Kuvaus"
+              }
+            }
+          ],
+          "metadata": {
+            "valintakokeidenYleiskuvaus": {
+              "fi": "<p>Valintakokeiden kuvaus - fi</p>"
+            }
+          },
+          "valintakokeet": [
+            {
+              "tyyppiKoodiUri": "tyyppi_1#1",
+              "nimi": {
+                "fi": "Kokeen nimi - fi"
+              },
+              "metadata": {
+                "tietoja": {
+                  "fi": "<p>Tietoa kokeesta - fi</p>"
+                },
+                "liittyyEnnakkovalmistautumista": true,
+                "ohjeetEnnakkovalmistautumiseen": {
+                  "fi": "<p>Ohjeet ennakkovalmistautumiseen - fi</p>"
+                },
+                "erityisjarjestelytMahdollisia": true,
+                "ohjeetErityisjarjestelyihin": {
+                  "fi": "<p>Ohjeet erityisjärjestelyihin - fi</p>"
+                }
+              },
+              "tilaisuudet": [
+                {
+                  "osoite": {
+                    "osoite": {
+                      "fi": "fi osoite"
+                    },
+                    "postinumeroKoodiUri": "posti_00350#1"
+                  },
+                  "aika": {
+                    "alkaa": "2019-04-16T08:44",
+                    "paattyy": "2019-04-18T08:44"
+                  },
+                  "lisatietoja": {
+                    "fi": "fi lisatietoja"
+                  },
+                  "jarjestamispaikka": {
+                    "fi": "Jarjestamispaikka - fi"
+                  }
+                }
+              ]
+            }
+          ],
+          "hakuajat": [
+            {
+              "alkaa": "2011-11-11T10:30",
+              "paattyy": "2011-11-12T11:45"
+            }
+          ],
+          "muokkaaja": "1.2.246.562.24.62301161440",
+          "organisaatioOid": "1.2.246.562.10.52251087186",
+          "kielivalinta": [
+            "fi"
+          ],
+          "modified": "2019-04-04T08:28",
+          "kaytetaanHaunHakulomaketta": false,
+          "hakulomaketyyppi": "ataru",
+          "hakulomakeAtaruId": "12345",
+          "hakulomakeKuvaus": {},
+          "hakulomakeLinkki": {},
+          "valintaperusteId": "649adb37-cd4d-4846-91a9-84b58b90f928",
+          "jarjestyspaikkaOid": "1.2.246.562.10.45854578546",
+          "liitteidenToimitusaika": null
+        },
+        "response": {
+          "muokattu": false
+        }
+      },
+      {
+        "url": "https://localhost:3000/kouta-backend/hakukohde/6.1.1.1.1.1",
+        "method": "GET",
+        "status": 200,
+        "headers": {},
+        "body": null,
+        "response": {
+          "oid": "6.1.1.1.1.1",
+          "toteutusOid": "2.1.1.1.1.1",
+          "hakuOid": "4.1.1.1.1.1",
+          "tila": "tallennettu",
+          "nimi": {
+            "fi": "Hakukohteen nimi"
+          },
+          "alkamiskausiKoodiUri": "kausi_0#1",
+          "alkamisvuosi": "2024",
+          "hakulomake": {},
+          "aloituspaikat": 150,
+          "ensikertalaisenAloituspaikat": 49,
+          "kaytetaanHaunAlkamiskautta": false,
+          "pohjakoulutusvaatimusKoodiUrit": [
+            "pohjakoulutusvaatimustoinenaste_0#1"
+          ],
+          "pohjakoulutusvaatimusTarkenne": {
+            "fi": "<p>Fi tarkenne</p>"
+          },
+          "muuPohjakoulutusvaatimus": {},
+          "toinenAsteOnkoKaksoistutkinto": true,
+          "kaytetaanHaunAikataulua": false,
+          "liitteetOnkoSamaToimitusaika": false,
+          "liitteetOnkoSamaToimitusosoite": false,
+          "liitteidenToimitusosoite": null,
+          "liitteidenToimitustapa": null,
+          "liitteet": [
+            {
+              "id": "927ac923-a839-4354-9db4-f95d276d9902",
+              "tyyppiKoodiUri": "liitetyypitamm_0#1",
+              "nimi": {
+                "fi": "Nimi"
+              },
+              "kuvaus": {
+                "fi": "Kuvaus"
+              },
+              "toimitusaika": "2011-11-11T10:30",
+              "toimitusosoite": {
+                "osoite": {
+                  "osoite": {
+                    "fi": "Osoite"
+                  },
+                  "postinumeroKoodiUri": "posti_0#2"
+                },
+                "sahkoposti": "sahkoposti@email.com"
+              },
+              "toimitustapa": "osoite"
+            }
+          ],
+          "metadata": {
+            "valintakokeidenYleiskuvaus": {
+              "fi": "<p>Valintakokeiden kuvaus - fi</p>"
+            }
+          },
+          "valintakokeet": [
+            {
+              "nimi": {
+                "fi": "Kokeen nimi - fi"
+              },
+              "metadata": {
+                "tietoja": {
+                  "fi": "<p>Tietoa kokeesta - fi</p>"
+                },
+                "liittyyEnnakkovalmistautumista": true,
+                "ohjeetEnnakkovalmistautumiseen": {
+                  "fi": "<p>Ohjeet ennakkovalmistautumiseen - fi</p>"
+                },
+                "erityisjarjestelytMahdollisia": true,
+                "ohjeetErityisjarjestelyihin": {
+                  "fi": "<p>Ohjeet erityisjärjestelyihin - fi</p>"
+                }
+              },
+              "tyyppiKoodiUri": "tyyppi_1#1",
+              "tilaisuudet": [
+                {
+                  "osoite": {
+                    "osoite": {
+                      "fi": "fi osoite"
+                    },
+                    "postinumeroKoodiUri": "posti_00350#1"
+                  },
+                  "aika": {
+                    "alkaa": "2019-04-16T08:44",
+                    "paattyy": "2019-04-18T08:44"
+                  },
+                  "lisatietoja": {
+                    "fi": "fi lisatietoja"
+                  },
+                  "jarjestamispaikka": {
+                    "fi": "Jarjestamispaikka - fi"
+                  }
+                }
+              ]
+            }
+          ],
+          "hakuajat": [
+            {
+              "alkaa": "2011-11-11T10:30",
+              "paattyy": "2011-11-12T11:45"
+            }
+          ],
+          "muokkaaja": "1.2.246.562.24.62301161440",
+          "organisaatioOid": "1.2.246.562.10.52251087186",
+          "kielivalinta": [
+            "fi",
+            "sv"
+          ],
+          "modified": "2019-04-04T08:28",
+          "kaytetaanHaunHakulomaketta": false,
+          "hakulomaketyyppi": "ataru",
+          "hakulomakeAtaruId": "12345",
+          "hakulomakeKuvaus": {},
+          "hakulomakeLinkki": {},
+          "valintaperusteId": "649adb37-cd4d-4846-91a9-84b58b90f928"
+        }
+      },
+      {
+        "url": "https://localhost:3000/kouta-backend/toteutus/2.1.1.1.1.1",
+        "method": "GET",
+        "status": 200,
+        "headers": {},
+        "body": null,
+        "response": {
+          "oid": "2.1.1.1.1.1",
+          "koulutusOid": "3.1.1.1.1",
+          "tila": "julkaistu",
+          "tarjoajat": [
+            "1.2.246.562.10.45854578546"
+          ],
+          "nimi": {
+            "fi": "Koulutuskeskus Salpaus, jatkuva haku, eläintenhoitaja"
+          },
+          "metadata": {
+            "kuvaus": {},
+            "opetus": {
+              "koulutuksenAlkamispaivamaara": "2019-08-23T00:00",
+              "koulutuksenPaattymispaivamaara": "2019-08-26T00:00",
+              "opetuskieliKoodiUrit": [
+                "oppilaitoksenopetuskieli_1#1"
+              ],
+              "opetuskieletKuvaus": {
+                "fi": "Opetuskieli kuvaus"
+              },
+              "suunniteltuKestoKuvaus": {
+                "fi": "Fi suunniteltuKestoKuvaus",
+                "sv": "Sv suunniteltuKestoKuvaus"
+              },
+              "suunniteltuKestoVuodet": 2,
+              "suunniteltuKestoKuukaudet": 6,
+              "opetusaikaKoodiUrit": [
+                "opetusaikakk_1#1"
+              ],
+              "opetusaikaKuvaus": {
+                "fi": "Opetusaika kuvaus"
+              },
+              "opetustapaKoodiUrit": [
+                "opetuspaikkakk_1#1"
+              ],
+              "opetustapaKuvaus": {
+                "fi": "Opetustapa kuvaus"
+              },
+              "onkoMaksullinen": true,
+              "maksullisuusKuvaus": {
+                "fi": "Maksullisuus kuvaus"
+              },
+              "maksunMaara": 20,
+              "alkamiskausiKoodiUri": "kausi_1#1",
+              "alkamisvuosi": "2024",
+              "alkamisaikaKuvaus": {
+                "fi": "Alkamisaika kuvaus"
+              },
+              "onkoStipendia": true,
+              "stipendinMaara": 90,
+              "stipendinKuvaus": {
+                "fi": "Stipendin kuvaus"
+              },
+              "lisatiedot": [
+                {
+                  "otsikkoKoodiUri": "koulutuksenlisatiedot_0#1",
+                  "teksti": {
+                    "fi": "koulutuksenlisatiedot_0 kuvaus"
+                  }
+                }
+              ]
+            },
+            "asiasanat": [
+              {
+                "kieli": "fi",
+                "arvo": "koira"
+              },
+              {
+                "kieli": "fi",
+                "arvo": "eläintenhoito"
+              }
+            ],
+            "ammattinimikkeet": [
+              {
+                "kieli": "fi",
+                "arvo": "eläintenhoitaja"
+              }
+            ],
+            "yhteyshenkilot": [
+              {
+                "nimi": {
+                  "fi": "Fi nimi",
+                  "sv": "Sv nimi"
+                },
+                "puhelinnumero": {
+                  "fi": "Fi puhelinnumero",
+                  "sv": "Sv puhelinnumero"
+                },
+                "sahkoposti": {
+                  "fi": "Fi sähköposti",
+                  "sv": "Sv sähköposti"
+                },
+                "titteli": {
+                  "fi": "Fi titteli",
+                  "sv": "Sv titteli"
+                },
+                "wwwSivu": {
+                  "fi": "Fi verkkosivu",
+                  "sv": "Sv verkkosivu"
+                }
+              }
+            ],
+            "tyyppi": "amm",
+            "osaamisalat": [
+              {
+                "koodiUri": "osaamisala_0",
+                "linkki": {
+                  "fi": "https://www.salpaus.fi/koulutusesittely/elaintenhoitaja/"
+                },
+                "otsikko": {
+                  "fi": "Otsikko"
+                }
+              }
+            ]
+          },
+          "muokkaaja": "1.2.246.562.24.62301161440",
+          "organisaatioOid": "1.2.246.562.10.52251087186",
+          "kielivalinta": [
+            "fi",
+            "sv"
+          ],
+          "modified": "2019-03-26T10:19"
+        }
+      },
+      {
+        "url": "https://localhost:3000/kouta-backend/haku/4.1.1.1.1.1",
+        "method": "GET",
+        "status": 200,
+        "headers": {},
+        "body": null,
+        "response": {
+          "oid": "4.1.1.1.1.1",
+          "tila": "julkaistu",
+          "nimi": {
+            "fi": "Haku"
+          },
+          "hakutapaKoodiUri": "hakutapa_0#1",
+          "hakukohteenLiittamisenTakaraja": "2019-02-08T07:05",
+          "hakukohteenMuokkaamisenTakaraja": "2019-02-08T07:05",
+          "alkamiskausiKoodiUri": "kausi_0#1",
+          "alkamisvuosi": "2024",
+          "kohdejoukkoKoodiUri": "haunkohdejoukko_0#1",
+          "kohdejoukonTarkenneKoodiUri": "haunkohdejoukontarkenne_0#1",
+          "hakulomaketyyppi": "muu",
+          "hakulomakeAtaruId": "12345",
+          "hakulomakeKuvaus": {},
+          "hakulomakeLinkki": {},
+          "metadata": {
+            "tulevaisuudenAikataulu": [
+              {
+                "alkaa": "2019-10-11T09:05",
+                "paattyy": "2019-12-25T20:30"
+              }
+            ],
+            "yhteyshenkilot": [
+              {
+                "nimi": {
+                  "fi": "nimi"
+                },
+                "titteli": {
+                  "fi": "titteli"
+                },
+                "puhelinnumero": {
+                  "fi": "puhelin"
+                },
+                "wwwSivu": {
+                  "fi": "verkkosivu"
+                },
+                "sahkoposti": {
+                  "fi": "sähkoposti"
+                }
+              }
+            ]
+          },
+          "organisaatioOid": "1.2.246.562.10.52251087186",
+          "hakuajat": [
+            {
+              "alkaa": "2019-02-08T07:05",
+              "paattyy": "2020-02-08T07:05"
+            }
+          ],
+          "ajastettuJulkaisu": "2019-12-05T06:45",
+          "muokkaaja": "1.2.246.562.24.62301161440",
+          "kielivalinta": [
+            "fi",
+            "sv"
+          ],
+          "modified": "2019-03-29T12:48"
+        }
+      }
+    ]
+  }
+}

--- a/src/main/app/cypress/plugins/index.js
+++ b/src/main/app/cypress/plugins/index.js
@@ -1,6 +1,7 @@
 const fs = require('fs');
 const wp = require('@cypress/webpack-preprocessor');
 const { initPlugin } = require('cypress-plugin-snapshots/plugin');
+const autoRecord = require('cypress-autorecord/plugin');
 const alias = require('../../webpack-alias');
 
 module.exports = (on, config) => {
@@ -36,5 +37,6 @@ module.exports = (on, config) => {
     })
   );
   initPlugin(on, config);
+  autoRecord(on, config, fs);
   return config;
 };

--- a/src/main/app/cypress/utils.ts
+++ b/src/main/app/cypress/utils.ts
@@ -280,7 +280,9 @@ export const fillKieliversiotSection = (
 ) => {
   getByTestId('kieliversiotSection').within(() => {
     chooseKieliversiotLanguages(['fi']);
-    pressJatka && jatka();
+    if (pressJatka) {
+      jatka();
+    }
   });
 };
 

--- a/src/main/app/package-lock.json
+++ b/src/main/app/package-lock.json
@@ -19592,6 +19592,12 @@
         }
       }
     },
+    "cypress-autorecord": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/cypress-autorecord/-/cypress-autorecord-2.0.0.tgz",
+      "integrity": "sha512-PLgvY6J0HrC72jMwo0IOFoyQs2ludKHN4lW+dVnSUbOH4Scfm5fgYE/m4Tov9LtCvfXsSPhjnrh84UztTDQLqw==",
+      "dev": true
+    },
     "cypress-pipe": {
       "version": "1.7.0",
       "resolved": "https://registry.npmjs.org/cypress-pipe/-/cypress-pipe-1.7.0.tgz",

--- a/src/main/app/package.json
+++ b/src/main/app/package.json
@@ -82,12 +82,10 @@
   },
   "lint-staged": {
     "*.{json,css,md}": [
-      "prettier --write",
-      "git add"
+      "prettier --write"
     ],
     "*.{js,jsx,ts,tsx}": [
-      "eslint --fix",
-      "git add"
+      "eslint --fix"
     ]
   },
   "jest": {

--- a/src/main/app/package.json
+++ b/src/main/app/package.json
@@ -81,8 +81,12 @@
     }
   },
   "lint-staged": {
-    "*.{js,jsx,ts,tsx,json,css,md}": [
-      "./node_modules/.bin/prettier --write",
+    "*.{json,css,md}": [
+      "prettier --write",
+      "git add"
+    ],
+    "*.{js,jsx,ts,tsx}": [
+      "eslint --fix",
       "git add"
     ]
   },
@@ -118,6 +122,7 @@
     "babel-plugin-lodash": "^3.3.4",
     "babel-plugin-styled-components": "^1.10.7",
     "cypress": "^5.3.0",
+    "cypress-autorecord": "^2.0.0",
     "cypress-pipe": "^1.7.0",
     "cypress-plugin-snapshots": "^1.4.4",
     "enzyme": "^3.11.0",

--- a/src/main/app/src/components/FormPage/FormPage.tsx
+++ b/src/main/app/src/components/FormPage/FormPage.tsx
@@ -99,7 +99,17 @@ const Wrapper = styled.div`
     `}
 `;
 
-const FormPage = ({
+type FormPageProps = {
+  header?: React.ReactNode;
+  steps?: React.ReactNode;
+  footer?: React.ReactNode;
+  draftUrl?: string;
+  toggleDraft?: React.ReactNode;
+  hasFooterHomeLink?: boolean;
+  readOnly?: boolean;
+};
+
+const FormPage: React.FC<FormPageProps> = ({
   header = null,
   steps = null,
   children = null,

--- a/src/main/app/src/components/FormSteps/index.tsx
+++ b/src/main/app/src/components/FormSteps/index.tsx
@@ -53,11 +53,11 @@ const stepIsDone = (step, activeStep) => {
   return stepIndex < activeStepIndex;
 };
 
-const FormSteps = ({ activeStep = KOULUTUS, ...props }) => {
+const FormSteps = ({ activeStep = KOULUTUS }) => {
   const { t } = useTranslation();
 
   return (
-    <Wrapper {...props}>
+    <Wrapper>
       <GroupContainer>
         <StepsIcon
           icon={ICONS[KOULUTUS]}

--- a/src/main/app/src/hooks/form.ts
+++ b/src/main/app/src/hooks/form.ts
@@ -74,7 +74,7 @@ export const getFormConfigByEntity = (entityName, koulutustyyppi) => {
   return formConfigsGettersByEntity[entityName](koulutustyyppi);
 };
 
-export const useEntityFormConfig = (entityName, koulutustyyppi) => {
+export const useEntityFormConfig = (entityName, koulutustyyppi = undefined) => {
   return useMemo(() => getFormConfigByEntity(entityName, koulutustyyppi), [
     entityName,
     koulutustyyppi,

--- a/src/main/app/src/hooks/useCurrentUserHasRole.ts
+++ b/src/main/app/src/hooks/useCurrentUserHasRole.ts
@@ -1,8 +1,21 @@
-import _ from 'lodash';
-import { useMemo } from 'react';
+import _ from 'lodash/fp';
+import { useCallback, useMemo } from 'react';
 import useOrganisaatio from '#/src/hooks/useOrganisaatio';
 import useAuthorizedUserRoleBuilder from '#/src/hooks/useAuthorizedUserRoleBuilder';
 import { ENTITY_ROLES, CRUD_ROLES } from '#/src/constants';
+
+export const useGetCurrentUserHasRole = (entity, role = CRUD_ROLES.READ) => {
+  const roleBuilder = useAuthorizedUserRoleBuilder();
+
+  return useCallback(
+    organisaatio =>
+      roleBuilder[`has${_.upperFirst(role)}`](
+        ENTITY_ROLES[entity],
+        organisaatio
+      ).result(),
+    [entity, role, roleBuilder]
+  );
+};
 
 export const useCurrentUserHasRole = (
   entity,
@@ -10,14 +23,10 @@ export const useCurrentUserHasRole = (
   organisaatioOid
 ) => {
   const { organisaatio } = useOrganisaatio(organisaatioOid);
-  const roleBuilder = useAuthorizedUserRoleBuilder();
+  const getCurrentUserHasRole = useGetCurrentUserHasRole(entity, role);
 
-  return useMemo(
-    () =>
-      roleBuilder[`has${_.upperFirst(role)}`](
-        ENTITY_ROLES[entity],
-        organisaatio
-      ).result(),
-    [entity, organisaatio, role, roleBuilder]
-  );
+  return useMemo(() => getCurrentUserHasRole(organisaatio), [
+    getCurrentUserHasRole,
+    organisaatio,
+  ]);
 };

--- a/src/main/app/src/pages/hakukohde/CreateHakukohdePage/index.tsx
+++ b/src/main/app/src/pages/hakukohde/CreateHakukohdePage/index.tsx
@@ -1,6 +1,5 @@
 import React, { useMemo, useCallback } from 'react';
 import { useTranslation } from 'react-i18next';
-import _ from 'lodash';
 
 import FormPage, { FormFooter } from '#/src/components/FormPage';
 import getOrganisaatioByOid from '#/src/utils/organisaatio/getOrganisaatioByOid';
@@ -80,16 +79,13 @@ const CreateHakukohdePage = props => {
     watch: [organisaatioOid, toteutusOid, hakuOid].join(','),
   });
 
-  const haku = _.get(data, 'haku');
-  const toteutus = _.get(data, 'toteutus');
+  const haku = data?.haku;
+  const toteutus = data?.toteutus;
 
   const initialValues = useMemo(() => {
     return (
       data &&
-      getInitialValues(
-        _.get(data, 'toteutus.nimi'),
-        _.get(data, 'toteutus.kielivalinta')
-      )
+      getInitialValues(data?.toteutus?.nimi, data?.toteutus?.kielivalinta)
     );
   }, [data]);
 
@@ -150,8 +146,7 @@ const CreateHakukohdePage = props => {
                 toteutus={toteutus}
                 tarjoajat={data.tarjoajat}
                 koulutustyyppi={
-                  _.get(data, 'koulutustyyppi') ||
-                  KOULUTUSTYYPPI.AMMATILLINEN_KOULUTUS
+                  data?.koulutustyyppi ?? KOULUTUSTYYPPI.AMMATILLINEN_KOULUTUS
                 }
                 showArkistoituTilaOption={false}
               />

--- a/src/main/app/src/pages/hakukohde/EditHakukohdePage/EditHakukohdeFooter.tsx
+++ b/src/main/app/src/pages/hakukohde/EditHakukohdePage/EditHakukohdeFooter.tsx
@@ -1,5 +1,5 @@
 import React, { useCallback } from 'react';
-import { useHistory } from 'react-router-dom';
+import { queryCache } from 'react-query';
 
 import { useSaveHakukohde } from '#/src/hooks/formSaveHooks';
 import getHakukohdeByFormValues from '#/src/utils/hakukohde/getHakukohdeByFormValues';
@@ -9,8 +9,6 @@ import { FormFooter } from '#/src/components/FormPage';
 import { useFormName } from '#/src/hooks/form';
 
 const EditHakukohdeFooter = ({ hakukohde, haku, toteutus, canUpdate }) => {
-  const history = useHistory();
-
   const submit = useCallback(
     async ({ values, httpClient, apiUrls }) => {
       await updateHakukohde({
@@ -22,13 +20,9 @@ const EditHakukohdeFooter = ({ hakukohde, haku, toteutus, canUpdate }) => {
         },
       });
 
-      history.replace({
-        state: {
-          hakukohdeUpdatedAt: Date.now(),
-        },
-      });
+      queryCache.invalidateQueries('hakukohde');
     },
-    [hakukohde, history]
+    [hakukohde]
   );
 
   const formName = useFormName();

--- a/src/main/app/src/pages/hakukohde/EditHakukohdePage/index.tsx
+++ b/src/main/app/src/pages/hakukohde/EditHakukohdePage/index.tsx
@@ -1,13 +1,9 @@
 import React, { useMemo } from 'react';
 import { useTranslation } from 'react-i18next';
 import { KOULUTUSTYYPPI, ENTITY, CRUD_ROLES } from '#/src/constants';
-import getKoulutustyyppiByKoulutusOid from '#/src/utils/koulutus/getKoulutustyyppiByKoulutusOid';
-import getHakukohdeByOid from '#/src/utils/hakukohde/getHakukohdeByOid';
-import useApiAsync from '#/src/hooks/useApiAsync';
+import { useHakukohdeByOid } from '#/src/utils/hakukohde/getHakukohdeByOid';
 import FullSpin from '#/src/components/FullSpin';
-import getToteutusByOid from '#/src/utils/toteutus/getToteutusByOid';
 import Title from '#/src/components/Title';
-import getHakuByOid from '#/src/utils/haku/getHakuByOid';
 import ReduxForm from '#/src/components/ReduxForm';
 import getFormValuesByHakukohde from '#/src/utils/hakukohde/getFormValuesByHakukohde';
 import FormConfigContext from '#/src/contexts/FormConfigContext';
@@ -23,56 +19,31 @@ import FormSteps from '#/src/components/FormSteps';
 import { useCurrentUserHasRole } from '#/src/hooks/useCurrentUserHasRole';
 import { useEntityFormConfig } from '#/src/hooks/form';
 import EditHakukohdeFooter from './EditHakukohdeFooter';
-
-const getData = async ({ httpClient, apiUrls, oid: hakukohdeOid }) => {
-  const hakukohde = await getHakukohdeByOid({
-    httpClient,
-    apiUrls,
-    oid: hakukohdeOid,
-  });
-
-  const { toteutusOid, hakuOid } = hakukohde;
-
-  const [toteutus, haku] = await Promise.all([
-    getToteutusByOid({ httpClient, apiUrls, oid: toteutusOid }),
-    getHakuByOid({ httpClient, apiUrls, oid: hakuOid }),
-  ]);
-
-  const { koulutustyyppi } = await (toteutus && toteutus.koulutusOid
-    ? getKoulutustyyppiByKoulutusOid({
-        oid: toteutus.koulutusOid,
-        httpClient,
-        apiUrls,
-      })
-    : null);
-
-  return {
-    hakukohde,
-    toteutus,
-    haku,
-    koulutustyyppi,
-    tarjoajat: toteutus?.tarjoajat,
-  };
-};
+import { useHakukohdePageData } from '../getHakukohdePageData';
 
 const EditHakukohdePage = props => {
   const {
     match: {
       params: { organisaatioOid, oid },
     },
-    location: { state = {} },
   } = props;
 
-  const { hakukohdeUpdatedAt = null } = state;
-  const watch = JSON.stringify([oid, hakukohdeUpdatedAt]);
+  const { data: hakukohde, isFetching: hakukohdeLoading } = useHakukohdeByOid({
+    oid,
+  });
 
   const {
-    data: { hakukohde, toteutus, haku, koulutustyyppi, tarjoajat } = {},
-  } = useApiAsync({
-    promiseFn: getData,
-    oid,
-    watch,
-  });
+    data: { toteutus, haku, koulutustyyppi, tarjoajat } = {},
+    isFetching: pageDataLoading,
+  } = useHakukohdePageData(
+    {
+      hakuOid: hakukohde?.hakuOid,
+      toteutusOid: hakukohde?.toteutusOid,
+    },
+    { enabled: hakukohde }
+  );
+
+  const isLoading = hakukohdeLoading || pageDataLoading;
 
   const { t } = useTranslation();
 
@@ -88,7 +59,7 @@ const EditHakukohdePage = props => {
 
   const config = useEntityFormConfig(ENTITY.HAKUKOHDE);
 
-  return !hakukohde ? (
+  return isLoading ? (
     <FullSpin />
   ) : (
     <ReduxForm form="editHakukohdeForm" initialValues={initialValues}>

--- a/src/main/app/src/pages/hakukohde/EditHakukohdePage/index.tsx
+++ b/src/main/app/src/pages/hakukohde/EditHakukohdePage/index.tsx
@@ -38,7 +38,7 @@ const getData = async ({ httpClient, apiUrls, oid: hakukohdeOid }) => {
     getHakuByOid({ httpClient, apiUrls, oid: hakuOid }),
   ]);
 
-  const { koulutustyyppi, tarjoajat } = await (toteutus && toteutus.koulutusOid
+  const { koulutustyyppi } = await (toteutus && toteutus.koulutusOid
     ? getKoulutustyyppiByKoulutusOid({
         oid: toteutus.koulutusOid,
         httpClient,
@@ -51,7 +51,7 @@ const getData = async ({ httpClient, apiUrls, oid: hakukohdeOid }) => {
     toteutus,
     haku,
     koulutustyyppi,
-    tarjoajat,
+    tarjoajat: toteutus?.tarjoajat,
   };
 };
 

--- a/src/main/app/src/pages/hakukohde/HakukohdeForm/HakukohdeForm.tsx
+++ b/src/main/app/src/pages/hakukohde/HakukohdeForm/HakukohdeForm.tsx
@@ -95,7 +95,7 @@ const HakukohdeForm = ({
         tarjoajat={tarjoajat}
         opetustapaKoodiUrit={opetustapaKoodiUrit}
         Component={JarjestyspaikkaSection}
-        organisaatioOid={organisaatioOid}
+        toteutusOrganisaatioOid={toteutus?.organisaatioOid}
       />
 
       <FormCollapse

--- a/src/main/app/src/pages/hakukohde/HakukohdeForm/JarjestyspaikkaSection.tsx
+++ b/src/main/app/src/pages/hakukohde/HakukohdeForm/JarjestyspaikkaSection.tsx
@@ -34,10 +34,12 @@ const JarjestyspaikkaSection = ({
   const language = useLanguage();
   const jarjestyspaikkaOptions = flatFilterHierarkia(
     hierarkia,
-    _.overEvery(organisaatioMatchesTyyppi(ORGANISAATIOTYYPPI.TOIMIPISTE), org =>
-      // Select intersection of organisaatio branches from selected organisaatio and tarjoajat
-      _.some(tarjoaja => _.includes(tarjoaja, org?.parentOidPath))(tarjoajat)
-    )
+    _.overEvery([
+      organisaatioMatchesTyyppi(ORGANISAATIOTYYPPI.TOIMIPISTE),
+      org =>
+        // Select intersection of organisaatio branches from selected organisaatio and tarjoajat
+        _.some(tarjoaja => _.includes(tarjoaja, org?.parentOidPath))(tarjoajat),
+    ])
   ).map(({ oid, nimi }) => ({
     value: oid,
     label: getFirstLanguageValue(nimi, language),

--- a/src/main/app/src/pages/hakukohde/HakukohdeForm/JarjestyspaikkaSection.tsx
+++ b/src/main/app/src/pages/hakukohde/HakukohdeForm/JarjestyspaikkaSection.tsx
@@ -126,8 +126,10 @@ const JarjestyspaikkaSection = ({
           value: org?.oid,
           label: getFirstLanguageValue(org?.nimi, language),
           disabled:
-            // Select intersection of organisaatio branches from selected organisaatio and tarjoajat
-            !_.some(tarjoaja => _.includes(tarjoaja, org?.parentOidPath))(
+            // Disabled when none of tarjoajat is found up in the organization's
+            // hierarchy including organization itself  or when user has no
+            // update rights for the organization.
+            _.every(tarjoaja => !_.includes(tarjoaja, org?.parentOidPath))(
               tarjoajat
             ) || !getCanUpdate(org),
         })),

--- a/src/main/app/src/pages/hakukohde/HakukohdeForm/JarjestyspaikkaSection.tsx
+++ b/src/main/app/src/pages/hakukohde/HakukohdeForm/JarjestyspaikkaSection.tsx
@@ -1,16 +1,22 @@
-import React from 'react';
+import React, { useMemo } from 'react';
 import { Field } from 'redux-form';
 import _ from 'lodash/fp';
 import { useTranslation } from 'react-i18next';
+import styled, { css } from 'styled-components';
 
 import useOrganisaatioHierarkia from '#/src/hooks/useOrganisaatioHierarkia';
-import { FormFieldRadioGroup } from '#/src/components/formFields';
-import { ORGANISAATIOTYYPPI } from '#/src/constants';
+import {
+  createFormFieldComponent,
+  simpleMapProps,
+} from '#/src/components/formFields';
+import { CRUD_ROLES, ENTITY, ORGANISAATIOTYYPPI } from '#/src/constants';
 import organisaatioMatchesTyyppi from '#/src/utils/organisaatio/organisaatioMatchesTyyppi';
 import { getTestIdProps } from '#/src/utils';
 import { getFirstLanguageValue } from '#/src/utils/languageUtils';
 import useLanguage from '#/src/hooks/useLanguage';
-import { flatFilterHierarkia } from '#/src/utils/organisaatio/hierarkiaHelpers';
+import { Radio } from '#/src/components/virkailija';
+import { useGetCurrentUserHasRole } from '#/src/hooks/useCurrentUserHasRole';
+import { flattenHierarkia } from '#/src/utils/organisaatio/hierarkiaHelpers';
 
 const JARJESTYSPAIKATTOMAT_OPETUSTAVAT = [
   'opetuspaikkakk_2#1', // Verkko
@@ -18,32 +24,117 @@ const JARJESTYSPAIKATTOMAT_OPETUSTAVAT = [
   'opetuspaikkakk_5#1', // Itsenainen
 ];
 
+const Container = styled.div<{ isLast: boolean }>`
+  ${({ isLast }) =>
+    !isLast &&
+    css`
+      margin-bottom: 4px;
+    `}
+`;
+
+type RadioGroupChild = React.ReactElement<{
+  checked?: boolean;
+  value: string;
+  onChange?: (arg: any) => void;
+  disabled?: boolean;
+  error?: boolean;
+}>;
+
+// TODO: Use RadioGroup from virkailija-ui-components when it supports disabled-props for individual Radio-elements
+export const RadioGroup = ({
+  value,
+  onChange,
+  disabled = false,
+  error = false,
+  children: childrenProp,
+}) => {
+  const validChildren = React.Children.toArray(childrenProp).filter(c =>
+    React.isValidElement(c)
+  ) as RadioGroupChild[];
+
+  const childrenCount = React.Children.count(validChildren);
+
+  return (
+    <>
+      {validChildren.map((child, index) => {
+        const checked = value !== undefined && child?.props?.value === value;
+        const element = React.cloneElement(child, {
+          checked,
+          onChange,
+          disabled: disabled || child.props?.disabled,
+          error,
+        });
+
+        return (
+          <Container
+            key={_.uniqueId('RadioContainer_')}
+            isLast={index === childrenCount - 1}
+          >
+            {element}
+          </Container>
+        );
+      })}
+    </>
+  );
+};
+
+const JarjestyspaikkaRadioGroup = createFormFieldComponent(
+  ({ disabled, options, value, error, onChange }) => {
+    return (
+      <RadioGroup
+        value={value}
+        disabled={disabled}
+        error={error}
+        onChange={onChange}
+      >
+        {options.map(({ value, disabled, label }) => (
+          <Radio key={value} value={value} disabled={disabled}>
+            {label}
+          </Radio>
+        ))}
+      </RadioGroup>
+    );
+  },
+  simpleMapProps
+);
+
 const JarjestyspaikkaSection = ({
   tarjoajat,
   opetustapaKoodiUrit,
-  organisaatioOid,
+  toteutusOrganisaatioOid,
 }: {
   tarjoajat: Array<string>;
   opetustapaKoodiUrit: Array<string>;
-  organisaatioOid: string;
+  toteutusOrganisaatioOid: string;
 }) => {
   const { t } = useTranslation();
 
-  const { hierarkia = [] } = useOrganisaatioHierarkia(organisaatioOid);
+  const { hierarkia = [] } = useOrganisaatioHierarkia(toteutusOrganisaatioOid);
+
+  const getCanUpdate = useGetCurrentUserHasRole(
+    ENTITY.HAKUKOHDE,
+    CRUD_ROLES.UPDATE
+  );
 
   const language = useLanguage();
-  const jarjestyspaikkaOptions = flatFilterHierarkia(
-    hierarkia,
-    _.overEvery([
-      organisaatioMatchesTyyppi(ORGANISAATIOTYYPPI.TOIMIPISTE),
-      org =>
-        // Select intersection of organisaatio branches from selected organisaatio and tarjoajat
-        _.some(tarjoaja => _.includes(tarjoaja, org?.parentOidPath))(tarjoajat),
-    ])
-  ).map(({ oid, nimi }) => ({
-    value: oid,
-    label: getFirstLanguageValue(nimi, language),
-  }));
+  const jarjestyspaikkaOptions = useMemo(
+    () =>
+      _.pipe(
+        flattenHierarkia,
+        _.filter(organisaatioMatchesTyyppi(ORGANISAATIOTYYPPI.TOIMIPISTE)),
+        _.map(org => ({
+          value: org?.oid,
+          label: getFirstLanguageValue(org?.nimi, language),
+          disabled:
+            // Select intersection of organisaatio branches from selected organisaatio and tarjoajat
+            !_.some(tarjoaja => _.includes(tarjoaja, org?.parentOidPath))(
+              tarjoajat
+            ) || !getCanUpdate(org),
+        })),
+        _.sortBy('label')
+      )(hierarkia),
+    [getCanUpdate, hierarkia, language, tarjoajat]
+  );
 
   const jarjestyspaikkaOidRequired = _.difference(opetustapaKoodiUrit)(
     JARJESTYSPAIKATTOMAT_OPETUSTAVAT
@@ -53,7 +144,7 @@ const JarjestyspaikkaSection = ({
     <div {...getTestIdProps('jarjestyspaikkaOidSelection')}>
       <Field
         label={t('hakukohdelomake.valitseJarjestyspaikka')}
-        component={FormFieldRadioGroup}
+        component={JarjestyspaikkaRadioGroup}
         options={jarjestyspaikkaOptions}
         name={`jarjestyspaikkaOid`}
       />

--- a/src/main/app/src/pages/hakukohde/getHakukohdePageData.ts
+++ b/src/main/app/src/pages/hakukohde/getHakukohdePageData.ts
@@ -1,0 +1,37 @@
+import getHakuByOid from '#/src/utils/haku/getHakuByOid';
+import getToteutusByOid from '#/src/utils/toteutus/getToteutusByOid';
+import getKoulutustyyppiByKoulutusOid from '#/src/utils/koulutus/getKoulutustyyppiByKoulutusOid';
+import { useApiQuery } from '#/src/hooks/useApiQuery';
+
+export const getHakukohdePageData = async ({
+  hakuOid,
+  toteutusOid,
+  httpClient,
+  apiUrls,
+}) => {
+  const [toteutus, haku] = await Promise.all([
+    getToteutusByOid({ oid: toteutusOid, httpClient, apiUrls }),
+    getHakuByOid({ oid: hakuOid, httpClient, apiUrls }),
+  ]);
+
+  const { koulutustyyppi } = await (toteutus && toteutus.koulutusOid
+    ? getKoulutustyyppiByKoulutusOid({
+        oid: toteutus.koulutusOid,
+        httpClient,
+        apiUrls,
+      })
+    : null);
+
+  return {
+    toteutus,
+    haku,
+    koulutustyyppi,
+    tarjoajat: toteutus?.tarjoajat,
+  };
+};
+
+export const useHakukohdePageData = (props, options = {}) =>
+  useApiQuery('hakukohdePageData', props, getHakukohdePageData, {
+    refetchOnWindowFocus: false,
+    ...options,
+  });

--- a/src/main/app/src/utils/hakukohde/getHakukohdeByOid.ts
+++ b/src/main/app/src/utils/hakukohde/getHakukohdeByOid.ts
@@ -1,13 +1,19 @@
-import { get, isObject } from 'lodash';
+import _ from 'lodash/fp';
+import { useApiQuery } from '#/src/hooks/useApiQuery';
 
 export const getHakukohdeByOid = async ({ oid, httpClient, apiUrls }) => {
   const { data, headers } = await httpClient.get(
     apiUrls.url('kouta-backend.hakukohde-by-oid', oid)
   );
 
-  const lastModified = get(headers, 'x-last-modified') || null;
+  const lastModified = headers?.['x-last-modified'] || null;
 
-  return isObject(data) ? { lastModified, ...data } : data;
+  return _.isObject(data) ? { lastModified, ...data } : data;
 };
 
 export default getHakukohdeByOid;
+
+export const useHakukohdeByOid = props =>
+  useApiQuery('hakukohde', props, getHakukohdeByOid, {
+    refetchOnWindowFocus: false,
+  });

--- a/src/main/app/src/utils/organisaatio/hierarkiaHelpers.ts
+++ b/src/main/app/src/utils/organisaatio/hierarkiaHelpers.ts
@@ -26,3 +26,8 @@ export const filterByName = (hierarkia, name, language) => {
     return [];
   });
 };
+
+export const flattenHierarkia = _.flatMap(org => [
+  org,
+  ...flattenHierarkia(org?.children ?? []),
+]);


### PR DESCRIPTION
Korjattu hakukohteen järjestyspaikan vaihtoehtojen näyttäminen (kaikki toimipisteet toteutuksen luoja-organisaatiosta, mutta enabloituna vain ne, joihin on oikeudet ja jotka on valittu toteutuksella tarjoajiksi). 

Hakukohteella tarjoajat luettiin aiemmin koulutukselta, mistä aiheutui mielenkiintoisia ongelmia. Tämä on myös korjattu ja samalla siirretty hakukohteen muokkaus- ja luontisivujen lähes identtinen datan noutamisfunktio erilliseen tiedostoon ja muokattu EditHakukohdePage ja CreateHakukohdePage noutamaan dataa react-querya käyttäen. Korvattu myös hakukohdeUpdatedAt URL state react-queryn cachen invalidoinnilla. Lisäksi korjattu joitakin tyyppivirheitä ja poistettu FormSteps-komponentilta turha propsien edelleenvälitys.