### PR TITLE
KTO-1112: KOMOTO järjestäjien valinta hierarkia-automatiikka pois

### DIFF
--- a/src/main/app/cypress/integration/__snapshots__/toteutus.test.ts.snap
+++ b/src/main/app/cypress/integration/__snapshots__/toteutus.test.ts.snap
@@ -124,7 +124,6 @@ exports[`createToteutus > should be able to create ammatillinen tutkinnon osa to
   "organisaatioOid": "1.1.1.1.1.1",
   "sorakuvausId": null,
   "tarjoajat": [
-    "1.2.1.1.1.1",
     "1.2.2.1.1.1"
   ],
   "tila": "julkaistu"
@@ -260,7 +259,6 @@ exports[`createToteutus > should be able to create ammatillinen toteutus #0`] =
   "organisaatioOid": "1.1.1.1.1.1",
   "sorakuvausId": null,
   "tarjoajat": [
-    "1.2.1.1.1.1",
     "1.2.2.1.1.1"
   ],
   "tila": "julkaistu"
@@ -419,7 +417,6 @@ exports[`createToteutus > should be able to create korkeakoulu toteutus #0`] =
   "organisaatioOid": "1.1.1.1.1.1",
   "sorakuvausId": null,
   "tarjoajat": [
-    "1.2.1.1.1.1",
     "1.2.2.1.1.1"
   ],
   "tila": "julkaistu"
@@ -559,7 +556,6 @@ exports[`createToteutus > should be able to create lukio toteutus #0`] =
   "organisaatioOid": "1.1.1.1.1.1",
   "sorakuvausId": null,
   "tarjoajat": [
-    "1.2.1.1.1.1",
     "1.2.2.1.1.1"
   ],
   "tila": "julkaistu"

--- a/src/main/app/package-lock.json
+++ b/src/main/app/package-lock.json
@@ -4408,12 +4408,12 @@
       }
     },
     "@opetushallitus/virkailija-ui-components": {
-      "version": "0.3.4",
-      "resolved": "https://artifactory.opintopolku.fi/artifactory/repository/oph-opintopolku-npm/@opetushallitus/virkailija-ui-components/-/virkailija-ui-components-0.3.4.tgz",
-      "integrity": "sha512-rOQjoqyBSLFxo4gDjDMhjaORkIjHRf/un87cpqENy4r4eVpA2PKiL0TtIGq3Wl/1mnn9bdFaeJoXgHv/4NL5sQ==",
+      "version": "0.3.6",
+      "resolved": "https://artifactory.opintopolku.fi/artifactory/repository/oph-opintopolku-npm/@opetushallitus/virkailija-ui-components/-/virkailija-ui-components-0.3.6.tgz",
+      "integrity": "sha512-rBatRxbqOO8WGhoYLaiyjF22v2S9m+ESYvGC36fcZZKi781+PGMiLNBG53ntPffa7Gl2CZQN5Cl+ilD+Dd8d8Q==",
       "requires": {
         "date-fns": "2.0.1",
-        "lodash": "4.17.15",
+        "lodash": "^4.17.20",
         "memoize-one": "5.1.1",
         "polished": "3.4.1",
         "react-day-picker": "7.3.2",
@@ -4425,9 +4425,9 @@
       },
       "dependencies": {
         "@babel/runtime": {
-          "version": "7.11.2",
-          "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.11.2.tgz",
-          "integrity": "sha512-TeWkU52so0mPtDcaCTxNBI/IHiz0pZgr8VEFqXFtZWpYD08ZB6FaSwVAS8MKRQAP3bYKiVjwysOJgMFY28o6Tw==",
+          "version": "7.12.13",
+          "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.12.13.tgz",
+          "integrity": "sha512-8+3UMPBrjFa/6TtKi/7sehPKqfAm4g6K+YQjyyFOLUTxzOngcRZTlAVY8sc2CORJYqdHQY8gRPHmn+qo15rCBw==",
           "requires": {
             "regenerator-runtime": "^0.13.4"
           }
@@ -4436,11 +4436,6 @@
           "version": "2.0.1",
           "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-2.0.1.tgz",
           "integrity": "sha512-C14oTzTZy8DH1Eq8N78owrCWvf3+cnJw88BTK/N3DYWVxDJuJzPaNdplzYxDYuuXXGvqBcO4Vy5SOrwAooXSWw=="
-        },
-        "lodash": {
-          "version": "4.17.15",
-          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.15.tgz",
-          "integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A=="
         },
         "polished": {
           "version": "3.4.1",
@@ -4478,15 +4473,6 @@
             "raf": "^3.4.0",
             "react-input-autosize": "^2.2.1",
             "react-transition-group": "^2.2.1"
-          }
-        },
-        "react-spring": {
-          "version": "8.0.27",
-          "resolved": "https://registry.npmjs.org/react-spring/-/react-spring-8.0.27.tgz",
-          "integrity": "sha512-nDpWBe3ZVezukNRandTeLSPcwwTMjNVu1IDq9qA/AMiUqHuRN4BeSWvKr3eIxxg1vtiYiOLy4FqdfCP5IoP77g==",
-          "requires": {
-            "@babel/runtime": "^7.3.1",
-            "prop-types": "^15.5.8"
           }
         },
         "regenerator-runtime": {

--- a/src/main/app/package.json
+++ b/src/main/app/package.json
@@ -22,7 +22,7 @@
     "analyze": "source-map-explorer 'build/static/js/*.js'"
   },
   "dependencies": {
-    "@opetushallitus/virkailija-ui-components": "^0.3.4",
+    "@opetushallitus/virkailija-ui-components": "^0.3.6",
     "@xstate/react": "^1.2.1",
     "axios": "^0.21.1",
     "core-js": "^3.8.1",

--- a/src/main/app/public/index.html
+++ b/src/main/app/public/index.html
@@ -9,10 +9,7 @@
     />
     <meta name="theme-color" content="#000000" />
     <link rel="manifest" href="%PUBLIC_URL%/manifest.json" />
-    <link
-      href="https://fonts.googleapis.com/icon?family=Material+Icons"
-      rel="stylesheet"
-    />
+    <link href="https://fonts.googleapis.com/css?family=Material+Icons|Material+Icons+Outlined" rel="stylesheet">
     <link href="https://fonts.googleapis.com/css?family=Roboto:400,500&display=swap" rel="stylesheet">
     <title>Tarjonta</title>
   </head>

--- a/src/main/app/src/components/Alert/index.tsx
+++ b/src/main/app/src/components/Alert/index.tsx
@@ -6,34 +6,34 @@ import styled, { css } from 'styled-components';
 import { Typography, Icon, Box } from '#/src/components/virkailija';
 import { spacing, getThemeProp } from '#/src/theme';
 
-const getIconByVariant = variant => {
-  if (variant === 'info') {
+const getIconByStatus = status => {
+  if (status === 'info') {
     return 'info';
-  } else if (variant === 'danger') {
+  } else if (status === 'danger') {
     return 'error';
-  } else if (variant === 'success') {
+  } else if (status === 'success') {
     return 'check_circle';
   }
 
   return undefined;
 };
 
-const getVariantColor = ({ variant, theme }) => {
-  if (variant === 'danger') {
+const getStatusColor = ({ status, theme }) => {
+  if (status === 'danger') {
     return theme.palette.danger.main;
-  } else if (variant === 'success') {
+  } else if (status === 'success') {
     return theme.palette.success.main;
   }
 
   return theme.palette.primary.main;
 };
 
-const VariantIcon = styled(Icon)`
+const StatusIcon = styled(Icon)`
   font-size: 1.8rem;
-  color: ${getVariantColor};
+  color: ${getStatusColor};
 `;
-const getVariantCss = ({ variant, theme }) => {
-  const color = getVariantColor({ theme, variant });
+const getStatusCss = ({ status, theme }) => {
+  const color = getStatusColor({ theme, status });
 
   return css`
     border-color: ${color};
@@ -49,23 +49,23 @@ const AlertBase = styled.div`
 
   ${({ hasTitle }) => !hasTitle && 'align-items: center'}
 
-  ${getVariantCss}
+  ${getStatusCss}
 `;
 
 const Alert = ({
-  variant = 'info',
+  status = 'info',
   title = null,
   children = null,
   showIcon = true,
   ...props
 }) => {
-  const icon = getIconByVariant(variant);
+  const icon = getIconByStatus(status);
   const hasTitle = Boolean(title);
 
   return (
-    <AlertBase variant={variant} hasTitle={hasTitle} {...props}>
+    <AlertBase status={status} hasTitle={hasTitle} {...props}>
       {icon && showIcon ? (
-        <VariantIcon variant={variant} type={icon} mr={2} />
+        <StatusIcon status={status} type={icon} mr={2} />
       ) : null}
       <Box flexGrow={1}>
         {title ? (

--- a/src/main/app/src/components/Collapse/__snapshots__/Collapse.test.tsx.snap
+++ b/src/main/app/src/components/Collapse/__snapshots__/Collapse.test.tsx.snap
@@ -98,12 +98,12 @@ exports[`renders correctly 1`] = `
       <span
         style="transform: rotate(180deg); display: inline-flex;"
       >
-        <span
+        <i
           class="c5 material-icons c6"
           role="button"
         >
           expand_more
-        </span>
+        </i>
       </span>
     </div>
   </div>
@@ -217,12 +217,12 @@ exports[`renders correctly 2`] = `
       <span
         style="transform: rotate(180deg); display: inline-flex;"
       >
-        <span
+        <i
           class="c4 material-icons c5"
           role="button"
         >
           expand_more
-        </span>
+        </i>
       </span>
     </div>
   </div>
@@ -347,12 +347,12 @@ exports[`renders correctly when closed 1`] = `
       <span
         style="transform: rotate(0deg); display: inline-flex;"
       >
-        <span
+        <i
           class="c5 material-icons c6"
           role="button"
         >
           expand_more
-        </span>
+        </i>
       </span>
     </div>
   </div>

--- a/src/main/app/src/components/Collapse/__snapshots__/Collapse.test.tsx.snap
+++ b/src/main/app/src/components/Collapse/__snapshots__/Collapse.test.tsx.snap
@@ -1,13 +1,13 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`renders correctly 1`] = `
+.c5 {
+  font-size: 1.5rem;
+}
+
 .c7 {
   box-sizing: border-box;
   padding: 24px;
-}
-
-.c5 {
-  font-size: 1.5rem;
 }
 
 .c3 {
@@ -133,13 +133,13 @@ exports[`renders correctly 1`] = `
 `;
 
 exports[`renders correctly 2`] = `
+.c4 {
+  font-size: 1.5rem;
+}
+
 .c6 {
   box-sizing: border-box;
   padding: 24px;
-}
-
-.c4 {
-  font-size: 1.5rem;
 }
 
 .c0 {
@@ -252,13 +252,13 @@ exports[`renders correctly 2`] = `
 `;
 
 exports[`renders correctly when closed 1`] = `
+.c5 {
+  font-size: 1.5rem;
+}
+
 .c7 {
   box-sizing: border-box;
   padding: 24px;
-}
-
-.c5 {
-  font-size: 1.5rem;
 }
 
 .c3 {

--- a/src/main/app/src/components/FormSteps/__snapshots__/FormSteps.test.tsx.snap
+++ b/src/main/app/src/components/FormSteps/__snapshots__/FormSteps.test.tsx.snap
@@ -157,11 +157,11 @@ exports[`renders correctly 1`] = `
       <div
         class="c4"
       >
-        <span
+        <i
           class="c5 material-icons c6"
         >
           school
-        </span>
+        </i>
       </div>
       <div
         class="c7"
@@ -175,11 +175,11 @@ exports[`renders correctly 1`] = `
       <div
         class="c4"
       >
-        <span
+        <i
           class="c5 material-icons c6"
         >
           flag
-        </span>
+        </i>
       </div>
       <div
         class="c7"
@@ -197,11 +197,11 @@ exports[`renders correctly 1`] = `
       <div
         class="c4"
       >
-        <span
+        <i
           class="c5 material-icons c6"
         >
           access_time
-        </span>
+        </i>
       </div>
       <div
         class="c7"
@@ -215,11 +215,11 @@ exports[`renders correctly 1`] = `
       <div
         class="c8"
       >
-        <span
+        <i
           class="c5 material-icons c9"
         >
           list_alt
-        </span>
+        </i>
       </div>
       <div
         class="c10"
@@ -237,11 +237,11 @@ exports[`renders correctly 1`] = `
       <div
         class="c11"
       >
-        <span
+        <i
           class="c5 material-icons c6"
         >
           filter_list
-        </span>
+        </i>
       </div>
       <div
         class="c7"
@@ -255,11 +255,11 @@ exports[`renders correctly 1`] = `
       <div
         class="c11"
       >
-        <span
+        <i
           class="c5 material-icons c6"
         >
           subject
-        </span>
+        </i>
       </div>
       <div
         class="c7"

--- a/src/main/app/src/components/FormSteps/__snapshots__/FormSteps.test.tsx.snap
+++ b/src/main/app/src/components/FormSteps/__snapshots__/FormSteps.test.tsx.snap
@@ -158,7 +158,7 @@ exports[`renders correctly 1`] = `
         class="c4"
       >
         <i
-          class="c5 material-icons c6"
+          class="c5 material-icons-outlined c6"
         >
           school
         </i>
@@ -176,7 +176,7 @@ exports[`renders correctly 1`] = `
         class="c4"
       >
         <i
-          class="c5 material-icons c6"
+          class="c5 material-icons-outlined c6"
         >
           flag
         </i>
@@ -198,7 +198,7 @@ exports[`renders correctly 1`] = `
         class="c4"
       >
         <i
-          class="c5 material-icons c6"
+          class="c5 material-icons-outlined c6"
         >
           access_time
         </i>
@@ -216,7 +216,7 @@ exports[`renders correctly 1`] = `
         class="c8"
       >
         <i
-          class="c5 material-icons c9"
+          class="c5 material-icons-outlined c9"
         >
           list_alt
         </i>
@@ -238,7 +238,7 @@ exports[`renders correctly 1`] = `
         class="c11"
       >
         <i
-          class="c5 material-icons c6"
+          class="c5 material-icons-outlined c6"
         >
           filter_list
         </i>
@@ -256,7 +256,7 @@ exports[`renders correctly 1`] = `
         class="c11"
       >
         <i
-          class="c5 material-icons c6"
+          class="c5 material-icons-outlined c6"
         >
           subject
         </i>

--- a/src/main/app/src/components/IconButton.tsx
+++ b/src/main/app/src/components/IconButton.tsx
@@ -1,9 +1,9 @@
 import React from 'react';
 
-import Icon from '@opetushallitus/virkailija-ui-components/Icon';
 import styled from 'styled-components';
 
 import Button from '#/src/components/Button';
+import { Icon } from '#/src/components/virkailija';
 
 const SizedIcon = styled(Icon)`
   font-size: 1.2em;

--- a/src/main/app/src/components/RemoveButton.tsx
+++ b/src/main/app/src/components/RemoveButton.tsx
@@ -11,7 +11,7 @@ export default function RemoveButton({ children = undefined, ...props }) {
       type="button"
       variant="outlined"
       color="secondary"
-      iconType="delete_outlined"
+      iconType="delete"
       {...props}
     >
       {children ? children : t('yleiset.poista')}

--- a/src/main/app/src/components/virkailija.tsx
+++ b/src/main/app/src/components/virkailija.tsx
@@ -1,3 +1,6 @@
+import VUCIcon from '@opetushallitus/virkailija-ui-components/Icon';
+export const Icon = props => <VUCIcon {...props} variant="outlined" />;
+
 export { default as Box } from '@opetushallitus/virkailija-ui-components/Box';
 export { default as Button } from '@opetushallitus/virkailija-ui-components/Button';
 export { default as Checkbox } from '@opetushallitus/virkailija-ui-components/Checkbox';
@@ -12,7 +15,6 @@ export { default as DropdownIcon } from '@opetushallitus/virkailija-ui-component
 export { default as FormControl } from '@opetushallitus/virkailija-ui-components/FormControl';
 export { default as FormHelperText } from '@opetushallitus/virkailija-ui-components/FormHelperText';
 export { default as FormLabel } from '@opetushallitus/virkailija-ui-components/FormLabel';
-export { default as Icon } from '@opetushallitus/virkailija-ui-components/Icon';
 export { default as Input } from '@opetushallitus/virkailija-ui-components/Input';
 export { default as InputIcon } from '@opetushallitus/virkailija-ui-components/InputIcon';
 export { default as ModalBody } from '@opetushallitus/virkailija-ui-components/ModalBody';

--- a/src/main/app/src/pages/koulutus/KoulutusForm/JarjestajaSection.tsx
+++ b/src/main/app/src/pages/koulutus/KoulutusForm/JarjestajaSection.tsx
@@ -66,7 +66,7 @@ const OrganizationSection = ({
     <>
       {tarjoajat.length > 0 || disableTarjoajaHierarkia ? (
         <Box mb={2}>
-          <Alert variant="info">
+          <Alert status="info">
             {t('koulutuslomake.tarjoajienLukumaara', {
               lukumaara: tarjoajat.length,
             })}

--- a/src/main/app/src/pages/toteutus/ToteutusForm/JarjestamispaikatSection.tsx
+++ b/src/main/app/src/pages/toteutus/ToteutusForm/JarjestamispaikatSection.tsx
@@ -38,6 +38,7 @@ const JarjestamispaikatSection = ({ organisaatioOid, name }) => {
         hierarkia={hierarkia}
         getIsDisabled={getIsDisabled}
         component={JarjestajatField}
+        disableAutoSelect={true}
       />
     </div>
   );


### PR DESCRIPTION
Valitaan KOMOTO järjestäjistä vain käyttäjän klikkaama checkbox, ei ylä- tai alatasoja automaattisesti, kuten aiemmin.

Tässä yhteydessä otettiin myös käyttään material-icons outlined-tyyli, joka oli aiemmin toteutettu virkailija-ui-components-repossa.