### PR TITLE
KTO-1170

### DIFF
--- a/src/main/app/src/components/KoulutusField.tsx
+++ b/src/main/app/src/components/KoulutusField.tsx
@@ -9,6 +9,7 @@ import { useKoulutuksetByKoulutustyyppi } from '#/src/utils/koulutus/getKoulutuk
 
 import { useBoundFormActions, useFieldValue, useIsDirty } from '../hooks/form';
 import { useHasChanged } from '../hooks/useHasChanged';
+import getKoodiNimiTranslation from '../utils/getKoodiNimiTranslation';
 
 const KoulutusField = props => {
   const { name } = props;
@@ -40,6 +41,9 @@ const KoulutusField = props => {
       koodistoData={koulutukset}
       label={t('yleiset.valitseKoulutus')}
       showAllOptions={true}
+      formatKoodiLabel={(koodi, language) =>
+        `${getKoodiNimiTranslation(koodi, language)} (${koodi.koodiArvo})`
+      }
       {...props}
     />
   );

--- a/src/main/app/src/components/KoulutusField.tsx
+++ b/src/main/app/src/components/KoulutusField.tsx
@@ -1,6 +1,5 @@
 import React, { useEffect } from 'react';
 
-import _ from 'lodash';
 import { useTranslation } from 'react-i18next';
 import { Field } from 'redux-form';
 
@@ -20,7 +19,7 @@ const KoulutusField = props => {
     koulutustyyppi
   );
 
-  const { t } = useTranslation();
+  const { t, i18n } = useTranslation();
 
   const koulutustyyppiChanged = useHasChanged(koulutustyyppi);
 
@@ -45,6 +44,7 @@ const KoulutusField = props => {
         `${getKoodiNimiTranslation(koodi, language)} (${koodi.koodiArvo})`
       }
       {...props}
+      language={i18n.language}
     />
   );
 };

--- a/src/main/app/src/pages/soraKuvaus/SoraKuvausForm/KoulutustyyppiSection.tsx
+++ b/src/main/app/src/pages/soraKuvaus/SoraKuvausForm/KoulutustyyppiSection.tsx
@@ -5,9 +5,9 @@ import { useTranslation } from 'react-i18next';
 import { Field } from 'redux-form';
 
 import {
+  FormFieldAsyncKoodistoSelect,
   FormFieldKoulutusalaSelect,
   FormFieldKoulutustyyppiSelect,
-  FormFieldSelect,
 } from '#/src/components/formFields';
 import { Box } from '#/src/components/virkailija';
 import {
@@ -16,15 +16,11 @@ import {
   useIsDirty,
 } from '#/src/hooks/form';
 import { useHasChanged } from '#/src/hooks/useHasChanged';
-import { useKoodistoDataOptions } from '#/src/hooks/useKoodistoOptions';
 import { getTestIdProps } from '#/src/utils';
+import getKoodiNimiTranslation from '#/src/utils/getKoodiNimiTranslation';
 import { useKoulutuksetByKoulutusala } from '#/src/utils/soraKuvaus/getKoulutuksetBykoulutusala';
 
-export const KoulutustyyppiSection = ({
-  name,
-  language,
-  canEditKoulutustyyppi,
-}) => {
+export const KoulutustyyppiSection = ({ name, canEditKoulutustyyppi }) => {
   const { t } = useTranslation();
 
   const { change } = useBoundFormActions();
@@ -45,11 +41,6 @@ export const KoulutustyyppiSection = ({
     koulutusalaFieldValue
   );
 
-  const koulutusOptions = useKoodistoDataOptions({
-    koodistoData: koulutukset,
-    language,
-  });
-
   return (
     <Box display="flex" flexDirection="column" maxWidth="900px">
       <Field
@@ -69,11 +60,13 @@ export const KoulutustyyppiSection = ({
         <Box flex="1 1 50%" {...getTestIdProps('koulutukset')}>
           <Field
             name="koulutukset"
-            options={koulutusOptions}
-            component={FormFieldSelect}
+            koodistoData={koulutukset}
+            component={FormFieldAsyncKoodistoSelect}
             label={t('yleiset.valitseKoulutus')}
-            disabled={_.isEmpty(koulutusOptions)}
-            language={language}
+            showAllOptions={true}
+            formatKoodiLabel={(koodi, language) =>
+              `${getKoodiNimiTranslation(koodi, language)} (${koodi.koodiArvo})`
+            }
             isMulti={true}
           />
         </Box>


### PR DESCRIPTION
Lisätty kulutus-pudotusvalikoihin nimen perään koulutuksen koodiarvo. SORA-kuvaus-lomakkeella vaihdettu lisäksi AsyncKoodistoSelect-komponenttiin, jotta voidaan tehdä samalla tavalla kuin Koulutus-lomakkeella.