### PR TITLE
KTO-1188: Oppilaitoksen tallentaminen ei onnistu

### DIFF
--- a/src/main/app/package-lock.json
+++ b/src/main/app/package-lock.json
@@ -12188,11 +12188,6 @@
         "whatwg-url": "^8.0.0"
       }
     },
-    "dataloader": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/dataloader/-/dataloader-1.4.0.tgz",
-      "integrity": "sha512-68s5jYdlvasItOJnCuI2Q9s4q98g0pCyL3HrcKJu8KNugUl8ahgmZYg38ysLTgQjjXX3H8CJLkAvWrclWfcalw=="
-    },
     "date-fns": {
       "version": "2.19.0",
       "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-2.19.0.tgz",

--- a/src/main/app/package.json
+++ b/src/main/app/package.json
@@ -25,7 +25,6 @@
     "@opetushallitus/virkailija-ui-components": "^0.4.0",
     "@xstate/react": "^1.3.1",
     "axios": "^0.21.1",
-    "dataloader": "^1.4.0",
     "date-fns": "^2.19.0",
     "debounce-promise": "^3.1.2",
     "draft-convert": "^2.1.10",

--- a/src/main/app/src/hooks/useOrganisaatio/index.ts
+++ b/src/main/app/src/hooks/useOrganisaatio/index.ts
@@ -31,7 +31,7 @@ export const useOrganisaatiot = oids => {
     { oids: _.castArray(oids) },
     {
       ...LONG_CACHE_QUERY_OPTIONS,
-      enabled: !_.isEmpty(oids) && !_.isNil(oids),
+      enabled: !_.isEmpty(oids),
       retry: 0,
     }
   );

--- a/src/main/app/src/hooks/useOrganisaatioHierarkia/index.ts
+++ b/src/main/app/src/hooks/useOrganisaatioHierarkia/index.ts
@@ -1,4 +1,7 @@
-import useApiAsync from '#/src/hooks/useApiAsync';
+import { useMemo } from 'react';
+
+import { LONG_CACHE_QUERY_OPTIONS } from '#/src/constants';
+import { useApiQuery } from '#/src/hooks/useApiQuery';
 import filterTree from '#/src/utils/filterTree';
 import getOrganisaatioHierarkiaByOid from '#/src/utils/organisaatio/getOrganisaatioHierarkiaByOid';
 
@@ -13,14 +16,18 @@ export const useOrganisaatioHierarkia = (
   oid: string,
   { skipParents = false, filter }: UseOrganisaatioHierarkiaOptions = {}
 ) => {
-  const { data, ...rest } = useApiAsync({
-    promiseFn: getOrganisaatioHierarkiaByOid,
-    oid,
-    skipParents,
-    watch: oid,
-  });
+  const { data, ...rest } = useApiQuery(
+    'getOrganisaatioHierarkiaByOid',
+    getOrganisaatioHierarkiaByOid,
+    {
+      promiseFn: getOrganisaatioHierarkiaByOid,
+      oid,
+      skipParents,
+    },
+    { ...LONG_CACHE_QUERY_OPTIONS, enabled: Boolean(oid) }
+  );
 
-  const hierarkia = filterTree(data, filter);
+  const hierarkia = useMemo(() => filterTree(data, filter), [data, filter]);
 
   return { hierarkia, ...rest };
 };

--- a/src/main/app/src/pages/HomePage/OrganisaatioDrawer/index.tsx
+++ b/src/main/app/src/pages/HomePage/OrganisaatioDrawer/index.tsx
@@ -38,7 +38,7 @@ import {
 import OrganisaatioTreeList from './OrganisaatioTreeList';
 import { PikavalinnatCollapse } from './PikavalinnatCollapse';
 import { SelectedOrganisaatioBox } from './SelectedOrganisaatioBox';
-import useOrganisaatioHierarkia from './useOrganisaatioHierarkia';
+import { useReadableOrganisaatioHierarkia } from './useReadableOrganisaatioHierarkia';
 
 const CloseIcon = styled(Icon).attrs({ type: 'close', role: 'button' })`
   color: ${getThemeProp('palette.text.primary')};
@@ -148,7 +148,10 @@ const DrawerContent = ({
     500
   );
 
-  const { hierarkia, isLoading: loadingHierarkia } = useOrganisaatioHierarkia({
+  const {
+    hierarkia,
+    isLoading: loadingHierarkia,
+  } = useReadableOrganisaatioHierarkia({
     name: debounceNameFilter,
     nameSearchEnabled,
   });

--- a/src/main/app/src/pages/HomePage/OrganisaatioDrawer/useOrganisaatioHierarkia.ts
+++ b/src/main/app/src/pages/HomePage/OrganisaatioDrawer/useOrganisaatioHierarkia.ts
@@ -2,12 +2,13 @@ import { useMemo, useCallback } from 'react';
 
 import _ from 'lodash';
 
+import { LONG_CACHE_QUERY_OPTIONS } from '#/src/constants';
 import { useAuthorizedUser } from '#/src/contexts/AuthorizedUserContext';
-import useApiAsync from '#/src/hooks/useApiAsync';
+import { useApiQuery } from '#/src/hooks/useApiQuery';
 import useAuthorizedUserRoleBuilder from '#/src/hooks/useAuthorizedUserRoleBuilder';
 import { useUserLanguage } from '#/src/hooks/useUserLanguage';
-import getRoleOrganisaatioOid from '#/src/utils/getRoleOrganisaatioOid';
 import getUserRoles from '#/src/utils/getUserRoles';
+import isOid from '#/src/utils/isOid';
 import getOrganisaatioHierarkia from '#/src/utils/organisaatio/getOrganisaatioHierarkia';
 import {
   filterByName,
@@ -16,8 +17,16 @@ import {
 
 import { createCanReadSomethingRoleBuilder } from '../utils';
 
-const getRolesOrganisaatioOids = roles => {
-  return _.uniq(roles.map(getRoleOrganisaatioOid).filter(Boolean));
+const pickKoutaRoleOid = role => {
+  if (role?.startsWith('APP_KOUTA')) {
+    const oidStr = role.slice(role.lastIndexOf('_') + 1, role.length);
+
+    return isOid(oidStr) ? oidStr : undefined;
+  }
+};
+
+const getKoutaRolesOrganisaatioOids = roles => {
+  return _.uniq(roles.map(pickKoutaRoleOid).filter(Boolean));
 };
 
 const isValidNameSearch = name => _.isString(name) && name.length >= 3;
@@ -39,16 +48,12 @@ const organisaatioHasCorrectType = organisaatio => {
   return !organisaatiotyypit.find(t => Boolean(invalidOrganisaatioTypeMap[t]));
 };
 
-const useOrganisaatioHierarkia = ({
-  name,
-  nameSearchEnabled = true,
-  languageFilterEnabled = true,
-}) => {
+const useOrganisaatioHierarkia = ({ name, nameSearchEnabled = true }) => {
   const roleBuilder = useAuthorizedUserRoleBuilder();
   const language = useUserLanguage();
   const user = useAuthorizedUser();
   const roles = useMemo(() => getUserRoles(user), [user]);
-  const oids = useMemo(() => getRolesOrganisaatioOids(roles), [roles]);
+  const oids = useMemo(() => getKoutaRolesOrganisaatioOids(roles), [roles]);
 
   const promiseFn = useMemo(() => {
     if (nameSearchEnabled && !isValidNameSearch(name)) {
@@ -58,15 +63,20 @@ const useOrganisaatioHierarkia = ({
     return getOrganisaatioHierarkia;
   }, [name, nameSearchEnabled]);
 
-  const watch = JSON.stringify([name, oids]);
-  const formattedName = _.isString(name) ? name.toLowerCase() : undefined;
+  const formattedName = useMemo(
+    () => (_.isString(name) ? name.toLowerCase() : undefined),
+    [name]
+  );
 
-  const { data, ...rest } = useApiAsync({
+  const { data, ...rest } = useApiQuery(
+    'searchOrganisaatioHierarkia',
     promiseFn,
-    searchString: formattedName,
-    oids,
-    watch,
-  });
+    {
+      searchString: formattedName,
+      oids,
+    },
+    { ...LONG_CACHE_QUERY_OPTIONS }
+  );
 
   const hasRequiredRoles = useCallback(
     organisaatio => {
@@ -82,16 +92,16 @@ const useOrganisaatioHierarkia = ({
     return _.isArray(data)
       ? flatFilterHierarkia(
           data,
-          org => hasRequiredRoles(org) && organisaatioHasCorrectType(org)
+          org => organisaatioHasCorrectType(org) && hasRequiredRoles(org)
         )
       : [];
   }, [data, hasRequiredRoles]);
 
   const hierarkia = useMemo(() => {
-    return languageFilterEnabled
+    return nameSearchEnabled
       ? filterByName(roleHierarkia, formattedName, language)
       : roleHierarkia;
-  }, [roleHierarkia, formattedName, language, languageFilterEnabled]);
+  }, [roleHierarkia, formattedName, language, nameSearchEnabled]);
 
   return { hierarkia, ...rest };
 };

--- a/src/main/app/src/pages/HomePage/OrganisaatioDrawer/useReadableOrganisaatioHierarkia.ts
+++ b/src/main/app/src/pages/HomePage/OrganisaatioDrawer/useReadableOrganisaatioHierarkia.ts
@@ -48,7 +48,10 @@ const organisaatioHasCorrectType = organisaatio => {
   return !organisaatiotyypit.find(t => Boolean(invalidOrganisaatioTypeMap[t]));
 };
 
-const useOrganisaatioHierarkia = ({ name, nameSearchEnabled = true }) => {
+export const useReadableOrganisaatioHierarkia = ({
+  name,
+  nameSearchEnabled = true,
+}) => {
   const roleBuilder = useAuthorizedUserRoleBuilder();
   const language = useUserLanguage();
   const user = useAuthorizedUser();
@@ -105,5 +108,3 @@ const useOrganisaatioHierarkia = ({ name, nameSearchEnabled = true }) => {
 
   return { hierarkia, ...rest };
 };
-
-export default useOrganisaatioHierarkia;

--- a/src/main/app/src/pages/HomePage/OrganisaatioDrawer/useReadableOrganisaatioHierarkia.ts
+++ b/src/main/app/src/pages/HomePage/OrganisaatioDrawer/useReadableOrganisaatioHierarkia.ts
@@ -19,7 +19,7 @@ import { createCanReadSomethingRoleBuilder } from '../utils';
 
 const pickKoutaRoleOid = role => {
   if (role?.startsWith('APP_KOUTA')) {
-    const oidStr = role.slice(role.lastIndexOf('_') + 1, role.length);
+    const oidStr = role.slice(role.lastIndexOf('_') + 1);
 
     return isOid(oidStr) ? oidStr : undefined;
   }

--- a/src/main/app/src/pages/OppilaitosPage/OppilaitosPage.tsx
+++ b/src/main/app/src/pages/OppilaitosPage/OppilaitosPage.tsx
@@ -59,7 +59,7 @@ export const OppilaitosPage = ({
   const canUpdate = useCurrentUserHasRole(
     ENTITY.OPPILAITOS,
     CRUD_ROLES.UPDATE,
-    oppilaitos?.organisaatioOid
+    organisaatioOid
   );
 
   const canCreate = useCurrentUserHasRole(
@@ -68,7 +68,7 @@ export const OppilaitosPage = ({
     organisaatioOid
   );
 
-  const readOnly = oppilaitos ? !canUpdate : !canCreate;
+  const readOnly = formMode === FormMode.EDIT ? !canUpdate : !canCreate;
 
   const config = useMemo(() => ({ noFieldConfigs: true, readOnly }), [
     readOnly,

--- a/src/main/app/src/utils/createRoleBuilder.ts
+++ b/src/main/app/src/utils/createRoleBuilder.ts
@@ -83,16 +83,12 @@ class RoleBuilder {
 
   hasRead(role, organisaatio) {
     return this.clone(
-      Boolean(
-        resolveOidPath(organisaatio).find(oid => {
-          return (
-            this.hasOrganisaatioRole(OPH_PAAKAYTTAJA_ROLE, oid) ||
-            READ_ROLES.map(r =>
-              this.hasOrganisaatioRole(`${role}_${r}`, oid)
-            ).some(Boolean)
-          );
-        })
-      )
+      resolveOidPath(organisaatio).some(oid => {
+        return (
+          this.hasOrganisaatioRole(OPH_PAAKAYTTAJA_ROLE, oid) ||
+          READ_ROLES.some(r => this.hasOrganisaatioRole(`${role}_${r}`, oid))
+        );
+      })
     );
   }
 
@@ -114,16 +110,12 @@ class RoleBuilder {
 
   hasUpdate(role, organisaatio) {
     return this.clone(
-      Boolean(
-        resolveOidPath(organisaatio).find(oid => {
-          return (
-            this.hasOrganisaatioRole(OPH_PAAKAYTTAJA_ROLE, oid) ||
-            UPDATE_ROLES.map(r =>
-              this.hasOrganisaatioRole(`${role}_${r}`, oid)
-            ).some(Boolean)
-          );
-        })
-      )
+      resolveOidPath(organisaatio).some(oid => {
+        return (
+          this.hasOrganisaatioRole(OPH_PAAKAYTTAJA_ROLE, oid) ||
+          UPDATE_ROLES.some(r => this.hasOrganisaatioRole(`${role}_${r}`, oid))
+        );
+      })
     );
   }
 
@@ -145,16 +137,12 @@ class RoleBuilder {
 
   hasCreate(role, organisaatio) {
     return this.clone(
-      Boolean(
-        resolveOidPath(organisaatio).find(oid => {
-          return (
-            this.hasOrganisaatioRole(OPH_PAAKAYTTAJA_ROLE, oid) ||
-            CREATE_ROLES.map(r =>
-              this.hasOrganisaatioRole(`${role}_${r}`, oid)
-            ).some(Boolean)
-          );
-        })
-      )
+      resolveOidPath(organisaatio).some(oid => {
+        return (
+          this.hasOrganisaatioRole(OPH_PAAKAYTTAJA_ROLE, oid) ||
+          CREATE_ROLES.some(r => this.hasOrganisaatioRole(`${role}_${r}`, oid))
+        );
+      })
     );
   }
 

--- a/src/main/app/src/utils/createRoleBuilder.ts
+++ b/src/main/app/src/utils/createRoleBuilder.ts
@@ -78,11 +78,7 @@ class RoleBuilder {
   }
 
   hasOrganisaatioRole(role, organisaatioOid) {
-    console.log('hasOrganisaatioRole', organisaatioOid, this.roleLookup);
-    return (
-      this.roleLookup.hasOwnProperty(organisaatioOid) &&
-      this.roleLookup[organisaatioOid].hasOwnProperty(role)
-    );
+    return Boolean(this.roleLookup?.[organisaatioOid]?.[role]);
   }
 
   hasRead(role, organisaatio) {

--- a/src/main/app/src/utils/createRoleBuilder.ts
+++ b/src/main/app/src/utils/createRoleBuilder.ts
@@ -78,6 +78,7 @@ class RoleBuilder {
   }
 
   hasOrganisaatioRole(role, organisaatioOid) {
+    console.log('hasOrganisaatioRole', organisaatioOid, this.roleLookup);
     return (
       this.roleLookup.hasOwnProperty(organisaatioOid) &&
       this.roleLookup[organisaatioOid].hasOwnProperty(role)

--- a/src/main/app/src/utils/createRoleBuilder.ts
+++ b/src/main/app/src/utils/createRoleBuilder.ts
@@ -60,7 +60,7 @@ const createRoleLookup = roles => {
 };
 
 class RoleBuilder {
-  constructor({ roles = [], roleLookup = undefined, result = true } = {}) {
+  constructor({ roles = [], roleLookup, result = true } = {}) {
     this.currentResult = result;
     this.roleLookup = roleLookup ? roleLookup : createRoleLookup(roles);
   }

--- a/src/main/app/src/utils/organisaatio/getOrganisaatioHierarkia.ts
+++ b/src/main/app/src/utils/organisaatio/getOrganisaatioHierarkia.ts
@@ -2,16 +2,16 @@ import _ from 'lodash';
 import queryString from 'query-string';
 
 const getOrganisaatioHierarkia = async ({
-  searchString = '',
+  searchString,
+  oids,
   aktiiviset = true,
   suunnitellut = true,
   lakkautetut = false,
-  oids,
   apiUrls,
   httpClient,
 }) => {
   const params = {
-    searchStr: searchString,
+    ...(searchString ? { searchStr: searchString } : {}),
     aktiiviset: aktiiviset ? 'true' : 'false',
     suunnitellut: suunnitellut ? 'true' : 'false',
     lakkautetut: lakkautetut ? 'true' : 'false',


### PR DESCRIPTION
Oppilaitos-sivulla noudetaan samaan tapaan tieto sekä luonti- (create), että päivitys (update) oikeuksista, joiden muodostamista varten noudetaan tiedot käyttäjän valitsemasta organisaatiosta. Nähtävästi react-async ei osaa käsitellä tällaisia rinnakkaisia pyyntöjä oikein, vaan syntyy kilpailutilanne, jossa jälkimmäinen tulos ei palaudu. Tässä korjattu kyseinen ongelma refaktoroimalla organisaatio-palvelun kutsut käyttämään react-query-kirjastoa, jota käytetään jo suurelta osin kouta-ui:ssa.
