### PR TITLE
OY-4275 Add missing indicators to mandatory fields

### DIFF
--- a/src/main/app/src/pages/koulutus/KoulutusForm/LisatiedotSection.tsx
+++ b/src/main/app/src/pages/koulutus/KoulutusForm/LisatiedotSection.tsx
@@ -36,6 +36,7 @@ const OsiotFields = ({ disabled, language, osiotOptions, name }) => {
         name={`${name}.osioKuvaukset.${value}.${language}`}
         component={FormFieldEditor}
         label={label}
+        required
       />
     </Box>
   ));

--- a/src/main/app/src/pages/toteutus/ToteutusForm/HakeutumisTaiIlmoittautumistapaSection.tsx
+++ b/src/main/app/src/pages/toteutus/ToteutusForm/HakeutumisTaiIlmoittautumistapaSection.tsx
@@ -119,6 +119,7 @@ const HakeutumisTaiIlmoittautusmistapaFields = createFormFieldComponent(
               label={t(`toteutuslomake.${hakuTapa}.lisatiedot`)}
               name={`${section}.lisatiedot.${language}`}
               hideHeaderSelect
+              required
             />
           </StyledBlueBox>
         )}


### PR DESCRIPTION
Some additional information fields were missing the indicator ("*") for mandatory field.

Also includes https://github.com/Opetushallitus/kouta-ui/pull/528 merged, so I was able to test the changes locally - that part is already reviewed separately. Relevant commits for this one are https://github.com/Opetushallitus/kouta-ui/pull/529/commits/b232dab8fd4cd6cd144ad112478ef4b7ab3ba7c1 and https://github.com/Opetushallitus/kouta-ui/pull/529/commits/01774faa0a88d885894acc0682326a6ad870a92f