### PR TITLE
KTO-945: KOMOTO alkamiskausi pakollisuus pois, ja korjauksia validointiin

### DIFF
--- a/src/main/app/cypress/integration/__snapshots__/toteutus.test.ts.snap
+++ b/src/main/app/cypress/integration/__snapshots__/toteutus.test.ts.snap
@@ -48,7 +48,7 @@ exports[`createToteutus > should be able to create ammatillinen tutkinnon osa to
       "koulutuksenAlkamispaivamaara": null,
       "koulutuksenAlkamisvuosi": 2020,
       "koulutuksenPaattymispaivamaara": null,
-      "koulutuksenTarkkaAlkamisaika": false,
+      "koulutuksenTarkkaAlkamisaika": null,
       "lisatiedot": [
         {
           "otsikkoKoodiUri": "koulutuksenlisatiedot_0#1",
@@ -173,7 +173,7 @@ exports[`createToteutus > should be able to create ammatillinen toteutus #0`] =
       "koulutuksenAlkamispaivamaara": null,
       "koulutuksenAlkamisvuosi": 2020,
       "koulutuksenPaattymispaivamaara": null,
-      "koulutuksenTarkkaAlkamisaika": false,
+      "koulutuksenTarkkaAlkamisaika": null,
       "lisatiedot": [
         {
           "otsikkoKoodiUri": "koulutuksenlisatiedot_0#1",
@@ -323,7 +323,7 @@ exports[`createToteutus > should be able to create korkeakoulu toteutus #0`] =
       "koulutuksenAlkamispaivamaara": null,
       "koulutuksenAlkamisvuosi": 2020,
       "koulutuksenPaattymispaivamaara": null,
-      "koulutuksenTarkkaAlkamisaika": false,
+      "koulutuksenTarkkaAlkamisaika": null,
       "lisatiedot": [
         {
           "otsikkoKoodiUri": "koulutuksenlisatiedot_0#1",
@@ -477,7 +477,7 @@ exports[`createToteutus > should be able to create lukio toteutus #0`] =
       "koulutuksenAlkamispaivamaara": null,
       "koulutuksenAlkamisvuosi": 2020,
       "koulutuksenPaattymispaivamaara": null,
-      "koulutuksenTarkkaAlkamisaika": false,
+      "koulutuksenTarkkaAlkamisaika": null,
       "lisatiedot": [
         {
           "otsikkoKoodiUri": "koulutuksenlisatiedot_0#1",
@@ -608,7 +608,7 @@ exports[`editToteutus > should be able to edit ammatillinen toteutus #0`] =
       "koulutuksenAlkamispaivamaara": null,
       "koulutuksenAlkamisvuosi": 2020,
       "koulutuksenPaattymispaivamaara": null,
-      "koulutuksenTarkkaAlkamisaika": false,
+      "koulutuksenTarkkaAlkamisaika": null,
       "lisatiedot": [
         {
           "otsikkoKoodiUri": "koulutuksenlisatiedot_0#1",
@@ -764,7 +764,7 @@ exports[`editToteutus > should be able to edit korkeakoulu toteutus #0`] =
       "koulutuksenAlkamispaivamaara": null,
       "koulutuksenAlkamisvuosi": 2020,
       "koulutuksenPaattymispaivamaara": null,
-      "koulutuksenTarkkaAlkamisaika": false,
+      "koulutuksenTarkkaAlkamisaika": null,
       "lisatiedot": [
         {
           "otsikkoKoodiUri": "koulutuksenlisatiedot_0#1",
@@ -924,7 +924,7 @@ exports[`editToteutus > should be able to edit lukio toteutus #0`] =
       "koulutuksenAlkamispaivamaara": null,
       "koulutuksenAlkamisvuosi": 2020,
       "koulutuksenPaattymispaivamaara": null,
-      "koulutuksenTarkkaAlkamisaika": false,
+      "koulutuksenTarkkaAlkamisaika": null,
       "lisatiedot": [
         {
           "otsikkoKoodiUri": "koulutuksenlisatiedot_0#1",
@@ -1059,7 +1059,7 @@ exports[`editToteutus > should be able to edit tutkinnon osa toteutus #0`] =
       "koulutuksenAlkamispaivamaara": null,
       "koulutuksenAlkamisvuosi": 2020,
       "koulutuksenPaattymispaivamaara": null,
-      "koulutuksenTarkkaAlkamisaika": false,
+      "koulutuksenTarkkaAlkamisaika": null,
       "lisatiedot": [
         {
           "otsikkoKoodiUri": "koulutuksenlisatiedot_0#1",

--- a/src/main/app/src/components/DatePickerInput/index.tsx
+++ b/src/main/app/src/components/DatePickerInput/index.tsx
@@ -32,6 +32,7 @@ const DatePickerInput = ({
   dayPickerProps = {},
   disabled,
   value,
+  onChange,
   ...props
 }) => {
   const { t } = useTranslation();
@@ -45,7 +46,10 @@ const DatePickerInput = ({
         ...dayPickerProps,
       }}
       {...props}
-      value={isValid(value) ? value : undefined}
+      value={isValid(value) ? value : ''}
+      onChange={e => {
+        onChange(isValid(e) ? e : null);
+      }}
       inputProps={{ ...(props?.inputProps ?? {}), disabled }}
     />
   );

--- a/src/main/app/src/utils/index.ts
+++ b/src/main/app/src/utils/index.ts
@@ -20,7 +20,8 @@ export const isCypress = Boolean(REACT_APP_CYPRESS);
 
 export const isValidDate = value => _.isDate(value) && !_.isNaN(value);
 
-export const isPartialDate = dateString => {
+export const isPartialDate = date => {
+  const dateString = _.isDate(date) ? getKoutaDateString(date) : null;
   if (dateString) {
     const [date] = dateString.split('T');
     return date === 'NaN-NaN-NaN';

--- a/src/main/app/src/utils/toteutus/getToteutusByFormValues.ts
+++ b/src/main/app/src/utils/toteutus/getToteutusByFormValues.ts
@@ -47,7 +47,7 @@ const getToteutusByFormValues = values => {
   const onkoStipendia = values?.jarjestamistiedot?.onkoStipendia === 'kylla';
 
   const koulutuksenTarkkaAlkamisaika =
-    values?.jarjestamistiedot?.koulutuksenTarkkaAlkamisaika || false;
+    values?.jarjestamistiedot?.koulutuksenTarkkaAlkamisaika || null;
 
   return {
     nimi: pickTranslations(values?.tiedot?.nimi || {}),

--- a/src/main/app/src/utils/toteutus/getToteutusFormConfig.ts
+++ b/src/main/app/src/utils/toteutus/getToteutusFormConfig.ts
@@ -305,42 +305,37 @@ const config = createFormConfigBuilder().registerSections([
         name: 'jarjestamistiedot.stipendinKuvaus',
       }),
       {
-        field: '.koulutuksenAlkamispaivaamara',
-        validate: validateIfJulkaistu(eb =>
-          eb.getValue('jarjestamistiedot.koulutuksenTarkkaAlkamisaika')
-            ? eb.validateExistence(
-                'jarjestamistiedot.koulutuksenAlkamispaivamaara'
-              )
-            : eb
-        ),
+        field: '.koulutuksenAlkamispaivamaara',
+        validate: (eb, values) =>
+          validateIf(
+            values?.jarjestamistiedot?.koulutuksenTarkkaAlkamisaika,
+            validateDateTimeRange(
+              'jarjestamistiedot.koulutuksenAlkamispaivamaara',
+              'jarjestamistiedot.koulutuksenPaattymispaivamaara'
+            )
+          )(eb),
+        required: true,
       },
       {
         field: '.koulutuksenPaattymispaivamaara',
         validate: validateIfJulkaistu(eb =>
           eb.getValue('jarjestamistiedot.koulutuksenTarkkaAlkamisaika')
-            ? eb.validateExistence(
-                'jarjestamistiedot.koulutuksenPaattymispaivamaara'
-              )
+            ? eb
+                .validateExistence(
+                  'jarjestamistiedot.koulutuksenAlkamispaivamaara'
+                )
+                .validateExistence(
+                  'jarjestamistiedot.koulutuksenPaattymispaivamaara'
+                )
             : eb
         ),
         required: true,
       },
       {
         field: '.koulutuksenAlkamiskausi',
-        validate: validateIfJulkaistu(eb =>
-          !eb.getValue('jarjestamistiedot.koulutuksenTarkkaAlkamisaika')
-            ? eb.validateExistence('jarjestamistiedot.koulutuksenAlkamiskausi')
-            : eb
-        ),
-        required: true,
       },
       {
         field: '.koulutuksenAlkamisvuosi',
-        validate: validateIfJulkaistu(eb =>
-          !eb.getValue('jarjestamistiedot.koulutuksenTarkkaAlkamisaika')
-            ? eb.validateExistence('jarjestamistiedot.koulutuksenAlkamisvuosi')
-            : eb
-        ),
       },
       {
         fragment: 'diplomi',


### PR DESCRIPTION


- Poista validoinnit ja pakollisuusindikaattori alkamiskausi ja alkamisvuosi -kentiltä
- Jos tarkkaAlkamisaika ei annettu, välitä null backendille
- DatePickerInput asetetaan arvoksi null, jos ei validi päivämäärä (aiemmin ei voinut poistaa arvoa).
- Validoi tarkka ajankohta myös käyttäen validateDateTimeRange funktiota
- Salli myös date-objekti isPartialDate-funktiolle