### PR TITLE
OY-4712 Muutettu haun editointinäkymän "Lisää hakukohde" -napin disablointi riippumattomaksi formin disabloinnista

### DIFF
--- a/src/main/app/src/pages/haku/HakuForm/HakuForm.tsx
+++ b/src/main/app/src/pages/haku/HakuForm/HakuForm.tsx
@@ -3,7 +3,6 @@ import React from 'react';
 import _fp from 'lodash/fp';
 import { useTranslation } from 'react-i18next';
 
-import { FormButton } from '#/src/components/FormButton';
 import FormCollapse from '#/src/components/FormCollapse';
 import FormCollapseGroup from '#/src/components/FormCollapseGroup';
 import { JulkaisutilaField } from '#/src/components/JulkaisutilaField';
@@ -12,7 +11,7 @@ import { LomakeFields } from '#/src/components/LomakeFields';
 import { OrganisaatioSection } from '#/src/components/OrganisaatioSection';
 import { OrganisaatioSectionCreate } from '#/src/components/OrganisaatioSectionCreate';
 import PohjaFormCollapse from '#/src/components/PohjaFormCollapse';
-import { Box } from '#/src/components/virkailija';
+import { Box, Button } from '#/src/components/virkailija';
 import { ENTITY, FormMode } from '#/src/constants';
 import { useFormMode } from '#/src/contexts/FormContext';
 import { useFieldValue, useSelectedLanguages } from '#/src/hooks/form';
@@ -194,7 +193,7 @@ const HakuForm = ({
                 height="100%"
                 flexBasis="100%"
               >
-                <FormButton
+                <Button
                   onClick={open}
                   disabled={!canAddHakukohde}
                   type="button"
@@ -204,7 +203,7 @@ const HakuForm = ({
                   )}
                 >
                   {t('yleiset.liitaHakukohde')}
-                </FormButton>
+                </Button>
               </Box>
             }
             Component={HakukohteetSection}


### PR DESCRIPTION
Commitissa 1760ef81dc794e98eade1e2c5a7ff48ce7334a58 haun editointinäkymän "lisää hakukohde" nappi oli muutettu disabloiduksi myös siinä tapauksessa että koko formi on disabloitu. Tämä on nyt purettu.