### PR TITLE
KTO-1037: Haun alkamiskausi: Henkilökohtaisen suunnitelman lisätiedot

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,17 +93,18 @@ Yksikkötestit löytyvät testattavan moduulin `*.test.jsx?` (esim. `components/
 
 Yksikkötestit voi ajaa komennolla `npm test` ja integraatiotestit komennolla `npm run test:integration`. Kaikki testit pystyy ajamaan komennolla `npm run test:ci`.
 
-### Cypress TestRunner, interaktiivisesti
+### Integraatiotestien ajaminen interaktiivisesti (Cypress)
 
-On hauska katsoa ja korjata cypress testia interaktiivisti Cypress TestRunnerilla: 
+Cypress-testejä voi ajaa myös interaktiivisesti käynnistämällä ensin kouta-ui:n integraatio-moodissa:
 
     cd src/main/app
-    npm start
+    npm start:integration
 
-Ja sitten samassa kansiossa, mutta toisessa shellissa: 
+ja sitten samassa kansiossa, mutta toisessa shellissa: 
 
     npx cypress open
     
+Cypress-integraatiotestit olettavat, että sovellus on renderöity käyttäen käännösavaimia, minkä vuoksi on käytettävä `npm start:integration`tai `npm start:integration:debug` komentoa sovelluksen käynnistämiseen. Npm Skripti `start:integration:debug` eroaa `start:integration`:sta siten, että se sallii sovelluksen kyselyt ulkopuolelle. Tämä helpottaa mm. cypressin-testien api-mockien päivittämistä ja testaamista, kun taas normaalisti integraatiotesteissä halutaan estää yhteydet ulkopuolisiin rajapintoihin.
 ### API-kutsujen mockaaminen
 
 Kouta-UI:ssa on toteutettu omat työkalut API-kutsujen mockauksen helpottamiseen. `npm run update-mocks` käy läpi hakemiston `cypress/mocks` JSON-tiedostot, kutsuu niissä määriteltyjä HTTP-pyyntöjä ja päivittää vastaukset kyseisiin tiedostoihin. Pellin alla kutsutaan nodejs:llä toteutettua `update-mocks.js`-skriptiä, jonka voi ajaa myös itse antamalla sille komentoriviparametrina polun hakemistoon, jossa päivitettävät mock-tiedostot sijatsevat. Mock-tiedostojen formaatti on seuraavanlainen:

--- a/README.md
+++ b/README.md
@@ -1,11 +1,23 @@
 # Kouta-UI
 
-Uuden koulutustarjonnan käyttöliittymä.
+Uuden koulutustarjonnan virkailijan käyttöliittymä.
 
 Kouta-UI on luotu create-react-app:lla, ja se on kääritty Spring Boot 2.0 -sovellukseen, jonka ainoa tehtävä on jakaa käyttöliittymä.
 
 [![Build Status](https://travis-ci.com/Opetushallitus/kouta-ui.svg?branch=master)](https://travis-ci.com/Opetushallitus/kouta-ui)
 [![Codacy Badge](https://app.codacy.com/project/badge/Grade/4fd6253f529e45efaba604131e864189)](https://www.codacy.com/gh/Opetushallitus/kouta-ui/dashboard?utm_source=github.com&amp;utm_medium=referral&amp;utm_content=Opetushallitus/kouta-ui&amp;utm_campaign=Badge_Grade)
+
+## Arkkitehtuuri ja kirjastot
+
+### Lomakkeiden logiikka
+
+Lomakkeiden kenttien näkyvyys riippuu muiden kenttien arvoista sekä käyttäjän oikeuksista (joitakin kenttiä näytetään ainoastaan OPH-virkailijoille). Lomakkeiden kenttien näkyvyyksien määrittelyt on tämän kirjoitusaikana (joulukuu 2020) toteutettu osittain lomakkeiden React-komponenteissa ja osittain FormConfig-objekteissa. FormConfig-objektien takia osa lomakkeiden logiikasta sijaitsee erillään komponenteista joihin se vaikuttaa. Tämä aiheuttaa hämmennystä etenkin uusissa kehittäjissä. FormConfig-objekteissa määritelty lomakkeiden kenttien piilottamiseen/näyttämiseen liittyvä logiikka on päätetty siirtää lomakkeiden komponentteihin. 
+
+Lomakkeiden tilan hallinta on toteutettu redux-form-kirjastolla. Redux-form *rekisteröi* kentän kun sitä vastaava komponentti renderöidään. Vastaavasti *rekisteröinti poistetaan* (unregister), kun kenttää vastaava komponentti poistetaan. Näiden redux-tapahtumien avulla tunnistetaan milloin käyttäjä on poistanut kentät itse näkyvistä ja niille halutaan lähettää tyhjä arvo. Tämä onnistuu, koska *unregister*-tapahtumaa ei lähetetä alussa kun kenttä on piilossa.
+
+### Palvelinkyselyiden hallinta ja muistintaminen
+
+Tämän kirjoitusaikana (joulukuu 2020) Kouta-UI:n API-kutsut on toteutettu usealla eri tavalla ja erilaisilla välimuistiratkaisuilla. Jotkin kyselyistä halutaan muistintaa pitkään (organisaatiopalvelu, eperusteet, koodisto jne.), ja joitakin vain hyvin lyhyen aikaa (kouta-backend). Haasteena on myös saman palvelimelta ladatun tiedon käyttäminen eri komponenteissa. Osittain on otettu käyttöön react-query, joka tarjoaa miellyttävän abstraktion palvelinpyyntöjen hallintaan. Samantyyppinen kouta-ui:ssa käytetty react-async-kirjasto ei tarjoa välimuistiratkaisuja ja jättää edelleen `useEffect`:in tapaan riippuvuuksien serialisoinnin käyttäjälle, mikä johtaa helposti ikuisiin latauslooppeihin ja muihin vastaaviin ongelmiin. Tavoite on korvata React-async kokonaan käyttäen react-query-kirjastoa.
 
 ## Käyttöliittymän kehittäminen
 

--- a/src/main/app/cypress/data/haku.ts
+++ b/src/main/app/cypress/data/haku.ts
@@ -1,4 +1,4 @@
-import { ALKAMISKAUSITYYPPI } from '#/src/constants';
+import { Alkamiskausityyppi } from '#/src/constants';
 
 export default () => ({
   oid: '1.2.246.562.29.00000000000000000001',
@@ -16,7 +16,7 @@ export default () => ({
   hakulomakeLinkki: {},
   metadata: {
     koulutuksenAlkamiskausi: {
-      alkamiskausityyppi: ALKAMISKAUSITYYPPI.ALKAMISKAUSI_JA_VUOSI,
+      alkamiskausityyppi: Alkamiskausityyppi.ALKAMISKAUSI_JA_VUOSI,
       koulutuksenAlkamiskausiKoodiUri: 'kausi_0#1',
       koulutuksenAlkamisvuosi: '2024',
     },

--- a/src/main/app/cypress/integration/__snapshots__/haku.test.ts.snap
+++ b/src/main/app/cypress/integration/__snapshots__/haku.test.ts.snap
@@ -151,6 +151,7 @@ exports[`createHaku > should be able to create haku with ataru hakulomake #0`] =
   "metadata": {
     "koulutuksenAlkamiskausi": {
       "alkamiskausityyppi": "tarkka alkamisajankohta",
+      "henkilokohtaisenSuunnitelmanLisatiedot": {},
       "koulutuksenAlkamiskausiKoodiUri": "kausi_0#1",
       "koulutuksenAlkamispaivamaara": "2020-11-01T00:00",
       "koulutuksenAlkamisvuosi": 2035,
@@ -211,6 +212,7 @@ exports[`createHaku > should be able to create haku with muu hakulomake #0`] =
   "metadata": {
     "koulutuksenAlkamiskausi": {
       "alkamiskausityyppi": null,
+      "henkilokohtaisenSuunnitelmanLisatiedot": {},
       "koulutuksenAlkamiskausiKoodiUri": null,
       "koulutuksenAlkamisvuosi": null
     },
@@ -246,6 +248,7 @@ exports[`createHaku > should be able to create haku with "ei sähköistä" hakul
   "metadata": {
     "koulutuksenAlkamiskausi": {
       "alkamiskausityyppi": null,
+      "henkilokohtaisenSuunnitelmanLisatiedot": {},
       "koulutuksenAlkamiskausiKoodiUri": null,
       "koulutuksenAlkamisvuosi": null
     },

--- a/src/main/app/cypress/integration/__snapshots__/haku.test.ts.snap
+++ b/src/main/app/cypress/integration/__snapshots__/haku.test.ts.snap
@@ -22,6 +22,7 @@ exports[`createHaku > should be able to create haku #0`] =
   "metadata": {
     "koulutuksenAlkamiskausi": {
       "alkamiskausityyppi": "tarkka alkamisajankohta",
+      "henkilokohtaisenSuunnitelmanLisatiedot": {},
       "koulutuksenAlkamiskausiKoodiUri": "kausi_0#1",
       "koulutuksenAlkamispaivamaara": "2020-11-01T00:00",
       "koulutuksenAlkamisvuosi": 2035,
@@ -85,6 +86,7 @@ exports[`editHaku > should be able to edit haku #0`] =
   "metadata": {
     "koulutuksenAlkamiskausi": {
       "alkamiskausityyppi": "alkamiskausi ja -vuosi",
+      "henkilokohtaisenSuunnitelmanLisatiedot": {},
       "koulutuksenAlkamiskausiKoodiUri": "kausi_0#1",
       "koulutuksenAlkamispaivamaara": null,
       "koulutuksenAlkamisvuosi": 2024,

--- a/src/main/app/src/components/KoulutuksenAloitusajankohtaFields.tsx
+++ b/src/main/app/src/components/KoulutuksenAloitusajankohtaFields.tsx
@@ -1,0 +1,108 @@
+import React from 'react';
+import { Field } from 'redux-form';
+import { useTranslation } from 'react-i18next';
+
+import useKoodistoOptions from '#/src/hooks/useKoodistoOptions';
+import { getTestIdProps } from '#/src/utils';
+import { Box } from '#/src/components/virkailija';
+import DateTimeRange from '#/src/components/DateTimeRange';
+import {
+  FormFieldRadioGroup,
+  FormFieldYearSelect,
+  FormFieldSwitch,
+  FormFieldEditor,
+} from '#/src/components/formFields';
+import Spacing from '#/src/components/Spacing';
+import { useFieldValue } from '#/src/hooks/form';
+import { createStyledRadioSection } from '#/src/components/createStyledRadioSection';
+import { TOTEUTUKSEN_AJANKOHTA } from '#/src/constants';
+
+const AlkamiskausiFields = ({ name }) => {
+  const { options } = useKoodistoOptions({ koodisto: 'kausi' });
+  const { t } = useTranslation();
+
+  const tiedossaTarkkaAjankohta = useFieldValue(
+    `${name}.tiedossaTarkkaAjankohta`
+  );
+
+  return (
+    <Spacing {...getTestIdProps('KausiJaVuosiFields')}>
+      <Box flexGrow="1" p={1}>
+        <Field
+          name={`${name}.kausi`}
+          component={FormFieldRadioGroup}
+          label={t('hakulomake.valitseAlkamiskausi')}
+          options={options}
+        />
+      </Box>
+      <Box flexGrow="1" p={1}>
+        <Field
+          name={`${name}.vuosi`}
+          component={FormFieldYearSelect}
+          placeholder={t('hakulomake.valitseAlkamisvuosi')}
+        />
+      </Box>
+      <Box flexGrow="1" p={1}>
+        <Field
+          name={`${name}.tiedossaTarkkaAjankohta`}
+          component={FormFieldSwitch}
+        >
+          {t('hakulomake.tiedossaTarkkaAjankohta')}
+        </Field>
+      </Box>
+      {tiedossaTarkkaAjankohta && (
+        <Box flexGrow="1" p={1}>
+          <DateTimeRange
+            startProps={{
+              name: `${name}.tarkkaAlkaa`,
+            }}
+            endProps={{
+              name: `${name}.tarkkaPaattyy`,
+            }}
+          />
+        </Box>
+      )}
+    </Spacing>
+  );
+};
+
+const HenkilokohtaisenSuunnitelmanLisatiedot = ({ name, language }) => {
+  const { t } = useTranslation();
+  return (
+    <Spacing>
+      <Field
+        name={`${name}.henkilokohtaisenSuunnitelmanLisatiedot.${language}`}
+        component={FormFieldEditor}
+        label={t('yleiset.lisatietoa')}
+      />
+    </Spacing>
+  );
+};
+
+const KoulutuksenAloitusajankohtaRadioGroup = createStyledRadioSection([
+  {
+    label: t => t('hakulomake.alkamiskausi'),
+    value: TOTEUTUKSEN_AJANKOHTA.ALKAMISKAUSI,
+    FieldsComponent: AlkamiskausiFields,
+  },
+  {
+    label: t => t('hakulomake.aloitusHenkilokohtaisenSuunnitelmanMukaisesti'),
+    value: TOTEUTUKSEN_AJANKOHTA.HENKILOKOHTAINEN_SUUNNITELMA,
+    FieldsComponent: HenkilokohtaisenSuunnitelmanLisatiedot,
+  },
+]);
+
+export const KoulutuksenAloitusajankohtaFields = ({
+  name,
+  section,
+  language,
+}) => {
+  return (
+    <Field
+      name={name}
+      component={KoulutuksenAloitusajankohtaRadioGroup}
+      section={section}
+      language={language}
+    />
+  );
+};

--- a/src/main/app/src/components/KoulutuksenAloitusajankohtaFields.tsx
+++ b/src/main/app/src/components/KoulutuksenAloitusajankohtaFields.tsx
@@ -15,7 +15,7 @@ import {
 import Spacing from '#/src/components/Spacing';
 import { useFieldValue } from '#/src/hooks/form';
 import { createStyledRadioSection } from '#/src/components/createStyledRadioSection';
-import { TOTEUTUKSEN_AJANKOHTA } from '#/src/constants';
+import { Ajankohtatyyppi } from '#/src/constants';
 
 const AlkamiskausiFields = ({ name }) => {
   const { options } = useKoodistoOptions({ koodisto: 'kausi' });
@@ -82,12 +82,12 @@ const HenkilokohtaisenSuunnitelmanLisatiedot = ({ name, language }) => {
 const KoulutuksenAloitusajankohtaRadioGroup = createStyledRadioSection([
   {
     label: t => t('hakulomake.alkamiskausi'),
-    value: TOTEUTUKSEN_AJANKOHTA.ALKAMISKAUSI,
+    value: Ajankohtatyyppi.ALKAMISKAUSI,
     FieldsComponent: AlkamiskausiFields,
   },
   {
     label: t => t('hakulomake.aloitusHenkilokohtaisenSuunnitelmanMukaisesti'),
-    value: TOTEUTUKSEN_AJANKOHTA.HENKILOKOHTAINEN_SUUNNITELMA,
+    value: Ajankohtatyyppi.HENKILOKOHTAINEN_SUUNNITELMA,
     FieldsComponent: HenkilokohtaisenSuunnitelmanLisatiedot,
   },
 ]);

--- a/src/main/app/src/components/Select/index.tsx
+++ b/src/main/app/src/components/Select/index.tsx
@@ -5,7 +5,8 @@ import ReactAsyncCreatableSelect from 'react-select/async-creatable';
 import ReactAsyncSelect from 'react-select/async';
 import { ThemeContext } from 'styled-components';
 import { useAsync } from 'react-async';
-import { get, isArray, isObject, isFunction, zipObject } from 'lodash';
+import _ from 'lodash';
+import { useTranslation } from 'react-i18next';
 
 import UiSelect, {
   getStyles,
@@ -13,7 +14,6 @@ import UiSelect, {
 } from '@opetushallitus/virkailija-ui-components/Select';
 
 import { memoizeOne } from '#/src/utils/memoize';
-import { useTranslation } from 'react-i18next';
 
 const OptionComponent = props => (
   <components.Option
@@ -47,7 +47,7 @@ const getDefaultProps = memoizeOne(t => ({
 }));
 
 const getOptionLabelByValue = options => {
-  if (!isArray(options)) {
+  if (!_.isArray(options)) {
     return {};
   }
 
@@ -59,23 +59,23 @@ const getOptionLabelByValue = options => {
 };
 
 const getValue = (value, options) => {
-  const hasOptions = isArray(options);
+  const hasOptions = _.isArray(options);
 
-  if (isObject(value) && value.value) {
+  if (_.isObject(value) && value.value) {
     return hasOptions
-      ? options.find(option => get(option, 'value') === value.value) || {
+      ? options.find(option => option?.value === value.value) || {
           label: value.value,
           ...value,
         }
       : { label: value.value, ...value };
   }
 
-  if (isArray(value)) {
+  if (_.isArray(value)) {
     const labelByValue = getOptionLabelByValue(options);
 
     return value
       .map(item => {
-        if (isObject(item) && item.value) {
+        if (_.isObject(item) && item.value) {
           const { value: itemValue, label: itemLabel, ...rest } = item;
 
           return {
@@ -100,14 +100,14 @@ type SelectProps = Props & {
   error?: boolean;
 };
 
-export const Select: React.FC<SelectProps> = ({
+export const Select = ({
   id,
   disabled,
   value,
   options,
   error = false,
   ...props
-}) => {
+}: SelectProps) => {
   const resolvedValue = useMemo(() => getValue(value, options), [
     value,
     options,
@@ -181,24 +181,24 @@ export const AsyncSelect = ({
   const labelCache = useRef({});
 
   const valuesWithoutLabel = useMemo(() => {
-    const valueArr = isArray(valueProp) ? valueProp : [valueProp];
+    const valueArr = _.isArray(valueProp) ? valueProp : [valueProp];
 
     return valueArr
-      .filter(v => !get(v, 'label') && !labelCache.current[get(v, 'value')])
-      .map(v => get(v, 'value'));
+      .filter(v => !v?.label && !labelCache.current[v?.value])
+      .map(v => v?.value);
   }, [valueProp]);
 
   const promiseFn = useMemo(() => {
     return async () => {
       const labels = await Promise.all(
         valuesWithoutLabel.map(v =>
-          (isFunction(loadLabel) ? loadLabel(v) : noopPromise()).catch(
+          (_.isFunction(loadLabel) ? loadLabel(v) : noopPromise()).catch(
             () => null
           )
         )
       );
 
-      const valueToLabel = zipObject(valuesWithoutLabel, labels);
+      const valueToLabel = _.zipObject(valuesWithoutLabel, labels);
 
       labelCache.current = {
         ...labelCache.current,

--- a/src/main/app/src/components/createStyledRadioSection.tsx
+++ b/src/main/app/src/components/createStyledRadioSection.tsx
@@ -23,7 +23,7 @@ const StyledBlueBox = styled(Box)`
 `;
 
 export const createStyledRadioSection = radioConfig =>
-  createFormFieldComponent(({ onChange, value, section }) => {
+  createFormFieldComponent(({ onChange, value, section, disabled }) => {
     const { t } = useTranslation();
     return (
       <Box display="flex" flexDirection="column">
@@ -36,6 +36,7 @@ export const createStyledRadioSection = radioConfig =>
                   checked={isChecked}
                   value={radioValue}
                   onChange={onChange}
+                  disabled={disabled}
                 >
                   {_.isFunction(label) ? label(t) : label}
                 </StyledGrayRadio>

--- a/src/main/app/src/components/createStyledRadioSection.tsx
+++ b/src/main/app/src/components/createStyledRadioSection.tsx
@@ -23,32 +23,36 @@ const StyledBlueBox = styled(Box)`
 `;
 
 export const createStyledRadioSection = radioConfig =>
-  createFormFieldComponent(({ onChange, value, section, disabled }) => {
-    const { t } = useTranslation();
-    return (
-      <Box display="flex" flexDirection="column">
-        {radioConfig.map(
-          ({ label = '', value: radioValue, FieldsComponent }) => {
-            const isChecked = value === radioValue;
-            return (
-              <Box key={radioValue} display="flex" flexDirection="column">
-                <StyledGrayRadio
-                  checked={isChecked}
-                  value={radioValue}
-                  onChange={onChange}
-                  disabled={disabled}
-                >
-                  {_.isFunction(label) ? label(t) : label}
-                </StyledGrayRadio>
-                {isChecked && FieldsComponent && (
-                  <StyledBlueBox>
-                    <FieldsComponent name={section} />
-                  </StyledBlueBox>
-                )}
-              </Box>
-            );
-          }
-        )}
-      </Box>
-    );
-  }, simpleMapProps);
+  createFormFieldComponent(
+    ({ onChange, value, section, disabled, language, error }) => {
+      const { t } = useTranslation();
+      return (
+        <Box display="flex" flexDirection="column">
+          {radioConfig.map(
+            ({ label = '', value: radioValue, FieldsComponent }) => {
+              const isChecked = value === radioValue;
+              return (
+                <Box key={radioValue} display="flex" flexDirection="column">
+                  <StyledGrayRadio
+                    checked={isChecked}
+                    value={radioValue}
+                    onChange={onChange}
+                    disabled={disabled}
+                    error={error}
+                  >
+                    {_.isFunction(label) ? label(t) : label}
+                  </StyledGrayRadio>
+                  {isChecked && FieldsComponent && (
+                    <StyledBlueBox>
+                      <FieldsComponent name={section} language={language} />
+                    </StyledBlueBox>
+                  )}
+                </Box>
+              );
+            }
+          )}
+        </Box>
+      );
+    },
+    simpleMapProps
+  );

--- a/src/main/app/src/constants.ts
+++ b/src/main/app/src/constants.ts
@@ -279,3 +279,8 @@ export enum TOTEUTUKSEN_AJANKOHTA {
   ALKAMISKAUSI = 'alkamiskausi',
   HENKILOKOHTAINEN_SUUNNITELMA = 'aloitusHenkilokohtaisenSuunnitelmanMukaisesti',
 }
+
+export enum FormMode {
+  CREATE = 'create',
+  EDIT = 'edit',
+}

--- a/src/main/app/src/constants.ts
+++ b/src/main/app/src/constants.ts
@@ -269,13 +269,13 @@ export const EPERUSTE_SERVICE_QUERY_OPTIONS = {
   cacheTime: Infinity,
 };
 
-export enum ALKAMISKAUSITYYPPI {
+export enum Alkamiskausityyppi {
   TARKKA_ALKAMISAJANKOHTA = 'tarkka alkamisajankohta',
   ALKAMISKAUSI_JA_VUOSI = 'alkamiskausi ja -vuosi',
   HENKILOKOHTAINEN_SUUNNITELMA = 'henkilokohtainen suunnitelma',
 }
 
-export enum TOTEUTUKSEN_AJANKOHTA {
+export enum Ajankohtatyyppi {
   ALKAMISKAUSI = 'alkamiskausi',
   HENKILOKOHTAINEN_SUUNNITELMA = 'aloitusHenkilokohtaisenSuunnitelmanMukaisesti',
 }

--- a/src/main/app/src/hooks/form.ts
+++ b/src/main/app/src/hooks/form.ts
@@ -20,9 +20,10 @@ import { getKielivalinta } from '#/src/utils/form/formConfigUtils';
 
 export const useFormName = () => useContext(FormNameContext);
 
-export const useForm = () => {
+export const useForm = (formNameProp?: string) => {
   const formName = useFormName();
-  return useSelector(state => _.get(state, `form.${formName}`));
+
+  return useSelector(state => _.get(state, `form.${formNameProp || formName}`));
 };
 
 export function useBoundFormActions() {

--- a/src/main/app/src/pages/haku/CreateHakuPage.tsx
+++ b/src/main/app/src/pages/haku/CreateHakuPage.tsx
@@ -1,32 +1,25 @@
-import React, { useMemo, useCallback } from 'react';
+import React, { useMemo } from 'react';
 import queryString from 'query-string';
 import { useTranslation } from 'react-i18next';
 
 import FormPage, {
   OrganisaatioRelation,
   RelationInfoContainer,
-  FormFooter,
 } from '#/src/components/FormPage';
-
-import { POHJAVALINTA, ENTITY } from '#/src/constants';
+import { POHJAVALINTA, ENTITY, FormMode } from '#/src/constants';
 import useSelectBase from '#/src/hooks/useSelectBase';
 import Title from '#/src/components/Title';
 import ReduxForm from '#/src/components/ReduxForm';
 import FormConfigContext from '#/src/contexts/FormConfigContext';
 import getHakuFormConfig from '#/src/utils/haku/getHakuFormConfig';
-import getHakuByOid from '#/src/utils/haku/getHakuByOid';
-import useApiAsync from '#/src/hooks/useApiAsync';
-import { getFormValuesByHaku } from '#/src/utils/haku/getFormValuesByHaku';
-import createHaku from '#/src/utils/haku/createHaku';
-import { getHakuByFormValues } from '#/src/utils/haku/getHakuByFormValues';
-import { useSaveForm } from '#/src/hooks/formSaveHooks';
-import validateHakuForm from '#/src/utils/haku/validateHakuForm';
+import { useHakuByOid } from '#/src/utils/haku/getHakuByOid';
 import FormSteps from '#/src/components/FormSteps';
 import FormHeader from '#/src/components/FormHeader';
-import HakuForm, { initialValues } from '#/src/pages/haku/HakuForm';
+import { getFormValuesByHaku } from '#/src/utils/haku/getFormValuesByHaku';
+import HakuForm, { initialValues } from './HakuForm';
+import HakuFooter from './HakuFooter';
 
 const config = getHakuFormConfig();
-const resolveFn = () => Promise.resolve();
 
 const getCopyValues = hakuOid => ({
   pohja: {
@@ -50,47 +43,30 @@ const CreateHakuPage = props => {
     history,
   } = props;
 
-  const { kopioHakuOid = null } = queryString.parse(search);
+  const { kopioHakuOid } = queryString.parse(search);
   const { t } = useTranslation();
   const selectBase = useSelectBase(history, { kopioParam: 'kopioHakuOid' });
 
-  const promiseFn = kopioHakuOid ? getHakuByOid : resolveFn;
+  const { data } = useHakuByOid(
+    { oid: kopioHakuOid },
+    {
+      enabled: kopioHakuOid,
+    }
+  );
 
-  const { data } = useApiAsync({
-    promiseFn,
-    oid: kopioHakuOid,
-    watch: kopioHakuOid,
-  });
   const initialValues = useMemo(() => {
     return getInitialValues(data);
   }, [data]);
 
-  const submit = useCallback(
-    async ({ values, httpClient, apiUrls }) => {
-      const { oid } = await createHaku({
-        httpClient,
-        apiUrls,
-        haku: { ...getHakuByFormValues(values), organisaatioOid },
-      });
-
-      history.push(`/organisaatio/${organisaatioOid}/haku/${oid}/muokkaus`);
-    },
-    [organisaatioOid, history]
-  );
-
-  const { save } = useSaveForm({
-    form: 'createHakuForm',
-    submit,
-    validate: validateHakuForm,
-  });
-
   return (
-    <ReduxForm form="createHakuForm" initialValues={initialValues}>
+    <ReduxForm form="hakuForm" initialValues={initialValues}>
       <Title>{t('sivuTitlet.uusiHaku')}</Title>
       <FormPage
         header={<FormHeader>{t('yleiset.haku')}</FormHeader>}
         steps={<FormSteps activeStep={ENTITY.HAKU} />}
-        footer={<FormFooter entity={ENTITY.HAKU} save={save} />}
+        footer={
+          <HakuFooter formMode={FormMode.CREATE} haku={{ organisaatioOid }} />
+        }
       >
         <RelationInfoContainer>
           <OrganisaatioRelation organisaatioOid={organisaatioOid} />

--- a/src/main/app/src/pages/haku/EditHakuPage.tsx
+++ b/src/main/app/src/pages/haku/EditHakuPage.tsx
@@ -5,38 +5,27 @@ import FormPage, {
   OrganisaatioRelation,
   RelationInfoContainer,
 } from '#/src/components/FormPage';
-import useApiAsync from '#/src/hooks/useApiAsync';
 import { Spin } from '#/src/components/virkailija';
-import getHakuByOid from '#/src/utils/haku/getHakuByOid';
+import { useHakuByOid } from '#/src/utils/haku/getHakuByOid';
 import Title from '#/src/components/Title';
 import ReduxForm from '#/src/components/ReduxForm';
 import { getFormValuesByHaku } from '#/src/utils/haku/getFormValuesByHaku';
 import FormConfigContext from '#/src/contexts/FormConfigContext';
-import { ENTITY, CRUD_ROLES } from '#/src/constants';
+import { ENTITY, CRUD_ROLES, FormMode } from '#/src/constants';
 import EntityFormHeader from '#/src/components/EntityFormHeader';
 import FormSteps from '#/src/components/FormSteps';
 import { useCurrentUserHasRole } from '#/src/hooks/useCurrentUserHasRole';
 import { useEntityFormConfig } from '#/src/hooks/form';
-import EditHakuFooter from './EditHakuFooter';
-import HakuForm from '#/src/pages/haku/HakuForm';
+import { HakuFooter } from './HakuFooter';
+import HakuForm from './HakuForm';
 
-const EditHakuPage = props => {
-  const {
-    history,
-    match: {
-      params: { organisaatioOid, oid },
-    },
-    location: { state = {} },
-  } = props;
-
-  const { hakuUpdatedAt = null } = state;
-  const watch = JSON.stringify([oid, hakuUpdatedAt]);
-
-  const { data: haku = null } = useApiAsync({
-    promiseFn: getHakuByOid,
-    oid,
-    watch,
-  });
+const EditHakuPage = ({
+  history,
+  match: {
+    params: { organisaatioOid, oid },
+  },
+}) => {
+  const { data: haku, isFetching } = useHakuByOid({ oid });
 
   const { t } = useTranslation();
   const initialValues = useMemo(() => {
@@ -63,7 +52,7 @@ const EditHakuPage = props => {
   const config = useEntityFormConfig(ENTITY.HAKU);
 
   return (
-    <ReduxForm form="editHakuForm" initialValues={initialValues}>
+    <ReduxForm form="hakuForm" initialValues={initialValues}>
       <Title>{t('sivuTitlet.haunMuokkaus')}</Title>
       <FormConfigContext.Provider value={{ ...config, readOnly: !canUpdate }}>
         <FormPage
@@ -71,13 +60,19 @@ const EditHakuPage = props => {
           header={<EntityFormHeader entityType={ENTITY.HAKU} entity={haku} />}
           steps={<FormSteps activeStep={ENTITY.HAKU} />}
           footer={
-            haku ? <EditHakuFooter haku={haku} canUpdate={canUpdate} /> : null
+            haku ? (
+              <HakuFooter
+                haku={haku}
+                formMode={FormMode.EDIT}
+                canUpdate={canUpdate}
+              />
+            ) : null
           }
         >
           <RelationInfoContainer>
             <OrganisaatioRelation organisaatioOid={organisaatioOid} />
           </RelationInfoContainer>
-          {haku ? (
+          {!isFetching && haku ? (
             <HakuForm
               haku={haku}
               organisaatioOid={organisaatioOid}

--- a/src/main/app/src/pages/haku/HakuFooter.tsx
+++ b/src/main/app/src/pages/haku/HakuFooter.tsx
@@ -13,8 +13,15 @@ import createHaku from '#/src/utils/haku/createHaku';
 import { getValuesForSaving } from '#/src/utils';
 import { useForm } from '#/src/hooks/form';
 import { useFormName } from '#/src/contexts/contextHooks';
+import { HakuModel } from '#/src/types/hakuTypes';
 
-const useSaveHaku = (formMode, haku) => {
+type HakuFooterProps = {
+  formMode: FormMode;
+  haku: HakuModel;
+  canUpdate?: boolean;
+};
+
+export const HakuFooter = ({ formMode, haku, canUpdate }: HakuFooterProps) => {
   const history = useHistory();
 
   const form = useForm();
@@ -61,24 +68,11 @@ const useSaveHaku = (formMode, haku) => {
   );
 
   const { save } = useSaveForm({
-    form: 'hakuForm',
+    form: formName,
     submit,
     validate: validateHakuForm,
   });
 
-  return save;
-};
-
-type HakuModel = any;
-
-type HakuFooterProps = {
-  formMode: FormMode;
-  haku: HakuModel;
-  canUpdate?: boolean;
-};
-
-export const HakuFooter = ({ formMode, haku, canUpdate }: HakuFooterProps) => {
-  const save = useSaveHaku(formMode, haku);
   return <FormFooter entity={ENTITY.HAKU} save={save} canUpdate={canUpdate} />;
 };
 

--- a/src/main/app/src/pages/haku/HakuFooter.tsx
+++ b/src/main/app/src/pages/haku/HakuFooter.tsx
@@ -1,4 +1,5 @@
 import React, { useCallback } from 'react';
+import { useSelector } from 'react-redux';
 import { queryCache } from 'react-query';
 import { useHistory } from 'react-router-dom';
 
@@ -9,28 +10,35 @@ import { useSaveForm } from '#/src/hooks/formSaveHooks';
 import { FormFooter } from '#/src/components/FormPage';
 import { ENTITY, FormMode } from '#/src/constants';
 import createHaku from '#/src/utils/haku/createHaku';
+import { getValuesForSaving } from '#/src/utils';
+import { useForm } from '#/src/hooks/form';
+import { useFormName } from '#/src/contexts/contextHooks';
 
-type HakuModel = any;
-
-type HakuFooterProps = {
-  formMode: FormMode;
-  haku: HakuModel;
-  canUpdate?: boolean;
-};
-
-export const HakuFooter = ({ formMode, haku, canUpdate }: HakuFooterProps) => {
+const useSaveHaku = (formMode, haku) => {
   const history = useHistory();
+
+  const form = useForm();
+  const formName = useFormName();
+  const unregisteredFields = useSelector(state => state?.unregisteredFields);
+  const initialValues = useSelector(state => state.form?.[formName]?.initial);
 
   const submit = useCallback(
     async ({ values, httpClient, apiUrls }) => {
       const dataSendFn = formMode === FormMode.CREATE ? createHaku : updateHaku;
+
+      const valuesForSaving = getValuesForSaving(
+        values,
+        form.registeredFields,
+        unregisteredFields,
+        initialValues
+      );
 
       const { oid } = await dataSendFn({
         httpClient,
         apiUrls,
         haku: {
           ...haku,
-          ...getHakuByFormValues(values),
+          ...getHakuByFormValues(valuesForSaving),
         },
       });
 
@@ -42,7 +50,14 @@ export const HakuFooter = ({ formMode, haku, canUpdate }: HakuFooterProps) => {
         queryCache.invalidateQueries(ENTITY.HAKU);
       }
     },
-    [formMode, haku, history]
+    [
+      form.registeredFields,
+      formMode,
+      haku,
+      history,
+      initialValues,
+      unregisteredFields,
+    ]
   );
 
   const { save } = useSaveForm({
@@ -51,6 +66,19 @@ export const HakuFooter = ({ formMode, haku, canUpdate }: HakuFooterProps) => {
     validate: validateHakuForm,
   });
 
+  return save;
+};
+
+type HakuModel = any;
+
+type HakuFooterProps = {
+  formMode: FormMode;
+  haku: HakuModel;
+  canUpdate?: boolean;
+};
+
+export const HakuFooter = ({ formMode, haku, canUpdate }: HakuFooterProps) => {
+  const save = useSaveHaku(formMode, haku);
   return <FormFooter entity={ENTITY.HAKU} save={save} canUpdate={canUpdate} />;
 };
 

--- a/src/main/app/src/pages/haku/HakuForm/HakuForm.tsx
+++ b/src/main/app/src/pages/haku/HakuForm/HakuForm.tsx
@@ -7,7 +7,7 @@ import Button from '#/src/components/Button';
 import { LomakeFields } from '#/src/components/LomakeFields';
 import useModal from '#/src/hooks/useModal';
 import isYhteishakuHakutapa from '#/src/utils/isYhteishakuHakutapa';
-import { useFieldValue } from '#/src/hooks/form';
+import { useFieldValue, useSelectedLanguages } from '#/src/hooks/form';
 import JulkaisutilaField from '#/src/components/JulkaisutilaField';
 import PohjaFormCollapse from '#/src/components/PohjaFormCollapse';
 import PohjaValintaSection from '#/src/components/PohjaValintaSection';
@@ -34,8 +34,7 @@ const HakuForm = ({
 }) => {
   const { t } = useTranslation();
   const { isOpen, open, close } = useModal();
-  const kieliversiot = useFieldValue('kieliversiot');
-  const languages = kieliversiot || [];
+  const languages = useSelectedLanguages();
   const hakutapa = useFieldValue('hakutapa');
   const isYhteishaku = isYhteishakuHakutapa(hakutapa);
 
@@ -99,6 +98,7 @@ const HakuForm = ({
           Component={ScheduleSection}
           isYhteishaku={isYhteishaku}
           isOphVirkailija={isOphVirkailija}
+          languages={languages}
         />
 
         <FormCollapse

--- a/src/main/app/src/pages/haku/HakuForm/ScheduleSection.tsx
+++ b/src/main/app/src/pages/haku/HakuForm/ScheduleSection.tsx
@@ -26,13 +26,10 @@ const ScheduleSection = ({ isOphVirkailija, isYhteishaku, name, language }) => {
         />
       </FieldGroup>
 
-      <FieldGroup
-        title={t('hakulomake.toteutuksenAjankohta')}
-        {...getTestIdProps('toteutuksenAjankohta')}
-      >
+      <FieldGroup title={t('hakulomake.koulutuksenAjankohta')}>
         <KoulutuksenAloitusajankohtaFields
           section={name}
-          name={`${name}.toteutuksenAjankohta`}
+          name={`${name}.ajankohtaTyyppi`}
           language={language}
         />
       </FieldGroup>

--- a/src/main/app/src/pages/haku/HakuForm/ScheduleSection.tsx
+++ b/src/main/app/src/pages/haku/HakuForm/ScheduleSection.tsx
@@ -69,12 +69,12 @@ const KausiJaVuosiFields = ({ name }) => {
   );
 };
 
-const HenkilokohtaisenSuunnitelmanLisatiedot = ({ name }) => {
+const HenkilokohtaisenSuunnitelmanLisatiedot = ({ name, language }) => {
   const { t } = useTranslation();
   return (
     <Spacing>
       <Field
-        name={`${name}.henkilokohtaisenSuunnitelmanLisatiedot`}
+        name={`${name}.henkilokohtaisenSuunnitelmanLisatiedot.${language}`}
         component={FormFieldEditor}
         label={t('yleiset.lisatietoa')}
       />
@@ -95,7 +95,7 @@ const ToteutuksenAjankohtaFields = createStyledRadioSection([
   },
 ]);
 
-const ScheduleSection = ({ isOphVirkailija, isYhteishaku, name }) => {
+const ScheduleSection = ({ isOphVirkailija, isYhteishaku, name, language }) => {
   const { t } = useTranslation();
 
   return (
@@ -120,6 +120,7 @@ const ScheduleSection = ({ isOphVirkailija, isYhteishaku, name }) => {
           name={`${name}.toteutuksenAjankohta`}
           component={ToteutuksenAjankohtaFields}
           section={name}
+          language={language}
         />
       </FieldGroup>
 

--- a/src/main/app/src/pages/haku/HakuForm/ScheduleSection.tsx
+++ b/src/main/app/src/pages/haku/HakuForm/ScheduleSection.tsx
@@ -2,98 +2,12 @@ import React from 'react';
 import { Field, FieldArray } from 'redux-form';
 import { useTranslation } from 'react-i18next';
 
-import useKoodistoOptions from '#/src/hooks/useKoodistoOptions';
 import { getTestIdProps } from '#/src/utils';
 import { Box } from '#/src/components/virkailija';
 import HakuajatFields from '#/src/components/HakuajatFields';
 import FieldGroup from '#/src/components/FieldGroup';
-import DateTimeRange from '#/src/components/DateTimeRange';
-import {
-  FormFieldDateTimeInput,
-  FormFieldRadioGroup,
-  FormFieldYearSelect,
-  FormFieldSwitch,
-  FormFieldEditor,
-} from '#/src/components/formFields';
-import Spacing from '#/src/components/Spacing';
-import { useFieldValue } from '#/src/hooks/form';
-import { createStyledRadioSection } from '#/src/components/createStyledRadioSection';
-import { TOTEUTUKSEN_AJANKOHTA } from '#/src/constants';
-
-const KausiJaVuosiFields = ({ name }) => {
-  const { options } = useKoodistoOptions({ koodisto: 'kausi' });
-  const { t } = useTranslation();
-
-  const tiedossaTarkkaAjankohta = useFieldValue(
-    `${name}.tiedossaTarkkaAjankohta`
-  );
-
-  return (
-    <Spacing {...getTestIdProps('KausiJaVuosiFields')}>
-      <Box flexGrow="1" p={1}>
-        <Field
-          name={`${name}.kausi`}
-          component={FormFieldRadioGroup}
-          label={t('hakulomake.valitseAlkamiskausi')}
-          options={options}
-        />
-      </Box>
-      <Box flexGrow="1" p={1}>
-        <Field
-          name={`${name}.vuosi`}
-          component={FormFieldYearSelect}
-          placeholder={t('hakulomake.valitseAlkamisvuosi')}
-        />
-      </Box>
-      <Box flexGrow="1" p={1}>
-        <Field
-          name={`${name}.tiedossaTarkkaAjankohta`}
-          component={FormFieldSwitch}
-        >
-          {t('hakulomake.tiedossaTarkkaAjankohta')}
-        </Field>
-      </Box>
-      {tiedossaTarkkaAjankohta && (
-        <Box flexGrow="1" p={1}>
-          <DateTimeRange
-            startProps={{
-              name: `${name}.tarkkaAlkaa`,
-            }}
-            endProps={{
-              name: `${name}.tarkkaPaattyy`,
-            }}
-          />
-        </Box>
-      )}
-    </Spacing>
-  );
-};
-
-const HenkilokohtaisenSuunnitelmanLisatiedot = ({ name, language }) => {
-  const { t } = useTranslation();
-  return (
-    <Spacing>
-      <Field
-        name={`${name}.henkilokohtaisenSuunnitelmanLisatiedot.${language}`}
-        component={FormFieldEditor}
-        label={t('yleiset.lisatietoa')}
-      />
-    </Spacing>
-  );
-};
-
-const ToteutuksenAjankohtaFields = createStyledRadioSection([
-  {
-    label: t => t('hakulomake.alkamiskausi'),
-    value: TOTEUTUKSEN_AJANKOHTA.ALKAMISKAUSI,
-    FieldsComponent: KausiJaVuosiFields,
-  },
-  {
-    label: t => t('hakulomake.aloitusHenkilokohtaisenSuunnitelmanMukaisesti'),
-    value: TOTEUTUKSEN_AJANKOHTA.HENKILOKOHTAINEN_SUUNNITELMA,
-    FieldsComponent: HenkilokohtaisenSuunnitelmanLisatiedot,
-  },
-]);
+import { FormFieldDateTimeInput } from '#/src/components/formFields';
+import { KoulutuksenAloitusajankohtaFields } from '#/src/components/KoulutuksenAloitusajankohtaFields';
 
 const ScheduleSection = ({ isOphVirkailija, isYhteishaku, name, language }) => {
   const { t } = useTranslation();
@@ -116,10 +30,9 @@ const ScheduleSection = ({ isOphVirkailija, isYhteishaku, name, language }) => {
         title={t('hakulomake.toteutuksenAjankohta')}
         {...getTestIdProps('toteutuksenAjankohta')}
       >
-        <Field
-          name={`${name}.toteutuksenAjankohta`}
-          component={ToteutuksenAjankohtaFields}
+        <KoulutuksenAloitusajankohtaFields
           section={name}
+          name={`${name}.toteutuksenAjankohta`}
           language={language}
         />
       </FieldGroup>

--- a/src/main/app/src/pages/haku/HakuForm/ScheduleSection.tsx
+++ b/src/main/app/src/pages/haku/HakuForm/ScheduleSection.tsx
@@ -13,6 +13,7 @@ import {
   FormFieldRadioGroup,
   FormFieldYearSelect,
   FormFieldSwitch,
+  FormFieldEditor,
 } from '#/src/components/formFields';
 import Spacing from '#/src/components/Spacing';
 import { useFieldValue } from '#/src/hooks/form';
@@ -68,6 +69,19 @@ const KausiJaVuosiFields = ({ name }) => {
   );
 };
 
+const HenkilokohtaisenSuunnitelmanLisatiedot = ({ name }) => {
+  const { t } = useTranslation();
+  return (
+    <Spacing>
+      <Field
+        name={`${name}.henkilokohtaisenSuunnitelmanLisatiedot`}
+        component={FormFieldEditor}
+        label={t('yleiset.lisatietoa')}
+      />
+    </Spacing>
+  );
+};
+
 const ToteutuksenAjankohtaFields = createStyledRadioSection([
   {
     label: t => t('hakulomake.alkamiskausi'),
@@ -77,6 +91,7 @@ const ToteutuksenAjankohtaFields = createStyledRadioSection([
   {
     label: t => t('hakulomake.aloitusHenkilokohtaisenSuunnitelmanMukaisesti'),
     value: TOTEUTUKSEN_AJANKOHTA.HENKILOKOHTAINEN_SUUNNITELMA,
+    FieldsComponent: HenkilokohtaisenSuunnitelmanLisatiedot,
   },
 ]);
 

--- a/src/main/app/src/pages/hakukohde/HakukohdeForm/KuvausSection.tsx
+++ b/src/main/app/src/pages/hakukohde/HakukohdeForm/KuvausSection.tsx
@@ -1,6 +1,5 @@
 import React, { useCallback } from 'react';
 import { Field } from 'redux-form';
-import { get } from 'lodash';
 import { useTranslation } from 'react-i18next';
 import getValintaperusteet from '#/src/utils/valintaperuste/getValintaperusteet';
 import useApiAsync from '#/src/hooks/useApiAsync';
@@ -12,12 +11,12 @@ import { useFieldValue } from '#/src/hooks/form';
 import useEntityOptions from '#/src/hooks/useEntityOptionsHook';
 
 const KuvausSection = ({ haku, organisaatioOid, name, languages }) => {
-  const hakuOid = get(haku, 'oid');
-  const kohdejoukkoKoodiUri = get(haku, 'kohdejoukkoKoodiUri');
+  const hakuOid = haku?.oid;
+  const kohdejoukkoKoodiUri = haku?.kohdejoukkoKoodiUri;
   const watch = [hakuOid, organisaatioOid].join(',');
   const { t } = useTranslation();
   const valintaperuste = useFieldValue(name);
-  const valintaperusteOid = get(valintaperuste, 'value');
+  const valintaperusteOid = valintaperuste?.value;
   const kieliValinnat = languages;
 
   const { data, reload } = useApiAsync({

--- a/src/main/app/src/state/rootReducer.ts
+++ b/src/main/app/src/state/rootReducer.ts
@@ -1,5 +1,6 @@
 import { combineReducers } from 'redux';
 import { persistReducer } from 'redux-persist';
+import { produce } from 'immer';
 import storage from 'redux-persist/lib/storage';
 import hardSet from 'redux-persist/lib/stateReconciler/hardSet';
 
@@ -28,5 +29,28 @@ export default (reducers = {}) =>
       },
       organisaatioSelection
     ),
+    // Which fields in the current redux-form were unregistered (removed from DOM)?
+    // This works because UNREGISTER_FIELD is not emitted on initial render when the fields are already hidden.
+    unregisteredFields: (
+      state: Record<string, { name: string }> = {},
+      action: { type: string; payload: { name: string } }
+    ) => {
+      switch (action?.type) {
+        case '@@redux-form/INITIALIZE':
+        case '@@redux-form/DESTROY':
+          return {};
+        case '@@redux-form/REGISTER_FIELD':
+          return produce(state, draft => {
+            delete draft[action.payload.name];
+          });
+        case '@@redux-form/UNREGISTER_FIELD':
+          return {
+            ...state,
+            [action.payload.name]: { name: action.payload.name },
+          };
+        default:
+          return state;
+      }
+    },
     ...reducers,
   });

--- a/src/main/app/src/translations/fi.ts
+++ b/src/main/app/src/translations/fi.ts
@@ -549,7 +549,7 @@ export default {
     valitseAlkamisvuosi: 'Valitse vuosi',
     aloitusHenkilokohtaisenSuunnitelmanMukaisesti:
       'Aloitus henkilökohtaisen suunnitelman mukaisesti',
-    toteutuksenAjankohta: 'Koulutuksen aloitusajankohta',
+    koulutuksenAjankohta: 'Koulutuksen aloitusajankohta',
   },
   hakukohdelomake: {
     toteutukseenLiitettyAlkamiskausi: 'Toteutukseen liitetty alkamiskausi',

--- a/src/main/app/src/translations/fi.ts
+++ b/src/main/app/src/translations/fi.ts
@@ -96,6 +96,7 @@ export default {
     lisaaHakuaika: 'Lisää hakuaika',
     tyyppi: 'Tyyppi',
     lisatietoja: 'Lisätietoja',
+    lisatietoa: 'Lisätietoa',
     valitseTyyppi: 'Valitse tyyppi',
     valitseKuvaus: 'Valitse kuvaus',
     valitseKieli: 'Valitse kieli',

--- a/src/main/app/src/translations/fi.ts
+++ b/src/main/app/src/translations/fi.ts
@@ -549,7 +549,7 @@ export default {
     valitseAlkamisvuosi: 'Valitse vuosi',
     aloitusHenkilokohtaisenSuunnitelmanMukaisesti:
       'Aloitus henkilökohtaisen suunnitelman mukaisesti',
-    toteutuksenAjankohta: 'Toteutuksen ajankohta',
+    toteutuksenAjankohta: 'Koulutuksen aloitusajankohta',
   },
   hakukohdelomake: {
     toteutukseenLiitettyAlkamiskausi: 'Toteutukseen liitetty alkamiskausi',

--- a/src/main/app/src/types/common.d.ts
+++ b/src/main/app/src/types/common.d.ts
@@ -13,3 +13,13 @@ type Koodi = {
   versio: number;
   metadata: any;
 };
+
+type Yhteystieto = {
+  nimi: TranslatedField<string>;
+  titteli: TranslatedField<string>;
+  puhelinnumero: TranslatedField<string>;
+  sahkoposti: TranslatedField<string>;
+  verkkosivu: TranslatedField<string>;
+};
+
+type KoulutusModel = any;

--- a/src/main/app/src/types/hakuTypes.ts
+++ b/src/main/app/src/types/hakuTypes.ts
@@ -24,7 +24,7 @@ export type HakuFormValues = {
   aikataulut: {
     toteutuksenAjankohta: TOTEUTUKSEN_AJANKOHTA;
     kausi?: string;
-    vuosi?: { value?: string };
+    vuosi?: { value: string };
     tiedossaTarkkaAjankohta: boolean;
     tarkkaAlkaa?: string;
     tarkkaPaattyy?: string;

--- a/src/main/app/src/types/hakuTypes.ts
+++ b/src/main/app/src/types/hakuTypes.ts
@@ -1,6 +1,7 @@
 import { TOTEUTUKSEN_AJANKOHTA, HAKULOMAKETYYPPI } from '#/src/constants';
+import { EditorState } from '#/src/components/Editor/Editor';
 
-type HakulomakeFormSection = {
+export type HakulomakeFormSection = {
   tyyppi: HAKULOMAKETYYPPI;
   lomake: { value?: string };
   linkki?: TranslatedField<string>;
@@ -22,16 +23,19 @@ export type HakuFormValues = {
   kieliversiot: Array<LanguageCode>;
   aikataulut: {
     toteutuksenAjankohta: TOTEUTUKSEN_AJANKOHTA;
-    kausi: string;
-    vuosi: { value?: string };
+    kausi?: string;
+    vuosi?: { value?: string };
     tiedossaTarkkaAjankohta: boolean;
-    tarkkaAlkaa: string;
-    tarkkaPaattyy: string;
+    tarkkaAlkaa?: string;
+    tarkkaPaattyy?: string;
     hakuaika: Array<FormDateRange>;
     aikataulu: Array<FormDateRange>;
     lisaamisenTakaraja: FormDate;
     muokkauksenTakaraja: FormDate;
     ajastettuJulkaisu: FormDate;
+    henkilokohtaisenSuunnitelmanLisatiedot?: TranslatedField<
+      typeof EditorState
+    >;
   };
   hakutapa: string;
   kohdejoukko: {

--- a/src/main/app/src/types/hakuTypes.ts
+++ b/src/main/app/src/types/hakuTypes.ts
@@ -1,5 +1,11 @@
-import { TOTEUTUKSEN_AJANKOHTA, HAKULOMAKETYYPPI } from '#/src/constants';
+import {
+  Ajankohtatyyppi,
+  HAKULOMAKETYYPPI,
+  JULKAISUTILA,
+} from '#/src/constants';
 import { EditorState } from '#/src/components/Editor/Editor';
+
+export type HakuModel = any;
 
 export type HakulomakeFormSection = {
   tyyppi: HAKULOMAKETYYPPI;
@@ -8,21 +14,13 @@ export type HakulomakeFormSection = {
   kuvaus?: TranslatedField<string>;
 };
 
-type Yhteystieto = {
-  nimi: TranslatedField<string>;
-  titteli: TranslatedField<string>;
-  puhelinnumero: TranslatedField<string>;
-  sahkoposti: TranslatedField<string>;
-  verkkosivu: TranslatedField<string>;
-};
-
 export type HakuFormValues = {
   muokkaaja: string;
-  tila: string;
+  tila: JULKAISUTILA;
   nimi: TranslatedField<string>;
   kieliversiot: Array<LanguageCode>;
   aikataulut: {
-    toteutuksenAjankohta: TOTEUTUKSEN_AJANKOHTA;
+    ajankohtaTyyppi: Ajankohtatyyppi;
     kausi?: string;
     vuosi?: { value: string };
     tiedossaTarkkaAjankohta: boolean;

--- a/src/main/app/src/utils/form/alkamiskausityyppiHelpers.test.ts
+++ b/src/main/app/src/utils/form/alkamiskausityyppiHelpers.test.ts
@@ -1,0 +1,51 @@
+import { Alkamiskausityyppi, Ajankohtatyyppi } from '#/src/constants';
+import {
+  alkamiskausityyppiToAjankohtatyyppi,
+  getAlkamiskausityyppiByAjankohtaSection,
+} from './alkamiskausityyppiHelpers';
+
+test.each([
+  [Alkamiskausityyppi.ALKAMISKAUSI_JA_VUOSI, Ajankohtatyyppi.ALKAMISKAUSI],
+  [Alkamiskausityyppi.TARKKA_ALKAMISAJANKOHTA, Ajankohtatyyppi.ALKAMISKAUSI],
+  [
+    Alkamiskausityyppi.HENKILOKOHTAINEN_SUUNNITELMA,
+    Ajankohtatyyppi.HENKILOKOHTAINEN_SUUNNITELMA,
+  ],
+])(
+  'alkamiskausityyppiToAjankohtaTyyppi',
+  (alkamiskausityyppi, ajankohtatyyppi) => {
+    expect(alkamiskausityyppiToAjankohtatyyppi(alkamiskausityyppi)).toEqual(
+      ajankohtatyyppi
+    );
+  }
+);
+
+test.each([
+  [
+    {
+      ajankohtaTyyppi: Ajankohtatyyppi.ALKAMISKAUSI,
+      tiedossaTarkkaAjankohta: true,
+    },
+    Alkamiskausityyppi.TARKKA_ALKAMISAJANKOHTA,
+  ],
+  [
+    {
+      ajankohtaTyyppi: Ajankohtatyyppi.ALKAMISKAUSI,
+      tiedossaTarkkaAjankohta: false,
+    },
+    Alkamiskausityyppi.ALKAMISKAUSI_JA_VUOSI,
+  ],
+  [
+    {
+      ajankohtaTyyppi: Ajankohtatyyppi.HENKILOKOHTAINEN_SUUNNITELMA,
+    },
+    Alkamiskausityyppi.HENKILOKOHTAINEN_SUUNNITELMA,
+  ],
+])(
+  'getAlkamiskausityyppiByAjankohtaSection',
+  (ajankohtaSection, alkamiskausityyppi) => {
+    expect(getAlkamiskausityyppiByAjankohtaSection(ajankohtaSection)).toEqual(
+      alkamiskausityyppi
+    );
+  }
+);

--- a/src/main/app/src/utils/form/alkamiskausityyppiHelpers.ts
+++ b/src/main/app/src/utils/form/alkamiskausityyppiHelpers.ts
@@ -1,0 +1,37 @@
+import _fp from 'lodash/fp';
+import { Ajankohtatyyppi, Alkamiskausityyppi } from '#/src/constants';
+
+export const alkamiskausityyppiToAjankohtatyyppi = _fp.cond([
+  [
+    _fp.overSome([
+      _fp.isEqual(Alkamiskausityyppi.ALKAMISKAUSI_JA_VUOSI),
+      _fp.isEqual(Alkamiskausityyppi.TARKKA_ALKAMISAJANKOHTA),
+    ]),
+    () => Ajankohtatyyppi.ALKAMISKAUSI,
+  ],
+  [
+    _fp.isEqual(Alkamiskausityyppi.HENKILOKOHTAINEN_SUUNNITELMA),
+    () => Ajankohtatyyppi.HENKILOKOHTAINEN_SUUNNITELMA,
+  ],
+]);
+
+const ajankohtaEquals = ajankohta => ajankohtaSection =>
+  ajankohtaSection?.ajankohtaTyyppi === ajankohta;
+
+const hasTarkkaAjankohta = ajankohtaSection =>
+  ajankohtaSection?.tiedossaTarkkaAjankohta;
+
+export const getAlkamiskausityyppiByAjankohtaSection = _fp.cond([
+  [
+    ajankohtaEquals(Ajankohtatyyppi.ALKAMISKAUSI),
+    _fp.cond([
+      [hasTarkkaAjankohta, () => Alkamiskausityyppi.TARKKA_ALKAMISAJANKOHTA],
+      [_fp.T, () => Alkamiskausityyppi.ALKAMISKAUSI_JA_VUOSI],
+    ]),
+  ],
+  [
+    ajankohtaEquals(Ajankohtatyyppi.HENKILOKOHTAINEN_SUUNNITELMA),
+    () => Alkamiskausityyppi.HENKILOKOHTAINEN_SUUNNITELMA,
+  ],
+  [_fp.T, () => null],
+]);

--- a/src/main/app/src/utils/form/getHakulomakeFieldsValues.ts
+++ b/src/main/app/src/utils/form/getHakulomakeFieldsValues.ts
@@ -8,7 +8,7 @@ export const getHakulomakeFieldsValues = ({
   hakulomakeAtaruId,
   hakulomakeLinkki,
   hakulomakeKuvaus,
-}) => ({
+}): HakulomakeFormSection => ({
   tyyppi: hakulomaketyyppi,
   lomake:
     hakulomaketyyppi === HAKULOMAKETYYPPI.ATARU

--- a/src/main/app/src/utils/form/getHakulomakeFieldsValues.ts
+++ b/src/main/app/src/utils/form/getHakulomakeFieldsValues.ts
@@ -1,6 +1,7 @@
 import _fp from 'lodash/fp';
 import { parseEditorState } from '#/src/components/Editor/utils';
 import { HAKULOMAKETYYPPI } from '#/src/constants';
+import { HakulomakeFormSection } from '#/src/types/hakuTypes';
 
 export const getHakulomakeFieldsValues = ({
   hakulomaketyyppi,

--- a/src/main/app/src/utils/haku/__snapshots__/getFormValuesByHaku.test.ts.snap
+++ b/src/main/app/src/utils/haku/__snapshots__/getFormValuesByHaku.test.ts.snap
@@ -16,12 +16,13 @@ Object {
         "paattyy": "2019-09-29T12:30",
       },
     ],
+    "henkilokohtaisenSuunnitelmanLisatiedot": Object {},
     "kausi": "alkamiskausi_1#1",
     "lisaamisenTakaraja": "2019-03-29T12:28",
     "muokkauksenTakaraja": "2019-03-11T09:45",
-    "tarkkaAlkaa": "2020-12-20T12:28",
-    "tarkkaPaattyy": "2020-12-21T12:28",
-    "tiedossaTarkkaAjankohta": true,
+    "tarkkaAlkaa": null,
+    "tarkkaPaattyy": null,
+    "tiedossaTarkkaAjankohta": false,
     "toteutuksenAjankohta": "alkamiskausi",
     "vuosi": Object {
       "value": "2020",
@@ -95,12 +96,13 @@ Object {
         "paattyy": "2019-09-29T12:30",
       },
     ],
+    "henkilokohtaisenSuunnitelmanLisatiedot": Object {},
     "kausi": "alkamiskausi_1#1",
     "lisaamisenTakaraja": "2019-03-29T12:28",
     "muokkauksenTakaraja": "2019-03-11T09:45",
-    "tarkkaAlkaa": "2020-12-20T12:28",
-    "tarkkaPaattyy": "2020-12-21T12:28",
-    "tiedossaTarkkaAjankohta": true,
+    "tarkkaAlkaa": null,
+    "tarkkaPaattyy": null,
+    "tiedossaTarkkaAjankohta": false,
     "toteutuksenAjankohta": "alkamiskausi",
     "vuosi": Object {
       "value": "2020",
@@ -174,15 +176,180 @@ Object {
         "paattyy": "2019-09-29T12:30",
       },
     ],
+    "henkilokohtaisenSuunnitelmanLisatiedot": Object {},
     "kausi": "alkamiskausi_1#1",
     "lisaamisenTakaraja": "2019-03-29T12:28",
     "muokkauksenTakaraja": "2019-03-11T09:45",
-    "tarkkaAlkaa": "2020-12-20T12:28",
-    "tarkkaPaattyy": "2020-12-21T12:28",
-    "tiedossaTarkkaAjankohta": true,
+    "tarkkaAlkaa": null,
+    "tarkkaPaattyy": null,
+    "tiedossaTarkkaAjankohta": false,
     "toteutuksenAjankohta": "alkamiskausi",
     "vuosi": Object {
       "value": "2020",
+    },
+  },
+  "hakulomake": Object {
+    "kuvaus": Object {},
+    "linkki": Object {},
+    "lomake": Object {
+      "value": "12345",
+    },
+    "tyyppi": "ataru",
+  },
+  "hakutapa": "hakutapa_1#1",
+  "kieliversiot": Array [
+    "fi",
+    "sv",
+  ],
+  "kohdejoukko": Object {
+    "kohdejoukko": "kohdejoukko_1#1",
+    "tarkenne": Object {
+      "value": "tarkenne_1#1",
+    },
+  },
+  "muokkaaja": "1.1.1.1",
+  "nimi": Object {
+    "fi": "Fi nimi",
+    "sv": "Sv nimi",
+  },
+  "tila": "tallennettu",
+  "yhteyshenkilot": Array [
+    Object {
+      "nimi": Object {
+        "fi": "Fi nimi",
+        "sv": "Sv nimi",
+      },
+      "puhelinnumero": Object {
+        "fi": "Fi puhelinnumero",
+        "sv": "Sv puhelinnumero",
+      },
+      "sahkoposti": Object {
+        "fi": "Fi sähköposti",
+        "sv": "Sv sähköposti",
+      },
+      "titteli": Object {
+        "fi": "Fi titteli",
+        "sv": "Sv titteli",
+      },
+      "verkkosivu": Object {
+        "fi": "Fi verkkosivu",
+        "sv": "Sv verkkosivu",
+      },
+    },
+  ],
+}
+`;
+
+exports[`getFormValuesByHaku toteutuksen ajankohta - Aloitus henkilokohtaisen suunnitelman mukaisesti 1`] = `
+Object {
+  "aikataulut": Object {
+    "aikataulu": Array [
+      Object {
+        "alkaa": "2019-02-20T12:28",
+        "paattyy": "2019-08-01T12:45",
+      },
+    ],
+    "ajastettuJulkaisu": "2020-01-20T05:00",
+    "hakuaika": Array [
+      Object {
+        "alkaa": "2019-03-29T12:28",
+        "paattyy": "2019-09-29T12:30",
+      },
+    ],
+    "henkilokohtaisenSuunnitelmanLisatiedot": Object {
+      "en":         "<p>hlokoht en </p>",
+      "fi":         "<p>hlokoht fi </p>",
+      "sv":         "<p>hlokoht sv </p>",
+    },
+    "kausi": null,
+    "lisaamisenTakaraja": "2019-03-29T12:28",
+    "muokkauksenTakaraja": "2019-03-11T09:45",
+    "tarkkaAlkaa": null,
+    "tarkkaPaattyy": null,
+    "tiedossaTarkkaAjankohta": false,
+    "toteutuksenAjankohta": "aloitusHenkilokohtaisenSuunnitelmanMukaisesti",
+    "vuosi": Object {
+      "value": "",
+    },
+  },
+  "hakulomake": Object {
+    "kuvaus": Object {},
+    "linkki": Object {},
+    "lomake": Object {
+      "value": "12345",
+    },
+    "tyyppi": "ataru",
+  },
+  "hakutapa": "hakutapa_1#1",
+  "kieliversiot": Array [
+    "fi",
+    "sv",
+  ],
+  "kohdejoukko": Object {
+    "kohdejoukko": "kohdejoukko_1#1",
+    "tarkenne": Object {
+      "value": "tarkenne_1#1",
+    },
+  },
+  "muokkaaja": "1.1.1.1",
+  "nimi": Object {
+    "fi": "Fi nimi",
+    "sv": "Sv nimi",
+  },
+  "tila": "tallennettu",
+  "yhteyshenkilot": Array [
+    Object {
+      "nimi": Object {
+        "fi": "Fi nimi",
+        "sv": "Sv nimi",
+      },
+      "puhelinnumero": Object {
+        "fi": "Fi puhelinnumero",
+        "sv": "Sv puhelinnumero",
+      },
+      "sahkoposti": Object {
+        "fi": "Fi sähköposti",
+        "sv": "Sv sähköposti",
+      },
+      "titteli": Object {
+        "fi": "Fi titteli",
+        "sv": "Sv titteli",
+      },
+      "verkkosivu": Object {
+        "fi": "Fi verkkosivu",
+        "sv": "Sv verkkosivu",
+      },
+    },
+  ],
+}
+`;
+
+exports[`getFormValuesByHaku toteutuksen ajankohta - Tarkka alkamisaika 1`] = `
+Object {
+  "aikataulut": Object {
+    "aikataulu": Array [
+      Object {
+        "alkaa": "2019-02-20T12:28",
+        "paattyy": "2019-08-01T12:45",
+      },
+    ],
+    "ajastettuJulkaisu": "2020-01-20T05:00",
+    "hakuaika": Array [
+      Object {
+        "alkaa": "2019-03-29T12:28",
+        "paattyy": "2019-09-29T12:30",
+      },
+    ],
+    "henkilokohtaisenSuunnitelmanLisatiedot": Object {},
+    "kausi": "alkamiskausi_1#1",
+    "lisaamisenTakaraja": "2019-03-29T12:28",
+    "muokkauksenTakaraja": "2019-03-11T09:45",
+    "tarkkaAlkaa": "2030-12-20T12:28",
+    "tarkkaPaattyy": "2030-12-21T12:28",
+    "tiedossaTarkkaAjankohta": true,
+    "toteutuksenAjankohta": "alkamiskausi",
+    "vuosi": Object {
+      "value": "2030",
     },
   },
   "hakulomake": Object {

--- a/src/main/app/src/utils/haku/__snapshots__/getFormValuesByHaku.test.ts.snap
+++ b/src/main/app/src/utils/haku/__snapshots__/getFormValuesByHaku.test.ts.snap
@@ -9,6 +9,7 @@ Object {
         "paattyy": "2019-08-01T12:45",
       },
     ],
+    "ajankohtaTyyppi": "alkamiskausi",
     "ajastettuJulkaisu": "2020-01-20T05:00",
     "hakuaika": Array [
       Object {
@@ -23,7 +24,6 @@ Object {
     "tarkkaAlkaa": null,
     "tarkkaPaattyy": null,
     "tiedossaTarkkaAjankohta": false,
-    "toteutuksenAjankohta": "alkamiskausi",
     "vuosi": Object {
       "value": "2020",
     },
@@ -89,6 +89,7 @@ Object {
         "paattyy": "2019-08-01T12:45",
       },
     ],
+    "ajankohtaTyyppi": "alkamiskausi",
     "ajastettuJulkaisu": "2020-01-20T05:00",
     "hakuaika": Array [
       Object {
@@ -103,7 +104,6 @@ Object {
     "tarkkaAlkaa": null,
     "tarkkaPaattyy": null,
     "tiedossaTarkkaAjankohta": false,
-    "toteutuksenAjankohta": "alkamiskausi",
     "vuosi": Object {
       "value": "2020",
     },
@@ -169,6 +169,7 @@ Object {
         "paattyy": "2019-08-01T12:45",
       },
     ],
+    "ajankohtaTyyppi": "alkamiskausi",
     "ajastettuJulkaisu": "2020-01-20T05:00",
     "hakuaika": Array [
       Object {
@@ -183,7 +184,6 @@ Object {
     "tarkkaAlkaa": null,
     "tarkkaPaattyy": null,
     "tiedossaTarkkaAjankohta": false,
-    "toteutuksenAjankohta": "alkamiskausi",
     "vuosi": Object {
       "value": "2020",
     },
@@ -249,6 +249,7 @@ Object {
         "paattyy": "2019-08-01T12:45",
       },
     ],
+    "ajankohtaTyyppi": "aloitusHenkilokohtaisenSuunnitelmanMukaisesti",
     "ajastettuJulkaisu": "2020-01-20T05:00",
     "hakuaika": Array [
       Object {
@@ -267,7 +268,6 @@ Object {
     "tarkkaAlkaa": null,
     "tarkkaPaattyy": null,
     "tiedossaTarkkaAjankohta": false,
-    "toteutuksenAjankohta": "aloitusHenkilokohtaisenSuunnitelmanMukaisesti",
     "vuosi": null,
   },
   "hakulomake": Object {
@@ -331,6 +331,7 @@ Object {
         "paattyy": "2019-08-01T12:45",
       },
     ],
+    "ajankohtaTyyppi": "alkamiskausi",
     "ajastettuJulkaisu": "2020-01-20T05:00",
     "hakuaika": Array [
       Object {
@@ -345,7 +346,6 @@ Object {
     "tarkkaAlkaa": "2030-12-20T12:28",
     "tarkkaPaattyy": "2030-12-21T12:28",
     "tiedossaTarkkaAjankohta": true,
-    "toteutuksenAjankohta": "alkamiskausi",
     "vuosi": Object {
       "value": "2030",
     },

--- a/src/main/app/src/utils/haku/__snapshots__/getFormValuesByHaku.test.ts.snap
+++ b/src/main/app/src/utils/haku/__snapshots__/getFormValuesByHaku.test.ts.snap
@@ -268,9 +268,7 @@ Object {
     "tarkkaPaattyy": null,
     "tiedossaTarkkaAjankohta": false,
     "toteutuksenAjankohta": "aloitusHenkilokohtaisenSuunnitelmanMukaisesti",
-    "vuosi": Object {
-      "value": "",
-    },
+    "vuosi": null,
   },
   "hakulomake": Object {
     "kuvaus": Object {},

--- a/src/main/app/src/utils/haku/__snapshots__/getHakuByFormValues.test.ts.snap
+++ b/src/main/app/src/utils/haku/__snapshots__/getHakuByFormValues.test.ts.snap
@@ -30,11 +30,12 @@ Object {
   "kohdejoukonTarkenneKoodiUri": "tarkenne_1#1",
   "metadata": Object {
     "koulutuksenAlkamiskausi": Object {
-      "alkamiskausityyppi": "tarkka alkamisajankohta",
+      "alkamiskausityyppi": "alkamiskausi ja -vuosi",
+      "henkilokohtaisenSuunnitelmanLisatiedot": Object {},
       "koulutuksenAlkamiskausiKoodiUri": "alkamiskausi_1#1",
-      "koulutuksenAlkamispaivamaara": "2019-09-16T08:44",
+      "koulutuksenAlkamispaivamaara": undefined,
       "koulutuksenAlkamisvuosi": 2020,
-      "koulutuksenPaattymispaivamaara": "2019-09-16T08:44",
+      "koulutuksenPaattymispaivamaara": undefined,
     },
     "tulevaisuudenAikataulu": Array [
       Object {
@@ -110,11 +111,12 @@ Object {
   "kohdejoukonTarkenneKoodiUri": "tarkenne_1#1",
   "metadata": Object {
     "koulutuksenAlkamiskausi": Object {
-      "alkamiskausityyppi": "tarkka alkamisajankohta",
+      "alkamiskausityyppi": "alkamiskausi ja -vuosi",
+      "henkilokohtaisenSuunnitelmanLisatiedot": Object {},
       "koulutuksenAlkamiskausiKoodiUri": "alkamiskausi_1#1",
-      "koulutuksenAlkamispaivamaara": "2019-09-16T08:44",
+      "koulutuksenAlkamispaivamaara": undefined,
       "koulutuksenAlkamisvuosi": 2020,
-      "koulutuksenPaattymispaivamaara": "2019-09-16T08:44",
+      "koulutuksenPaattymispaivamaara": undefined,
     },
     "tulevaisuudenAikataulu": Array [
       Object {
@@ -188,7 +190,169 @@ Object {
   "kohdejoukonTarkenneKoodiUri": "tarkenne_1#1",
   "metadata": Object {
     "koulutuksenAlkamiskausi": Object {
+      "alkamiskausityyppi": "alkamiskausi ja -vuosi",
+      "henkilokohtaisenSuunnitelmanLisatiedot": Object {},
+      "koulutuksenAlkamiskausiKoodiUri": "alkamiskausi_1#1",
+      "koulutuksenAlkamispaivamaara": undefined,
+      "koulutuksenAlkamisvuosi": 2020,
+      "koulutuksenPaattymispaivamaara": undefined,
+    },
+    "tulevaisuudenAikataulu": Array [
+      Object {
+        "alkaa": "2019-08-16T08:44",
+        "paattyy": "2019-08-18T08:44",
+      },
+      Object {
+        "alkaa": "2019-09-16T08:44",
+        "paattyy": "2019-09-18T08:44",
+      },
+    ],
+    "yhteyshenkilot": Array [
+      Object {
+        "nimi": Object {
+          "fi": "Fi nimi",
+          "sv": "Sv nimi",
+        },
+        "puhelinnumero": Object {
+          "fi": "Fi puhelinnumero",
+          "sv": "Sv puhelinnumero",
+        },
+        "sahkoposti": Object {
+          "fi": "Fi sähköposti",
+          "sv": "Sv sähköposti",
+        },
+        "titteli": Object {
+          "fi": "Fi titteli",
+          "sv": "Sv titteli",
+        },
+        "wwwSivu": Object {
+          "fi": "Fi verkkosivu",
+          "sv": "Sv verkkosivu",
+        },
+      },
+    ],
+  },
+  "muokkaaja": "1.1.1.1",
+  "nimi": Object {
+    "fi": "Nimi",
+    "sv": "Namn",
+  },
+  "tila": "tallennettu",
+}
+`;
+
+exports[`getHakuByFormValues toteutuksen ajankohta - Aloitus henkilokohtaisen suunnitelman mukaisesti 1`] = `
+Object {
+  "ajastettuJulkaisu": "2019-11-16T08:44",
+  "hakuajat": Array [
+    Object {
+      "alkaa": "2019-04-16T08:44",
+      "paattyy": "2019-04-18T08:44",
+    },
+    Object {
+      "alkaa": "2019-06-16T08:44",
+      "paattyy": "2019-06-18T08:44",
+    },
+  ],
+  "hakukohteenLiittamisenTakaraja": "2019-09-16T08:44",
+  "hakukohteenMuokkaamisenTakaraja": "2019-10-16T08:44",
+  "hakulomakeAtaruId": "12345",
+  "hakulomakeKuvaus": Object {},
+  "hakulomakeLinkki": Object {},
+  "hakulomaketyyppi": "ataru",
+  "hakutapaKoodiUri": "hakutapa_1#1",
+  "kielivalinta": Array [
+    "fi",
+    "sv",
+  ],
+  "kohdejoukkoKoodiUri": "haunkohdejoukko_12",
+  "kohdejoukonTarkenneKoodiUri": "tarkenne_1#1",
+  "metadata": Object {
+    "koulutuksenAlkamiskausi": Object {
+      "alkamiskausityyppi": "henkilokohtainen suunnitelma",
+      "henkilokohtaisenSuunnitelmanLisatiedot": Object {
+        "fi": "<p>hlokoht fi </p>",
+        "sv": "<p>hlokoht sv </p>",
+      },
+      "koulutuksenAlkamiskausiKoodiUri": "alkamiskausi_1#1",
+      "koulutuksenAlkamispaivamaara": undefined,
+      "koulutuksenAlkamisvuosi": 2020,
+      "koulutuksenPaattymispaivamaara": undefined,
+    },
+    "tulevaisuudenAikataulu": Array [
+      Object {
+        "alkaa": "2019-08-16T08:44",
+        "paattyy": "2019-08-18T08:44",
+      },
+      Object {
+        "alkaa": "2019-09-16T08:44",
+        "paattyy": "2019-09-18T08:44",
+      },
+    ],
+    "yhteyshenkilot": Array [
+      Object {
+        "nimi": Object {
+          "fi": "Fi nimi",
+          "sv": "Sv nimi",
+        },
+        "puhelinnumero": Object {
+          "fi": "Fi puhelinnumero",
+          "sv": "Sv puhelinnumero",
+        },
+        "sahkoposti": Object {
+          "fi": "Fi sähköposti",
+          "sv": "Sv sähköposti",
+        },
+        "titteli": Object {
+          "fi": "Fi titteli",
+          "sv": "Sv titteli",
+        },
+        "wwwSivu": Object {
+          "fi": "Fi verkkosivu",
+          "sv": "Sv verkkosivu",
+        },
+      },
+    ],
+  },
+  "muokkaaja": "1.1.1.1",
+  "nimi": Object {
+    "fi": "Nimi",
+    "sv": "Namn",
+  },
+  "tila": "tallennettu",
+}
+`;
+
+exports[`getHakuByFormValues toteutuksen ajankohta - Tarkka alkamisaika 1`] = `
+Object {
+  "ajastettuJulkaisu": "2019-11-16T08:44",
+  "hakuajat": Array [
+    Object {
+      "alkaa": "2019-04-16T08:44",
+      "paattyy": "2019-04-18T08:44",
+    },
+    Object {
+      "alkaa": "2019-06-16T08:44",
+      "paattyy": "2019-06-18T08:44",
+    },
+  ],
+  "hakukohteenLiittamisenTakaraja": "2019-09-16T08:44",
+  "hakukohteenMuokkaamisenTakaraja": "2019-10-16T08:44",
+  "hakulomakeAtaruId": "12345",
+  "hakulomakeKuvaus": Object {},
+  "hakulomakeLinkki": Object {},
+  "hakulomaketyyppi": "ataru",
+  "hakutapaKoodiUri": "hakutapa_1#1",
+  "kielivalinta": Array [
+    "fi",
+    "sv",
+  ],
+  "kohdejoukkoKoodiUri": "haunkohdejoukko_12",
+  "kohdejoukonTarkenneKoodiUri": "tarkenne_1#1",
+  "metadata": Object {
+    "koulutuksenAlkamiskausi": Object {
       "alkamiskausityyppi": "tarkka alkamisajankohta",
+      "henkilokohtaisenSuunnitelmanLisatiedot": Object {},
       "koulutuksenAlkamiskausiKoodiUri": "alkamiskausi_1#1",
       "koulutuksenAlkamispaivamaara": "2019-09-16T08:44",
       "koulutuksenAlkamisvuosi": 2020,

--- a/src/main/app/src/utils/haku/getFormValuesByHaku.test.ts
+++ b/src/main/app/src/utils/haku/getFormValuesByHaku.test.ts
@@ -1,15 +1,13 @@
-import { merge, each } from 'lodash';
+import _ from 'lodash';
 
 import {
-  ALKAMISKAUSITYYPPI,
+  Alkamiskausityyppi,
   HAKULOMAKETYYPPI,
-  TOTEUTUKSEN_AJANKOHTA,
+  Ajankohtatyyppi,
 } from '#/src/constants';
-import {
-  alkamiskausityyppiToToteutuksenAjankohta,
-  getFormValuesByHaku,
-} from './getFormValuesByHaku';
+import { getFormValuesByHaku } from './getFormValuesByHaku';
 import { serializeEditorState } from '#/src/components/Editor/utils';
+import { alkamiskausityyppiToAjankohtatyyppi } from '#/src/utils/form/alkamiskausityyppiHelpers';
 
 const baseHaku = {
   muokkaaja: '1.1.1.1',
@@ -26,7 +24,7 @@ const baseHaku = {
   kohdejoukonTarkenneKoodiUri: 'tarkenne_1#1',
   metadata: {
     koulutuksenAlkamiskausi: {
-      alkamiskausityyppi: ALKAMISKAUSITYYPPI.ALKAMISKAUSI_JA_VUOSI,
+      alkamiskausityyppi: Alkamiskausityyppi.ALKAMISKAUSI_JA_VUOSI,
       koulutuksenAlkamiskausiKoodiUri: 'alkamiskausi_1#1',
       koulutuksenAlkamisvuosi: '2020',
     },
@@ -60,7 +58,7 @@ test('getFormValuesByHaku returns correct form values given haku', () => {
 
 test('getFormValuesByHaku returns correct form values given different hakulomake variations', () => {
   const valuesMuu = getFormValuesByHaku(
-    merge({}, baseHaku, {
+    _.merge({}, baseHaku, {
       hakulomaketyyppi: HAKULOMAKETYYPPI.MUU,
       hakulomakeLinkki: {
         fi: 'https://google.fi',
@@ -69,7 +67,7 @@ test('getFormValuesByHaku returns correct form values given different hakulomake
   );
 
   const valuesEiHakua = getFormValuesByHaku(
-    merge({}, baseHaku, {
+    _.merge({}, baseHaku, {
       hakulomaketyyppi: HAKULOMAKETYYPPI.EI_SAHKOISTA_HAKUA,
       hakulomakeKuvaus: {
         fi: '<p>kuvaus</p>',
@@ -84,10 +82,10 @@ test('getFormValuesByHaku returns correct form values given different hakulomake
 test('getFormValuesByHaku toteutuksen ajankohta - Tarkka alkamisaika', () => {
   expect(
     getFormValuesByHaku(
-      merge({}, baseHaku, {
+      _.merge({}, baseHaku, {
         metadata: {
           koulutuksenAlkamiskausi: {
-            alkamiskausityyppi: ALKAMISKAUSITYYPPI.TARKKA_ALKAMISAJANKOHTA,
+            alkamiskausityyppi: Alkamiskausityyppi.TARKKA_ALKAMISAJANKOHTA,
             koulutuksenAlkamiskausiKoodiUri: 'alkamiskausi_1#1',
             koulutuksenAlkamispaivamaara: '2030-12-20T12:28',
             koulutuksenPaattymispaivamaara: '2030-12-21T12:28',
@@ -107,10 +105,10 @@ test('getFormValuesByHaku toteutuksen ajankohta - Aloitus henkilokohtaisen suunn
   };
 
   const values = getFormValuesByHaku(
-    merge({}, baseHaku, {
+    _.merge({}, baseHaku, {
       metadata: {
         koulutuksenAlkamiskausi: {
-          alkamiskausityyppi: ALKAMISKAUSITYYPPI.HENKILOKOHTAINEN_SUUNNITELMA,
+          alkamiskausityyppi: Alkamiskausityyppi.HENKILOKOHTAINEN_SUUNNITELMA,
           henkilokohtaisenSuunnitelmanLisatiedot: henkKohtLisatiedotValues,
           koulutuksenAlkamiskausiKoodiUri: null,
           koulutuksenAlkamispaivamaara: null,
@@ -122,7 +120,7 @@ test('getFormValuesByHaku toteutuksen ajankohta - Aloitus henkilokohtaisen suunn
   );
   expect(values).toMatchSnapshot();
 
-  each(
+  _.each(
     values?.aikataulut.henkilokohtaisenSuunnitelmanLisatiedot,
     (lisatiedotEditorState, lisatiedotKey) => {
       expect(serializeEditorState(lisatiedotEditorState)).toEqual(
@@ -134,20 +132,20 @@ test('getFormValuesByHaku toteutuksen ajankohta - Aloitus henkilokohtaisen suunn
 
 test('alkamiskausityyppiToToteutuksenAjankohta', () => {
   expect(
-    alkamiskausityyppiToToteutuksenAjankohta(
-      ALKAMISKAUSITYYPPI.ALKAMISKAUSI_JA_VUOSI
+    alkamiskausityyppiToAjankohtatyyppi(
+      Alkamiskausityyppi.ALKAMISKAUSI_JA_VUOSI
     )
-  ).toEqual(TOTEUTUKSEN_AJANKOHTA.ALKAMISKAUSI);
+  ).toEqual(Ajankohtatyyppi.ALKAMISKAUSI);
 
   expect(
-    alkamiskausityyppiToToteutuksenAjankohta(
-      ALKAMISKAUSITYYPPI.TARKKA_ALKAMISAJANKOHTA
+    alkamiskausityyppiToAjankohtatyyppi(
+      Alkamiskausityyppi.TARKKA_ALKAMISAJANKOHTA
     )
-  ).toEqual(TOTEUTUKSEN_AJANKOHTA.ALKAMISKAUSI);
+  ).toEqual(Ajankohtatyyppi.ALKAMISKAUSI);
 
   expect(
-    alkamiskausityyppiToToteutuksenAjankohta(
-      ALKAMISKAUSITYYPPI.HENKILOKOHTAINEN_SUUNNITELMA
+    alkamiskausityyppiToAjankohtatyyppi(
+      Alkamiskausityyppi.HENKILOKOHTAINEN_SUUNNITELMA
     )
-  ).toEqual(TOTEUTUKSEN_AJANKOHTA.HENKILOKOHTAINEN_SUUNNITELMA);
+  ).toEqual(Ajankohtatyyppi.HENKILOKOHTAINEN_SUUNNITELMA);
 });

--- a/src/main/app/src/utils/haku/getFormValuesByHaku.ts
+++ b/src/main/app/src/utils/haku/getFormValuesByHaku.ts
@@ -63,7 +63,9 @@ export const getFormValuesByHaku = (haku): HakuFormValues => {
         alkamiskausityyppi
       ),
       kausi: koulutuksenAlkamiskausiKoodiUri,
-      vuosi: { value: _.toString(koulutuksenAlkamisvuosi) || '' },
+      vuosi: koulutuksenAlkamisvuosi && {
+        value: _.toString(koulutuksenAlkamisvuosi),
+      },
       tiedossaTarkkaAjankohta:
         alkamiskausityyppi === ALKAMISKAUSITYYPPI.TARKKA_ALKAMISAJANKOHTA,
       tarkkaAlkaa: koulutuksenAlkamispaivamaara,

--- a/src/main/app/src/utils/haku/getFormValuesByHaku.ts
+++ b/src/main/app/src/utils/haku/getFormValuesByHaku.ts
@@ -2,6 +2,7 @@ import _ from 'lodash/fp';
 import { getHakulomakeFieldsValues } from '#/src/utils/form/getHakulomakeFieldsValues';
 import { ALKAMISKAUSITYYPPI, TOTEUTUKSEN_AJANKOHTA } from '#/src/constants';
 import { HakuFormValues } from '#/src/types/hakuTypes';
+import { parseEditorState } from '#/src/components/Editor/utils';
 
 export const alkamiskausityyppiToToteutuksenAjankohta = _.cond([
   [
@@ -49,6 +50,7 @@ export const getFormValuesByHaku = (haku): HakuFormValues => {
     koulutuksenAlkamispaivamaara = null,
     koulutuksenPaattymispaivamaara = null,
     koulutuksenAlkamisvuosi = '',
+    henkilokohtaisenSuunnitelmanLisatiedot,
   } = koulutuksenAlkamiskausi;
 
   return {
@@ -71,6 +73,9 @@ export const getFormValuesByHaku = (haku): HakuFormValues => {
       lisaamisenTakaraja: hakukohteenLiittamisenTakaraja,
       muokkauksenTakaraja: hakukohteenMuokkaamisenTakaraja,
       ajastettuJulkaisu,
+      henkilokohtaisenSuunnitelmanLisatiedot: _.mapValues(parseEditorState)(
+        henkilokohtaisenSuunnitelmanLisatiedot
+      ),
     },
     hakutapa: hakutapaKoodiUri,
     kohdejoukko: {

--- a/src/main/app/src/utils/haku/getFormValuesByHaku.ts
+++ b/src/main/app/src/utils/haku/getFormValuesByHaku.ts
@@ -1,22 +1,9 @@
 import _ from 'lodash/fp';
 import { getHakulomakeFieldsValues } from '#/src/utils/form/getHakulomakeFieldsValues';
-import { ALKAMISKAUSITYYPPI, TOTEUTUKSEN_AJANKOHTA } from '#/src/constants';
+import { Alkamiskausityyppi } from '#/src/constants';
 import { HakuFormValues } from '#/src/types/hakuTypes';
 import { parseEditorState } from '#/src/components/Editor/utils';
-
-export const alkamiskausityyppiToToteutuksenAjankohta = _.cond([
-  [
-    _.overSome([
-      _.isEqual(ALKAMISKAUSITYYPPI.ALKAMISKAUSI_JA_VUOSI),
-      _.isEqual(ALKAMISKAUSITYYPPI.TARKKA_ALKAMISAJANKOHTA),
-    ]),
-    () => TOTEUTUKSEN_AJANKOHTA.ALKAMISKAUSI,
-  ],
-  [
-    _.isEqual(ALKAMISKAUSITYYPPI.HENKILOKOHTAINEN_SUUNNITELMA),
-    () => TOTEUTUKSEN_AJANKOHTA.HENKILOKOHTAINEN_SUUNNITELMA,
-  ],
-]);
+import { alkamiskausityyppiToAjankohtatyyppi } from '#/src/utils/form/alkamiskausityyppiHelpers';
 
 export const getFormValuesByHaku = (haku): HakuFormValues => {
   const {
@@ -59,15 +46,13 @@ export const getFormValuesByHaku = (haku): HakuFormValues => {
     nimi,
     kieliversiot: kielivalinta,
     aikataulut: {
-      toteutuksenAjankohta: alkamiskausityyppiToToteutuksenAjankohta(
-        alkamiskausityyppi
-      ),
+      ajankohtaTyyppi: alkamiskausityyppiToAjankohtatyyppi(alkamiskausityyppi),
       kausi: koulutuksenAlkamiskausiKoodiUri,
       vuosi: koulutuksenAlkamisvuosi && {
         value: _.toString(koulutuksenAlkamisvuosi),
       },
       tiedossaTarkkaAjankohta:
-        alkamiskausityyppi === ALKAMISKAUSITYYPPI.TARKKA_ALKAMISAJANKOHTA,
+        alkamiskausityyppi === Alkamiskausityyppi.TARKKA_ALKAMISAJANKOHTA,
       tarkkaAlkaa: koulutuksenAlkamispaivamaara,
       tarkkaPaattyy: koulutuksenPaattymispaivamaara,
       hakuaika: hakuajat,

--- a/src/main/app/src/utils/haku/getHakuByFormValues.test.ts
+++ b/src/main/app/src/utils/haku/getHakuByFormValues.test.ts
@@ -1,21 +1,18 @@
 import { mapValues, merge } from 'lodash';
 
-import {
-  getHakuByFormValues,
-  getAlkamiskausityyppi,
-} from '#/src/utils/haku/getHakuByFormValues';
+import { getHakuByFormValues } from '#/src/utils/haku/getHakuByFormValues';
 
 import {
-  ALKAMISKAUSITYYPPI,
   HAKULOMAKETYYPPI,
-  TOTEUTUKSEN_AJANKOHTA,
+  Ajankohtatyyppi,
+  JULKAISUTILA,
 } from '#/src/constants';
 import { HakuFormValues } from '#/src/types/hakuTypes';
 import { parseEditorState } from '#/src/components/Editor/utils';
 
 const baseValues: HakuFormValues = {
   muokkaaja: '1.1.1.1',
-  tila: 'tallennettu',
+  tila: JULKAISUTILA.TALLENNETTU,
   nimi: {
     fi: 'Nimi',
     sv: 'Namn',
@@ -44,7 +41,7 @@ const baseValues: HakuFormValues = {
         paattyy: '2019-09-18T08:44',
       },
     ],
-    toteutuksenAjankohta: TOTEUTUKSEN_AJANKOHTA.ALKAMISKAUSI,
+    ajankohtaTyyppi: Ajankohtatyyppi.ALKAMISKAUSI,
     tiedossaTarkkaAjankohta: false,
     lisaamisenTakaraja: '2019-09-16T08:44',
     muokkauksenTakaraja: '2019-10-16T08:44',
@@ -107,7 +104,7 @@ test('getHakuByFormValues toteutuksen ajankohta - Tarkka alkamisaika', () => {
     getHakuByFormValues(
       merge({}, baseValues, {
         aikataulut: {
-          toteutuksenAjankohta: TOTEUTUKSEN_AJANKOHTA.ALKAMISKAUSI,
+          ajankohtaTyyppi: Ajankohtatyyppi.ALKAMISKAUSI,
           tiedossaTarkkaAjankohta: true,
           tarkkaAlkaa: '2019-09-16T08:44',
           tarkkaPaattyy: '2019-09-16T08:44',
@@ -124,8 +121,7 @@ test('getHakuByFormValues toteutuksen ajankohta - Aloitus henkilokohtaisen suunn
     getHakuByFormValues(
       merge({}, baseValues, {
         aikataulut: {
-          toteutuksenAjankohta:
-            TOTEUTUKSEN_AJANKOHTA.HENKILOKOHTAINEN_SUUNNITELMA,
+          ajankohtaTyyppi: Ajankohtatyyppi.HENKILOKOHTAINEN_SUUNNITELMA,
           henkilokohtaisenSuunnitelmanLisatiedot: mapValues(
             {
               fi: '<p>hlokoht fi </p>',
@@ -138,39 +134,4 @@ test('getHakuByFormValues toteutuksen ajankohta - Aloitus henkilokohtaisen suunn
       })
     )
   ).toMatchSnapshot();
-});
-
-test('getAlkamiskausityyppi', () => {
-  expect(
-    getAlkamiskausityyppi(
-      merge({}, baseValues, {
-        aikataulut: {
-          toteutuksenAjankohta: TOTEUTUKSEN_AJANKOHTA.ALKAMISKAUSI,
-          tiedossaTarkkaAjankohta: true,
-        },
-      })
-    )
-  ).toEqual(ALKAMISKAUSITYYPPI.TARKKA_ALKAMISAJANKOHTA);
-
-  expect(
-    getAlkamiskausityyppi(
-      merge({}, baseValues, {
-        aikataulut: {
-          toteutuksenAjankohta: TOTEUTUKSEN_AJANKOHTA.ALKAMISKAUSI,
-          tiedossaTarkkaAjankohta: false,
-        },
-      })
-    )
-  ).toEqual(ALKAMISKAUSITYYPPI.ALKAMISKAUSI_JA_VUOSI);
-
-  expect(
-    getAlkamiskausityyppi(
-      merge({}, baseValues, {
-        aikataulut: {
-          toteutuksenAjankohta:
-            TOTEUTUKSEN_AJANKOHTA.HENKILOKOHTAINEN_SUUNNITELMA,
-        },
-      })
-    )
-  ).toEqual(ALKAMISKAUSITYYPPI.HENKILOKOHTAINEN_SUUNNITELMA);
 });

--- a/src/main/app/src/utils/haku/getHakuByFormValues.test.ts
+++ b/src/main/app/src/utils/haku/getHakuByFormValues.test.ts
@@ -1,4 +1,4 @@
-import { merge } from 'lodash';
+import { mapValues, merge } from 'lodash';
 
 import {
   getHakuByFormValues,
@@ -44,10 +44,8 @@ const baseValues: HakuFormValues = {
         paattyy: '2019-09-18T08:44',
       },
     ],
-    toteutuksenAjankohta: 'alkamiskausi',
-    tiedossaTarkkaAjankohta: true,
-    tarkkaAlkaa: '2019-09-16T08:44',
-    tarkkaPaattyy: '2019-09-16T08:44',
+    toteutuksenAjankohta: TOTEUTUKSEN_AJANKOHTA.ALKAMISKAUSI,
+    tiedossaTarkkaAjankohta: false,
     lisaamisenTakaraja: '2019-09-16T08:44',
     muokkauksenTakaraja: '2019-10-16T08:44',
     ajastettuJulkaisu: '2019-11-16T08:44',
@@ -102,6 +100,44 @@ test('getHakuByFormValues returns correct haku given different hakulomake variat
 
   expect(hakuMuu).toMatchSnapshot();
   expect(hakuEiHakua).toMatchSnapshot();
+});
+
+test('getHakuByFormValues toteutuksen ajankohta - Tarkka alkamisaika', () => {
+  expect(
+    getHakuByFormValues(
+      merge({}, baseValues, {
+        aikataulut: {
+          toteutuksenAjankohta: TOTEUTUKSEN_AJANKOHTA.ALKAMISKAUSI,
+          tiedossaTarkkaAjankohta: true,
+          tarkkaAlkaa: '2019-09-16T08:44',
+          tarkkaPaattyy: '2019-09-16T08:44',
+          kausi: 'alkamiskausi_1#1',
+          vuosi: { value: '2020' },
+        },
+      })
+    )
+  ).toMatchSnapshot();
+});
+
+test('getHakuByFormValues toteutuksen ajankohta - Aloitus henkilokohtaisen suunnitelman mukaisesti', () => {
+  expect(
+    getHakuByFormValues(
+      merge({}, baseValues, {
+        aikataulut: {
+          toteutuksenAjankohta:
+            TOTEUTUKSEN_AJANKOHTA.HENKILOKOHTAINEN_SUUNNITELMA,
+          henkilokohtaisenSuunnitelmanLisatiedot: mapValues(
+            {
+              fi: '<p>hlokoht fi </p>',
+              sv: '<p>hlokoht sv </p>',
+              en: '<p>hlokoht en </p>',
+            },
+            parseEditorState
+          ),
+        },
+      })
+    )
+  ).toMatchSnapshot();
 });
 
 test('getAlkamiskausityyppi', () => {

--- a/src/main/app/src/utils/haku/getHakuByFormValues.ts
+++ b/src/main/app/src/utils/haku/getHakuByFormValues.ts
@@ -5,6 +5,7 @@ import { getHakulomakeFieldsData } from '#/src/utils/form/getHakulomakeFieldsDat
 import isKorkeakoulutusKohdejoukkoKoodiUri from '#/src/utils/isKorkeakoulutusKohdejoukkoKoodiUri';
 import { ALKAMISKAUSITYYPPI, TOTEUTUKSEN_AJANKOHTA } from '#/src/constants';
 import { HakuFormValues } from '#/src/types/hakuTypes';
+import { serializeEditorState } from '#/src/components/Editor/utils';
 
 const getKielivalinta = values => values?.kieliversiot || [];
 
@@ -76,6 +77,10 @@ export const getHakuByFormValues = (values: HakuFormValues) => {
         koulutuksenAlkamisvuosi: maybeParseNumber(
           values?.aikataulut?.vuosi?.value
         ),
+        henkilokohtaisenSuunnitelmanLisatiedot: _fp.compose(
+          _fp.mapValues(serializeEditorState),
+          pickTranslations
+        )(values?.aikataulut?.henkilokohtaisenSuunnitelmanLisatiedot ?? {}),
       },
       tulevaisuudenAikataulu: (values?.aikataulut?.aikataulu || []).map(
         ({ alkaa, paattyy }) => ({

--- a/src/main/app/src/utils/haku/getHakuByFormValues.ts
+++ b/src/main/app/src/utils/haku/getHakuByFormValues.ts
@@ -3,32 +3,11 @@ import _fp from 'lodash/fp';
 import { isPartialDate, maybeParseNumber } from '#/src/utils';
 import { getHakulomakeFieldsData } from '#/src/utils/form/getHakulomakeFieldsData';
 import isKorkeakoulutusKohdejoukkoKoodiUri from '#/src/utils/isKorkeakoulutusKohdejoukkoKoodiUri';
-import { ALKAMISKAUSITYYPPI, TOTEUTUKSEN_AJANKOHTA } from '#/src/constants';
 import { HakuFormValues } from '#/src/types/hakuTypes';
 import { serializeEditorState } from '#/src/components/Editor/utils';
+import { getAlkamiskausityyppiByAjankohtaSection } from '../form/alkamiskausityyppiHelpers';
 
 const getKielivalinta = values => values?.kieliversiot || [];
-
-const isToteutuksenAjankohta = ajankohta => ({ aikataulut }) =>
-  aikataulut?.toteutuksenAjankohta === ajankohta;
-
-const hasTarkkaAjankohta = ({ aikataulut }) =>
-  aikataulut?.tiedossaTarkkaAjankohta;
-
-export const getAlkamiskausityyppi = _fp.cond([
-  [
-    isToteutuksenAjankohta(TOTEUTUKSEN_AJANKOHTA.ALKAMISKAUSI),
-    _fp.cond([
-      [hasTarkkaAjankohta, () => ALKAMISKAUSITYYPPI.TARKKA_ALKAMISAJANKOHTA],
-      [_fp.T, () => ALKAMISKAUSITYYPPI.ALKAMISKAUSI_JA_VUOSI],
-    ]),
-  ],
-  [
-    isToteutuksenAjankohta(TOTEUTUKSEN_AJANKOHTA.HENKILOKOHTAINEN_SUUNNITELMA),
-    () => ALKAMISKAUSITYYPPI.HENKILOKOHTAINEN_SUUNNITELMA,
-  ],
-  [_fp.T, () => null],
-]);
 
 export const getHakuByFormValues = (values: HakuFormValues) => {
   const kielivalinta = getKielivalinta(values);
@@ -70,7 +49,9 @@ export const getHakuByFormValues = (values: HakuFormValues) => {
     hakulomaketyyppi,
     metadata: {
       koulutuksenAlkamiskausi: {
-        alkamiskausityyppi: getAlkamiskausityyppi(values),
+        alkamiskausityyppi: getAlkamiskausityyppiByAjankohtaSection(
+          values?.aikataulut
+        ),
         koulutuksenAlkamispaivamaara: values?.aikataulut?.tarkkaAlkaa,
         koulutuksenPaattymispaivamaara: values?.aikataulut?.tarkkaPaattyy,
         koulutuksenAlkamiskausiKoodiUri: values?.aikataulut?.kausi || null,

--- a/src/main/app/src/utils/haku/getHakuByOid.ts
+++ b/src/main/app/src/utils/haku/getHakuByOid.ts
@@ -1,13 +1,21 @@
-import { get, isObject } from 'lodash';
+import { ENTITY } from '#/src/constants';
+import { useApiQuery } from '#/src/hooks/useApiQuery';
+import _ from 'lodash';
 
 export const getHakuByOid = async ({ oid, httpClient, apiUrls }) => {
   const { data, headers } = await httpClient.get(
     apiUrls.url('kouta-backend.haku-by-oid', oid)
   );
 
-  const lastModified = get(headers, 'x-last-modified') || null;
+  const lastModified = _.get(headers, 'x-last-modified') || null;
 
-  return isObject(data) ? { lastModified, ...data } : data;
+  return _.isObject(data) ? { lastModified, ...data } : data;
 };
+
+export const useHakuByOid = (props, options = {}) =>
+  useApiQuery(ENTITY.HAKU, props, getHakuByOid, {
+    refetchOnWindowFocus: false,
+    ...options,
+  });
 
 export default getHakuByOid;

--- a/src/main/app/src/utils/haku/getHakuFormConfig.ts
+++ b/src/main/app/src/utils/haku/getHakuFormConfig.ts
@@ -1,4 +1,4 @@
-import _ from 'lodash/fp';
+import _fp from 'lodash/fp';
 import { ifAny, otherwise } from '#/src/utils';
 import {
   HAKULOMAKETYYPPI,
@@ -44,6 +44,9 @@ const config = createFormConfigBuilder().registerSections([
       {
         field: '.kohdejoukko',
         required: true,
+        validate: validateIfJulkaistu(
+          validateExistence('kohdejoukko.kohdejoukko')
+        ),
       },
       {
         field: '.tarkenne',
@@ -69,6 +72,9 @@ const config = createFormConfigBuilder().registerSections([
       },
       {
         field: '.toteutuksenAjankohta',
+        validate: validateIfJulkaistu(
+          validateExistence('aikataulut.toteutuksenAjankohta')
+        ),
       },
       {
         field: '.kausi',
@@ -82,7 +88,7 @@ const config = createFormConfigBuilder().registerSections([
               values?.aikataulut?.toteutuksenAjankohta ===
                 TOTEUTUKSEN_AJANKOHTA.ALKAMISKAUSI &&
               values?.tila === JULKAISUTILA.JULKAISTU,
-            _.pipe(
+            _fp.pipe(
               validateExistence('aikataulut.kausi'),
               validateExistence('aikataulut.vuosi')
             )
@@ -100,15 +106,11 @@ const config = createFormConfigBuilder().registerSections([
               TOTEUTUKSEN_AJANKOHTA.ALKAMISKAUSI &&
               values?.aikataulut?.tiedossaTarkkaAjankohta &&
               values?.tila === JULKAISUTILA.JULKAISTU,
-            _.pipe(
-              validateExistenceOfDate('aikataulut.tarkkaAlkaa'),
-              validateExistenceOfDate('aikataulut.tarkkaPaattyy')
-            )
+            validateExistenceOfDate('aikataulut.tarkkaAlkaa')
           )(eb),
       },
       {
         field: '.tarkkaPaattyy',
-        required: true,
       },
       {
         field: '.hakuaika',
@@ -122,7 +124,7 @@ const config = createFormConfigBuilder().registerSections([
               const isErillishaku = isErillishakuHakutapa(hakutapa);
               const isYhteishaku = isYhteishakuHakutapa(hakutapa);
 
-              return _.flow([
+              return _fp.flow([
                 validateExistenceOfDate('alkaa'),
                 validateIf(
                   isYhteishaku || isErillishaku,
@@ -174,7 +176,7 @@ const config = createFormConfigBuilder().registerSections([
         validate: validateIfJulkaistu(
           (eb, values) =>
             eb.validateExistence('hakulomake.tyyppi') &&
-            _.cond([
+            _fp.cond([
               [
                 ifAny(HAKULOMAKETYYPPI.ATARU),
                 () => eb.validateExistence('hakulomake.lomake'),

--- a/src/main/app/src/utils/haku/getHakuFormConfig.ts
+++ b/src/main/app/src/utils/haku/getHakuFormConfig.ts
@@ -3,7 +3,7 @@ import { ifAny, otherwise } from '#/src/utils';
 import {
   HAKULOMAKETYYPPI,
   JULKAISUTILA,
-  TOTEUTUKSEN_AJANKOHTA,
+  Ajankohtatyyppi,
 } from '#/src/constants';
 import isYhteishakuHakutapa from '#/src/utils/isYhteishakuHakutapa';
 import isErillishakuHakutapa from '#/src/utils/isErillishakuHakutapa';
@@ -71,9 +71,9 @@ const config = createFormConfigBuilder().registerSections([
         required: true,
       },
       {
-        field: '.toteutuksenAjankohta',
+        field: '.ajankohtaTyyppi',
         validate: validateIfJulkaistu(
-          validateExistence('aikataulut.toteutuksenAjankohta')
+          validateExistence('aikataulut.ajankohtaTyyppi')
         ),
       },
       {
@@ -85,8 +85,8 @@ const config = createFormConfigBuilder().registerSections([
         validate: (eb, values) =>
           validateIf(
             isYhteishakuHakutapa(getHakutapa(values)) &&
-              values?.aikataulut?.toteutuksenAjankohta ===
-                TOTEUTUKSEN_AJANKOHTA.ALKAMISKAUSI &&
+              values?.aikataulut?.ajankohtaTyyppi ===
+                Ajankohtatyyppi.ALKAMISKAUSI &&
               values?.tila === JULKAISUTILA.JULKAISTU,
             _fp.pipe(
               validateExistence('aikataulut.kausi'),
@@ -102,8 +102,8 @@ const config = createFormConfigBuilder().registerSections([
         required: true,
         validate: (eb, values) =>
           validateIf(
-            values?.aikataulut?.toteutuksenAjankohta ===
-              TOTEUTUKSEN_AJANKOHTA.ALKAMISKAUSI &&
+            values?.aikataulut?.ajankohtaTyyppi ===
+              Ajankohtatyyppi.ALKAMISKAUSI &&
               values?.aikataulut?.tiedossaTarkkaAjankohta &&
               values?.tila === JULKAISUTILA.JULKAISTU,
             validateExistenceOfDate('aikataulut.tarkkaAlkaa')

--- a/src/main/app/src/utils/haku/getHakuFormConfig.ts
+++ b/src/main/app/src/utils/haku/getHakuFormConfig.ts
@@ -15,6 +15,7 @@ import {
   pohjaValintaSectionConfig,
   tilaSectionConfig,
   validateIf,
+  validateOptionalTranslatedField,
 } from '#/src/utils/form/formConfigUtils';
 import {
   validateExistence,
@@ -129,6 +130,12 @@ const config = createFormConfigBuilder().registerSections([
                 ),
               ])(eb);
             })
+        ),
+      },
+      {
+        field: '.henkilokohtaisenSuunnitelmanLisatiedot',
+        validate: validateOptionalTranslatedField(
+          'aikataulut.henkilokohtaisenSuunnitelmanLisatiedot'
         ),
       },
       {

--- a/src/main/app/src/utils/index.test.ts
+++ b/src/main/app/src/utils/index.test.ts
@@ -1,4 +1,8 @@
-import { isDeepEmptyFormValues } from '#/src/utils';
+import {
+  getFieldName,
+  getValuesForSaving,
+  isDeepEmptyFormValues,
+} from '#/src/utils';
 
 const OBJECT_IN_ARRAY = [
   {
@@ -33,4 +37,109 @@ test('Should return false for not empty object', () => {
 
 test('Should return false for zero', () => {
   expect(isDeepEmptyFormValues(0)).toEqual(false);
+});
+
+test.each([
+  [
+    {
+      nimi: {
+        fi: 'nimi fi',
+        sv: 'nimi sv',
+      },
+    },
+    {},
+    {
+      'nimi.fi': { name: 'nimi.fi' },
+      'nimi.sv': { name: 'nimi.sv' },
+    },
+    {},
+    {
+      nimi: null,
+    },
+  ],
+  [
+    {
+      nimi: {
+        fi: 'nimi fi',
+        sv: 'nimi sv',
+      },
+    },
+    {
+      'nimi.fi': { name: 'nimi.fi' },
+      'nimi.sv': { name: 'nimi.sv' },
+    },
+    {
+      'nimi.fi': { name: 'nimi.fi' },
+    },
+    {},
+    {
+      nimi: {
+        fi: 'nimi fi',
+        sv: 'nimi sv',
+      },
+    },
+  ],
+  [
+    {
+      nimi: {
+        fi: 'nimi fi',
+        sv: 'nimi sv',
+      },
+    },
+    {
+      'nimi.fi': { name: 'nimi.fi' },
+    },
+    {
+      'nimi.fi': { name: 'nimi.fi' },
+      'nimi.sv': { name: 'nimi.sv' },
+    },
+    {},
+    {
+      nimi: {
+        fi: 'nimi fi',
+        sv: 'nimi sv',
+      },
+    },
+  ],
+  [
+    {
+      nimi: {
+        fi: 'nimi fi',
+        sv: 'nimi sv',
+      },
+    },
+    {
+      'nimi.fi': { name: 'nimi.fi' },
+    },
+    {
+      'nimi.sv': { name: 'nimi.sv' },
+    },
+    {},
+    {
+      nimi: {
+        fi: 'nimi fi',
+        sv: 'nimi sv',
+      },
+    },
+  ],
+])(
+  'getValuesForSaving',
+  (values, registeredFields, unregisteredFields, initialValues, result) => {
+    expect(
+      getValuesForSaving(
+        values,
+        registeredFields,
+        unregisteredFields,
+        initialValues
+      )
+    ).toEqual(result);
+  }
+);
+
+test.each([
+  ['nimi.fi', 'nimi'],
+  ['nimi', 'nimi'],
+  ['perustiedot.nimi', 'perustiedot.nimi'],
+])('getFieldName', (name, fieldName) => {
+  expect(getFieldName(name)).toEqual(fieldName);
 });

--- a/src/main/app/src/utils/index.ts
+++ b/src/main/app/src/utils/index.ts
@@ -182,16 +182,17 @@ export const maybeParseNumber = value => {
 
 export const toSelectValue = value => (_.isNil(value) ? null : { value });
 
-const getFieldName = name =>
-  name.match(`(.+?)(\\.${LANGUAGES.join('|')})?$`)?.[1];
+// Returns field name without language part
+export const getFieldName = name =>
+  name.match(`^(.+?)(\\.(${LANGUAGES.join('|')}))?$`)?.[1];
 
 // Get form values for saving. Filters out fields that user has hidden.
 // Result can be sassed to get**ByFormValues().
 export const getValuesForSaving = (
-  values,
-  registeredFields,
-  unregisteredFields,
-  initialValues = {}
+  values: any,
+  registeredFields: Record<string, { name: string }>,
+  unregisteredFields: Record<string, { name: string }>,
+  initialValues: any = {}
 ) => {
   // Use initial values as a base. Especially important for editing.
   const saveableValues: any = initialValues;
@@ -210,7 +211,11 @@ export const getValuesForSaving = (
 
   // Some exceptions (fields that should be saved even though they are not visible)
   // TODO: There might be a few other exceptions. Check before using in other forms and add here.
-  _.set(saveableValues, 'koulutustyyppi', values?.koulutustyyppi);
-  _.set(saveableValues, 'muokkaaja', values?.muokkaaja);
+  if (values?.koulutustyyppi) {
+    _.set(saveableValues, 'koulutustyyppi', values?.koulutustyyppi);
+  }
+  if (values?.muokkaaja) {
+    _.set(saveableValues, 'muokkaaja', values?.muokkaaja);
+  }
   return saveableValues;
 };


### PR DESCRIPTION
- Lisätty hakulomakkeelle Haun aikataulu -osioon Lisätietoa-kenttä, joka näkyy kun on valittu "Aloitus henkilökohtaisen suunnitelman mukaisesti"
- Korjattu validointeja: Kohdejoukko pakolliseksi, Tarkka päättymisaika pakollisuus pois, "Koulutuksen aloitusajankohta" pakolliseksi, kun julkastu.
- Refaktoroitu Edit- ja CreateHakuForm jakamaan submit-callback ja käyttämään react-querya
- Toteutettu käyttäjän piilottamien kenttien asettaminen null:ksi, jotta ei tarvitse manuaalisesti käydä niitä läpi.
- Pieniä parannuksia koodin tyyliin.