### PR TITLE
KTO-955 Aakkostus bugi

### DIFF
--- a/src/main/app/src/hooks/useEntityOptionsHook.ts
+++ b/src/main/app/src/hooks/useEntityOptionsHook.ts
@@ -26,7 +26,7 @@ export const useEntityOptions = entities => {
                 getFirstLanguageValue(entity.nimi, language) +
                 ` (${t(getJulkaisutilaTranslationKey(entity.tila))})`,
             })),
-            _.orderBy([({ label }) => _.lowerCase(label)], 'asc')
+            _.orderBy(({ label }) => _.lowerCase(label), 'asc')
           )(entities as EntityForDropdown[])
         : [],
     [entities, language, t]

--- a/src/main/app/src/hooks/useEntityOptionsHook.ts
+++ b/src/main/app/src/hooks/useEntityOptionsHook.ts
@@ -26,7 +26,7 @@ export const useEntityOptions = entities => {
                 getFirstLanguageValue(entity.nimi, language) +
                 ` (${t(getJulkaisutilaTranslationKey(entity.tila))})`,
             })),
-            _.orderBy('label', 'asc')
+            _.orderBy([({ label }) => _.lowerCase(label)], 'asc')
           )(entities as EntityForDropdown[])
         : [],
     [entities, language, t]


### PR DESCRIPTION
Lodash aakkostaa defaulttina ensin isot kirjaimet ja sen jälkeen pienet. Annetaan orderBy:lle lowercasena niin ei tee eroa näiden välille.