### PR TITLE
KTO-951: Ammatillisen KOMOn tallentaminen valittaa nimen puuttumisesta joillakin koulutuksilla

### DIFF
--- a/src/main/app/cypress/tsconfig.json
+++ b/src/main/app/cypress/tsconfig.json
@@ -7,7 +7,7 @@
     "jsx": "react",
     "allowJs": true,
     "moduleResolution": "node",
-    "types": ["cypress", "@types/testing-library__cypress"]
+    "types": ["cypress", "@types/testing-library__cypress", "cypress-plugin-snapshots"]
   },
   "include": ["**/*.ts", "**/*.js"]
 }

--- a/src/main/app/src/hooks/form.ts
+++ b/src/main/app/src/hooks/form.ts
@@ -16,6 +16,7 @@ import getValintaperusteFormConfig from '#/src/utils/valintaperuste/getValintape
 import getSoraKuvausFormConfig from '#/src/utils/soraKuvaus/getSoraKuvausFormConfig';
 import getOppilaitosFormConfig from '#/src/utils/oppilaitos/getOppilaitosFormConfig';
 import getOppilaitoksenOsaFormConfig from '#/src/utils/oppilaitoksenOsa/getOppilaitoksenOsaFormConfig';
+import { getKielivalinta } from '#/src/utils/form/formConfigUtils';
 
 export const useFormName = () => useContext(FormNameContext);
 
@@ -90,4 +91,9 @@ export const useFormConfig = () => {
       ...(contextConfig || {}),
     };
   }, [contextConfig]);
+};
+
+export const useSelectedLanguages = () => {
+  const formName = useFormName();
+  return useSelector(state => getKielivalinta(state?.form?.[formName]?.values));
 };

--- a/src/main/app/src/hooks/useKoodi/index.ts
+++ b/src/main/app/src/hooks/useKoodi/index.ts
@@ -5,11 +5,14 @@ import useKoodisto from '#/src/hooks/useKoodisto';
 import parseKoodiUri from '#/src/utils/koodi/parseKoodiUri';
 
 const useKoodi = koodiUri => {
-  const { koodisto, versio, koodi } = useMemo(() => parseKoodiUri(koodiUri), [
+  const { koodisto, koodi } = useMemo(() => parseKoodiUri(koodiUri), [
     koodiUri,
   ]);
 
-  const { data, ...rest } = useKoodisto({ koodisto, versio });
+  // Not passing koodisto version parsed from koodiUri here, because we
+  // want to use the latest koodisto. Also if a single koodi tries to fetch
+  // koodisto again for an older koodisto versio this will return empty data.
+  const { data, ...rest } = useKoodisto({ koodisto, versio: '' });
 
   const koodistoKoodi = useMemo(() => {
     return isArray(data) ? data.find(k => k.koodiUri === koodi) : undefined;

--- a/src/main/app/src/pages/koulutus/KoulutusForm/useLocalizedKoulutus.ts
+++ b/src/main/app/src/pages/koulutus/KoulutusForm/useLocalizedKoulutus.ts
@@ -1,10 +1,11 @@
-import { useEffect } from 'react';
-import _ from 'lodash';
+import { useEffect, useState } from 'react';
+import _ from 'lodash/fp';
 import useKoodi from '#/src/hooks/useKoodi';
 import {
   useBoundFormActions,
   useIsDirty,
   useFieldValue,
+  useSelectedLanguages,
 } from '#/src/hooks/form';
 import { useHasChanged } from '#/src/hooks/useHasChanged';
 
@@ -13,6 +14,7 @@ export const useLocalizedKoulutus = ({
   nimiFieldName,
   language,
 }) => {
+  const languages = useSelectedLanguages();
   const koulutusValue = useFieldValue(koulutusFieldName);
   const koulutusKoodi = useKoodi(koulutusValue?.value);
   const koodi = koulutusKoodi?.koodi;
@@ -25,8 +27,8 @@ export const useLocalizedKoulutus = ({
     if (koodi && isDirty) {
       const { metadata } = koodi;
       const localizedNimi = _.find(
-        metadata,
-        ({ kieli }) => _.toLower(kieli) === language
+        ({ kieli }) => _.toLower(kieli) === language,
+        metadata
       )?.nimi;
 
       if (localizedNimi) {
@@ -36,20 +38,36 @@ export const useLocalizedKoulutus = ({
   }, [language, koodi, koulutusFieldName, isDirty, change]);
 
   const koulutusHasChanged = useHasChanged(koulutusValue);
+  const [nimiShouldUpdate, setNimiShouldUpdate] = useState(false);
+
+  useEffect(() => {
+    if (koulutusHasChanged) {
+      setNimiShouldUpdate(true);
+    }
+  }, [koulutusHasChanged]);
 
   // When koulutus field has changed to a defined value and got its 'koodi'
   // change the language versioned 'nimi' fields accordingly
   // if the form is dirty (don't override initial values)
   useEffect(() => {
-    if (nimiFieldName && koulutusHasChanged && isDirty) {
-      if (koodi) {
-        _.each(koodi?.metadata, ({ kieli, nimi }) => {
-          const lang = _.toLower(kieli);
-          change(`${nimiFieldName}.${lang}`, nimi);
-        });
-      } else {
-        change(nimiFieldName, {});
-      }
+    if (nimiFieldName && nimiShouldUpdate && isDirty) {
+      const newNimiFieldValue = {};
+      _.each(({ kieli, nimi }) => {
+        const lang = _.toLower(kieli);
+        if (languages.includes(lang)) {
+          newNimiFieldValue[lang] = nimi;
+        }
+      }, koodi?.metadata);
+      change(nimiFieldName, newNimiFieldValue);
+      setNimiShouldUpdate(false);
     }
-  }, [change, nimiFieldName, koodi, language, koulutusHasChanged, isDirty]);
+  }, [
+    change,
+    nimiFieldName,
+    koodi,
+    language,
+    isDirty,
+    languages,
+    nimiShouldUpdate,
+  ]);
 };


### PR DESCRIPTION
Kouta-ui noutaa koulutus-koodiston kutsumalla koodisto-servicen /json/{koulutuskoodi}/koodi-URIa onlyValidKoodis-optiolla ilman koodistoversiota. Tämä palauttaa myös koulutuksia vanhemmista koodistoista. Näissä tapauksissa koodisto noudettiin uudelleen antamalla vanha koodistoversio, joka palauttaa tyhjän vastauksen. Perimmäisenä ongelmana ovat koodin ja koodiston voimassaolojen epäloogisuudet. Esimerkiksi koulutus (https://virkailija.testiopintopolku.fi/koodisto-ui/html/koodi/koulutus_364946/7) väittää olevansa voimassa, mutta kyseisen koodistoversion voimassaolo on päättynyt (https://virkailija.testiopintopolku.fi/koodisto-ui/html/koodisto/koulutus/7)
Korjasin poistamalla kokonaan version välittämisen koodisto-kutsulle, jolloin käytetään aina viimeistintä versiota. Samalla parantelin hieman hookkia, joka kopioi koulutus-kentän arvot nimi-kenttään.