### PR TITLE
OY-4453 sort field names before tidying up empty translated fields

### DIFF
--- a/src/main/app/src/utils/index.test.ts
+++ b/src/main/app/src/utils/index.test.ts
@@ -143,6 +143,16 @@ test.each([
       },
     },
   ],
+  [
+    { nimet: [{ nimi: { fi: '' } }] },
+    {
+      'nimet[0].nimi.fi': { name: 'nimet[0].nimi.fi' },
+      nimet: { name: 'nimet' },
+    },
+    {},
+    {},
+    { nimet: [{ nimi: {} }] },
+  ],
 ])(
   'getValuesForSaving',
   (values, registeredFields, unregisteredFields, initialValues, result) => {

--- a/src/main/app/src/utils/index.ts
+++ b/src/main/app/src/utils/index.ts
@@ -249,16 +249,22 @@ export const getValuesForSaving = (
   // Ensure that all fields that were unregistered (hidden by the user) are sent to backend as empty values
   _.forEach(unregisteredFields, ({ name }) => {
     const fieldName = getFieldNameWithoutLanguage(name);
-    _.set(saveableValues, fieldName, null);
+    _.set(saveableValues, fieldName!, null);
   });
 
+  // In case of fields from multiple hierarchy levels, we want to process the lowest level one first so we don't accidentally
+  // override anything. Sorting the list of registered fields gives eg. yhteyshenkilo before yhteyshenkilo[0].nimi.
+  const sortedFields = Object.values(registeredFields)
+    .map(f => f.name)
+    .sort();
+
   // Ensure that the fields that are registered (visible) will be saved
-  _.forEach(registeredFields, ({ name }) => {
+  sortedFields.forEach(name => {
     const fieldName = getFieldNameWithoutLanguage(name);
-    const fieldValue = _.get(values, fieldName);
+    const fieldValue = _.get(values, fieldName!);
 
     const valueForSave = isEmptyTranslatedField(fieldValue) ? {} : fieldValue;
-    _.set(saveableValues, fieldName, valueForSave);
+    _.set(saveableValues, fieldName!, valueForSave);
   });
 
   // Some exceptions (fields that should be saved even though they are not visible)


### PR DESCRIPTION
In some cases, fields were cleaned up and copied in wrong, non-hierarchical order before saving - potentially overwriting already cleaned-up data and thus later messing up validations.

Sort the field names / form paths, so we always have a deterministic / correct hierarchical order for the cleanup (eg. yhteyshenkilot before yhteyshenkilot[0].nimi and so on).